### PR TITLE
Specify non-default workspace resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["crates/ir", "crates/codegen", "crates/object", "crates/parser", "crates/filecheck", "crates/triple", "crates/interpreter"]


### PR DESCRIPTION
Removes compilation warning about different resolver in crates and workspace.