### PR TITLE
Allow forward function declaration in sonatina file format

### DIFF
--- a/crates/ir/src/builder/module_builder.rs
+++ b/crates/ir/src/builder/module_builder.rs
@@ -39,6 +39,14 @@ impl ModuleBuilder {
         }
     }
 
+    pub fn sig(&self, func: FuncRef) -> &Signature {
+        &self.funcs[func].sig
+    }
+
+    pub fn get_func(&self, func: &str) -> Option<FuncRef> {
+        self.declared_funcs.get(func).copied()
+    }
+
     pub fn make_global(&self, global: GlobalVariableData) -> GlobalVariable {
         self.ctx.with_gv_store_mut(|s| s.make_gv(global))
     }

--- a/crates/ir/src/function.rs
+++ b/crates/ir/src/function.rs
@@ -43,7 +43,7 @@ impl Function {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signature {
     /// Name of the function.
     name: String,


### PR DESCRIPTION
This change allows forward function declaration in sonatina file format to test mutually recursive functions.