### PR TITLE
Refactor display type for instruction arguments

### DIFF
--- a/crates/ir/src/dfg.rs
+++ b/crates/ir/src/dfg.rs
@@ -1,7 +1,7 @@
 //! This module contains Sonatine IR data flow graph.
-use std::{collections::BTreeSet, fmt};
+use std::collections::BTreeSet;
 
-use cranelift_entity::{packed_option::PackedOption, PrimaryMap, SecondaryMap};
+use cranelift_entity::{entity_impl, packed_option::PackedOption, PrimaryMap, SecondaryMap};
 use fxhash::FxHashMap;
 
 use crate::{global_variable::ConstantValue, module::ModuleCtx, GlobalVariable};
@@ -304,15 +304,9 @@ pub enum ValueDef {
 }
 
 /// An opaque reference to [`BlockData`]
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, Copy, Hash, PartialOrd, Ord)]
 pub struct Block(pub u32);
-cranelift_entity::entity_impl!(Block);
-
-impl fmt::Display for Block {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "block{}", self.0)
-    }
-}
+entity_impl!(Block, "block");
 
 /// A block data definition.
 /// A Block data doesn't hold any information for layout of a program. It is managed by

--- a/crates/ir/src/graphviz/function.rs
+++ b/crates/ir/src/graphviz/function.rs
@@ -2,7 +2,7 @@ use std::iter;
 
 use dot2::{label::Text, GraphWalk, Id, Labeller, Style};
 
-use crate::{value::DisplayArgValues, Block, ControlFlowGraph, Function, InsnData};
+use crate::{value::DisplayArgValue, Block, ControlFlowGraph, Function, InsnData};
 
 use super::block::BlockNode;
 
@@ -129,8 +129,8 @@ impl<'a> BlockEdge<'a> {
             if let InsnData::Phi { values, blocks, .. } = func.dfg.insn_data(insn) {
                 for (i, block) in blocks.into_iter().enumerate() {
                     if *block == from {
-                        let flow_arg = [values[i]];
-                        let v = DisplayArgValues::new(&flow_arg, &func.dfg);
+                        let flow_arg = values[i];
+                        let v = DisplayArgValue::new(flow_arg, &func.dfg);
                         return Text::LabelStr(format!("{v}").into());
                     }
                 }


### PR DESCRIPTION
- Replace `DisplayArgValues` type with simpler representation as atomic `DisplayArgValue`s.
- Add utility method for displaying list of arguments.