### PR TITLE
Fix `gep` related calculation

### DIFF
--- a/crates/ir/src/insn.rs
+++ b/crates/ir/src/insn.rs
@@ -770,13 +770,18 @@ fn get_gep_result_type(dfg: &DataFlowGraph, base: Value, indices: &[Value]) -> T
     });
 
     let mut result_ty = base_ty;
-    for &index in indices {
+    for (i, &index) in indices.iter().enumerate() {
         let Type::Compound(compound) = result_ty else {
-            unreachable!()
+            if indices.len() - i == 1 {
+                break;
+            } else {
+                unreachable!()
+            }
         };
 
         result_ty = ctx.with_ty_store(|s| match s.resolve_compound(compound) {
-            CompoundTypeData::Array { elem, .. } | CompoundTypeData::Ptr(elem) => *elem,
+            CompoundTypeData::Array { elem, .. } => *elem,
+            CompoundTypeData::Ptr(_) => result_ty,
             CompoundTypeData::Struct(s) => {
                 let index = match dfg.value_data(index) {
                     ValueData::Immediate { imm, .. } => imm.as_usize(),

--- a/crates/ir/src/insn.rs
+++ b/crates/ir/src/insn.rs
@@ -289,7 +289,8 @@ impl InsnData {
 
             Self::Call { args, .. }
             | Self::BrTable { args, .. }
-            | Self::Phi { values: args, .. } => args,
+            | Self::Phi { values: args, .. }
+            | Self::Gep { args } => args,
 
             Self::Return { args } => args.as_ref().map(core::slice::from_ref).unwrap_or_default(),
 
@@ -308,7 +309,8 @@ impl InsnData {
 
             Self::Call { args, .. }
             | Self::BrTable { args, .. }
-            | Self::Phi { values: args, .. } => args,
+            | Self::Phi { values: args, .. }
+            | Self::Gep { args } => args,
 
             Self::Return { args } => args.as_mut().map(core::slice::from_mut).unwrap_or_default(),
 

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -223,6 +223,7 @@ impl<'a> Lexer<'a> {
     fn try_eat_opcode(&mut self) -> Option<Code> {
         try_eat_variant! {
             self,
+            (b"gep", Code::Gep),
             (b"not", Code::Not),
             (b"neg", Code::Neg),
             (b"add", Code::Add),
@@ -254,7 +255,6 @@ impl<'a> Lexer<'a> {
             (b"fallthrough", Code::FallThrough),
             (b"br_table", Code::BrTable),
             (b"br", Code::Br),
-            (b"gep", Code::Gep),
             (b"alloca", Code::Alloca),
             (b"return", Code::Return),
             (b"phi", Code::Phi),

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -931,6 +931,16 @@ mod tests {
     }
 
     #[test]
+    fn test_gep() {
+        assert!(test_func_parser(
+            "func public %test(v0.**i32) -> **i32:
+    block0:
+        v1.*i32 = gep v0 10.i32;
+        return v1;"
+        ));
+    }
+
+    #[test]
     fn parser_with_phi() {
         assert!(test_func_parser(
             "func private %test_func() -> void:

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -933,9 +933,10 @@ mod tests {
     #[test]
     fn test_gep() {
         assert!(test_func_parser(
-            "func public %test(v0.**i32) -> **i32:
+            "func public %test(v0.*i32, v1.*[*i64; 10]) -> *i32:
     block0:
-        v1.*i32 = gep v0 10.i32;
+        v2.*i32 = gep v0 10.i32;
+        v3.**i64 = gep v1 10.i32;
         return v1;"
         ));
     }


### PR DESCRIPTION
1. Fix invalid tokenization in `parser`
2. Add missing `args` handling for `gep`
3. Fix the wrong result type calculation