### PR TITLE
Fix lifetime bug

### DIFF
--- a/crates/ir/src/function.rs
+++ b/crates/ir/src/function.rs
@@ -90,18 +90,18 @@ impl Signature {
     }
 }
 
-pub struct DisplaySignature<'a> {
+pub struct DisplaySignature<'a, 'b> {
     sig: &'a Signature,
-    dfg: &'a DataFlowGraph,
+    dfg: &'b DataFlowGraph,
 }
 
-impl<'a> DisplaySignature<'a> {
-    pub fn new(sig: &'a Signature, dfg: &'a DataFlowGraph) -> Self {
+impl<'a, 'b> DisplaySignature<'a, 'b> {
+    pub fn new(sig: &'a Signature, dfg: &'b DataFlowGraph) -> Self {
         Self { sig, dfg }
     }
 }
 
-impl<'a> fmt::Display for DisplaySignature<'a> {
+impl<'a, 'b> fmt::Display for DisplaySignature<'a, 'b> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { sig, dfg } = *self;
         let Signature {

--- a/crates/ir/src/insn.rs
+++ b/crates/ir/src/insn.rs
@@ -468,7 +468,7 @@ impl<'a> fmt::Display for DisplayInsnData<'a> {
             Call {
                 args, func: callee, ..
             } => {
-                let callee = DisplayCalleeFuncRef::new(callee, func);
+                let callee = DisplayCalleeFuncRef::new(*callee, func);
                 write!(f, "call %{callee} ")?;
                 display_arg_values(f, args, dfg)?;
                 ";".fmt(f)

--- a/crates/ir/src/module.rs
+++ b/crates/ir/src/module.rs
@@ -91,12 +91,12 @@ pub struct FuncRef(u32);
 entity_impl!(FuncRef);
 
 pub struct DisplayCalleeFuncRef<'a> {
-    callee: &'a FuncRef,
+    callee: FuncRef,
     func: &'a Function,
 }
 
 impl<'a> DisplayCalleeFuncRef<'a> {
-    pub fn new(callee: &'a FuncRef, func: &'a Function) -> Self {
+    pub fn new(callee: FuncRef, func: &'a Function) -> Self {
         Self { callee, func }
     }
 }
@@ -104,7 +104,7 @@ impl<'a> DisplayCalleeFuncRef<'a> {
 impl<'a> fmt::Display for DisplayCalleeFuncRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Self { callee, func } = *self;
-        let sig = func.callees.get(callee).unwrap();
+        let sig = func.callees.get(&callee).unwrap();
         write!(f, "{}", sig.name())
     }
 }


### PR DESCRIPTION
Fix lifetime bug introduced in graphviz PR: unjustified assumption about same lifetime on references nested in `DisplaySignature` and `DisplayCalleeFuncRef` type.