### PR TITLE
Remove JumpOp from Jump insn; remove "fallthrough" op in text repr

### DIFF
--- a/crates/codegen/src/loop_analysis.rs
+++ b/crates/codegen/src/loop_analysis.rs
@@ -224,7 +224,7 @@ impl<'a, 'b> Iterator for BlocksInLoopPostOrder<'a, 'b> {
                 None => {
                     self.block_state.insert(block, BlockState::Visited);
                     for &succ in self.cfg.succs_of(block) {
-                        if self.block_state.get(&succ).is_none()
+                        if !self.block_state.contains_key(&succ)
                             && self.lpt.is_in_loop(succ, self.lp)
                         {
                             self.stack.push(succ);

--- a/crates/codegen/src/optim/simplify_impl.rs
+++ b/crates/codegen/src/optim/simplify_impl.rs
@@ -5,7 +5,7 @@ use smallvec::SmallVec;
 use cranelift_entity::{entity_impl, PrimaryMap, SecondaryMap};
 
 use sonatina_ir::{
-    insn::{BinaryOp, CastOp, DataLocationKind, JumpOp, UnaryOp},
+    insn::{BinaryOp, CastOp, DataLocationKind, UnaryOp},
     module::FuncRef,
     Block, DataFlowGraph, Immediate, Insn, InsnData, Type, Value,
 };
@@ -135,7 +135,6 @@ pub enum ExprData {
 
     /// Unconditional jump operations.
     Jump {
-        code: JumpOp,
         dests: BlockArray1,
     },
 
@@ -208,10 +207,7 @@ impl ExprData {
                 ret_ty: *ret_ty,
             },
 
-            InsnData::Jump { code, dests } => Self::Jump {
-                code: *code,
-                dests: *dests,
-            },
+            InsnData::Jump { dests } => Self::Jump { dests: *dests },
 
             InsnData::Branch { args, dests } => Self::Branch {
                 args: [args[0].into()],
@@ -281,10 +277,7 @@ impl ExprData {
                 ret_ty: *ret_ty,
             },
 
-            Self::Jump { code, dests } => InsnData::Jump {
-                code: *code,
-                dests: *dests,
-            },
+            Self::Jump { dests } => InsnData::Jump { dests: *dests },
 
             Self::Branch { args, dests } => InsnData::Branch {
                 args: [args[0].as_value()?],

--- a/crates/codegen/src/optim/simplify_impl/expr.isle
+++ b/crates/codegen/src/optim/simplify_impl/expr.isle
@@ -89,13 +89,6 @@
     Trunc
   )
 )
-(type
-  JumpOp extern
-  (enum
-    Jump
-    FallThrough
-  )
-)
 
 (type
   DataLocationKind extern
@@ -114,7 +107,7 @@
     (Load (args ArgArray1) (loc DataLocationKind))
     (Store (args ArgArray2) (ty Type) (loc DataLocationKind))
     (Call (func FuncRef) (args ArgList) (ret_ty Type))
-    (Jump (code JumpOp) (dests BlockArray1))
+    (Jump (dests BlockArray1))
     (Branch (args ArgArray1) (dests BlockArray2))
     (BrTable (args ArgList) (default BrTableDefaultDest) (table BlockList))
     (Alloca (ty Type))

--- a/crates/filecheck/fixtures/gvn/commutativity.sntn
+++ b/crates/filecheck/fixtures/gvn/commutativity.sntn
@@ -2,7 +2,7 @@ target = "evm-ethereum-london"
 
 # check: block1:
 # nextln:  v10.i8 = add v0 v1;
-# nextln:  fallthrough block2;
+# nextln:  jump block2;
 # nextln: 
 # check: block2:
 # nextln:  v20.i8 = sub v0 v1;
@@ -13,7 +13,7 @@ func public %commutativity(v0.i8, v1.i8) -> void:
         v10.i8 = add v0 v1;
         v11.i8 = add v0 v1;
         v12.i8 = add v1 v0;
-        fallthrough block2;
+        jump block2;
 
     block2:
         v20.i8 = sub v0 v1;

--- a/crates/filecheck/fixtures/gvn/llvm_phi-of-ops-move-block.sntn
+++ b/crates/filecheck/fixtures/gvn/llvm_phi-of-ops-move-block.sntn
@@ -60,7 +60,7 @@ func public %llvm_test(v0.*i32, v100.*i64) -> void:
 
 # regex: VALUE=\bv\d+\b
 # check:    block0:
-# nextln:       fallthrough block1;
+# nextln:       jump block1;
 # nextln: 
 # nextln:   block1:
 # nextln:       v1.i32 = phi (0.i32 block0) (v6 block5);
@@ -87,7 +87,7 @@ func public %llvm_test(v0.*i32, v100.*i64) -> void:
 # nextln:       return;
 func public %llvm_test2(v0.i1) -> void:
     block0:
-        fallthrough block1;
+        jump block1;
 
     block1:
         v1.i32 = phi (0.i32 block0) (v6 block5);

--- a/crates/filecheck/fixtures/gvn/value_phi_loop.sntn
+++ b/crates/filecheck/fixtures/gvn/value_phi_loop.sntn
@@ -3,12 +3,12 @@ target = "evm-ethereum-london"
 # regex: VALUE=\bv\d+\b
 # check:    block0:
 # nextln:        v1.i32 = add v100 v101;
-# nextln:        fallthrough block1;
+# nextln:        jump block1;
 # nextln: 
 # nextln:    block1:
 # nextln:        $(var1=$VALUE).i32 = phi (v1 block0) (v31 block3);
 # nextln:        v10.i32 = phi (v100 block0) (v30 block3);
-# nextln:        fallthrough block2;
+# nextln:        jump block2;
 # nextln: 
 # nextln:    block2:
 # nextln:        br v102 block3 block4;
@@ -30,12 +30,12 @@ target = "evm-ethereum-london"
 func public %value_phi_loop(v100.i32, v101.i32, v102.i1, v103.i1, v104.i32, v105.i32) -> i32:
     block0:
         v1.i32 = add v100 v101;
-        fallthrough block1;
+        jump block1;
 
     block1:
         v10.i32 = phi (v100 block0) (v30 block3);
         v11.i32 = add v10 v101;
-        fallthrough block2;
+        jump block2;
 
     block2:
         v22.i32 = sub v11 v101;

--- a/crates/filecheck/fixtures/licm/basic.sntn
+++ b/crates/filecheck/fixtures/licm/basic.sntn
@@ -2,7 +2,7 @@ target = "evm-ethereum-london"
 
 # check:  block0:
 # nextln:      v3.i32 = add v0 v1;
-# nextln:      fallthrough block1;
+# nextln:      jump block1;
 # nextln: 
 # nextln:  block1:
 # nextln:      v2.i32 = phi (0.i32 block0) (v4 block2);
@@ -17,7 +17,7 @@ target = "evm-ethereum-london"
 # nextln:      return;
 func public %basic(v0.i32, v1.i32) -> void:
     block0:
-        fallthrough block1;
+        jump block1;
 
     block1:
         v2.i32 = phi (0.i32 block0) (v4 block2);

--- a/crates/filecheck/fixtures/sccp/complex_loop.sntn
+++ b/crates/filecheck/fixtures/sccp/complex_loop.sntn
@@ -2,7 +2,7 @@ target = "evm-ethereum-london"
 
 # sameln: func public %complex_loop() -> i8:
 # nextln:     block1:
-# nextln:         fallthrough block2;
+# nextln:         jump block2;
 # nextln: 
 # nextln:     block2:
 # nextln:         v4.i8 = phi (v7 block7) (0.i8 block1);
@@ -26,7 +26,7 @@ func public %complex_loop() -> i8:
         v0.i8 = add 1.i8 0.i8;
         v1.i8 = add v0 0.i8;
         v2.i8 = sub v0 1.i8;
-        fallthrough block2;
+        jump block2;
 
     block2:
         v3.i8 = phi (v9 block7) (v0 block1);
@@ -47,7 +47,7 @@ func public %complex_loop() -> i8:
 
     block6:
         v8.i8 = add v4 2.i8;
-        fallthrough block7;
+        jump block7;
 
     block7:
         v9.i8 = phi (v0 block5) (v4 block6);

--- a/crates/filecheck/fixtures/sccp/const_loop.sntn
+++ b/crates/filecheck/fixtures/sccp/const_loop.sntn
@@ -4,7 +4,7 @@ target = "evm-ethereum-london"
 
 # sameln: func public %const_loop() -> i8:
 # nextln:     block1:
-# nextln:         fallthrough block2;
+# nextln:         jump block2;
 # nextln: 
 # nextln:     block2:
 # nextln:         jump block3;
@@ -13,7 +13,7 @@ target = "evm-ethereum-london"
 # nextln:         return 11.i8;
 func public %const_loop() -> i8:
     block1:
-        fallthrough block2;
+        jump block2;
 
     block2:
         v1.i8 = phi (1.i8 block1) (v2 block2);

--- a/crates/ir/src/builder/func_builder.rs
+++ b/crates/ir/src/builder/func_builder.rs
@@ -2,7 +2,7 @@ use smallvec::SmallVec;
 
 use crate::{
     func_cursor::{CursorLocation, FuncCursor, InsnInserter},
-    insn::{BinaryOp, CastOp, DataLocationKind, InsnData, JumpOp, UnaryOp},
+    insn::{BinaryOp, CastOp, DataLocationKind, InsnData, UnaryOp},
     module::FuncRef,
     Block, Function, GlobalVariable, Immediate, Type, Value,
 };
@@ -183,10 +183,7 @@ impl<'a> FunctionBuilder<'a> {
 
     pub fn jump(&mut self, dest: Block) {
         debug_assert!(!self.ssa_builder.is_sealed(dest));
-        let insn_data = InsnData::Jump {
-            code: JumpOp::Jump,
-            dests: [dest],
-        };
+        let insn_data = InsnData::Jump { dests: [dest] };
 
         let pred = self.cursor().block();
         self.ssa_builder.append_pred(dest, pred.unwrap());

--- a/crates/ir/src/graphviz/mod.rs
+++ b/crates/ir/src/graphviz/mod.rs
@@ -57,10 +57,9 @@ mod test {
 
         let mut text = vec![];
         render_to(&module.funcs[func_ref], &mut text).unwrap();
+        let text = String::from_utf8(text).unwrap();
 
-        assert_eq!(
-            text,
-            b"digraph test_func {
+        let expected =             "digraph test_func {
     block3[label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\"><tr><td bgcolor=\"gray\" align=\"center\" colspan=\"1\">block3</td></tr><tr><td align=\"left\" balign=\"left\">v3.i64 = phi (1.i64 block1) (2.i64 block2);<br/>v4.i64 = add v3 v0;<br/>ret;<br/></td></tr></table>>][shape=\"none\"];
     block2[label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\"><tr><td bgcolor=\"gray\" align=\"center\" colspan=\"1\">block2</td></tr><tr><td align=\"left\" balign=\"left\">jump block3;<br/></td></tr></table>>][shape=\"none\"];
     block1[label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\"><tr><td bgcolor=\"gray\" align=\"center\" colspan=\"1\">block1</td></tr><tr><td align=\"left\" balign=\"left\">jump block3;<br/></td></tr></table>>][shape=\"none\"];
@@ -72,7 +71,7 @@ mod test {
     block0 -> block1[label=\"\"];
     block0 -> block2[label=\"\"];
 }
-"
-        );
+";
+        assert_eq!(text, expected);
     }
 }

--- a/crates/ir/src/insn.rs
+++ b/crates/ir/src/insn.rs
@@ -87,7 +87,6 @@ pub enum InsnData {
 
     /// Unconditional jump instruction.
     Jump {
-        code: JumpOp,
         dests: [Block; 1],
     },
 
@@ -174,10 +173,7 @@ impl InsnData {
     }
 
     pub fn jump(dest: Block) -> InsnData {
-        InsnData::Jump {
-            code: JumpOp::Jump,
-            dests: [dest],
-        }
+        InsnData::Jump { dests: [dest] }
     }
 
     pub fn phi(ty: Type) -> InsnData {
@@ -473,9 +469,9 @@ impl<'a> fmt::Display for DisplayInsnData<'a> {
                 display_arg_values(f, args, dfg)?;
                 ";".fmt(f)
             }
-            Jump { code, dests } => {
+            Jump { dests } => {
                 let block = dests[0];
-                write!(f, "{code} {block};")
+                write!(f, "jump {block};")
             }
             Branch { args, dests } => {
                 "branch ".fmt(f)?;
@@ -653,28 +649,6 @@ impl CastOp {
 }
 
 impl fmt::Display for CastOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// Unconditional jump operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum JumpOp {
-    Jump,
-    FallThrough,
-}
-
-impl JumpOp {
-    pub(super) fn as_str(self) -> &'static str {
-        match self {
-            Self::Jump => "jump",
-            Self::FallThrough => "fallthrough",
-        }
-    }
-}
-
-impl fmt::Display for JumpOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.as_str())
     }

--- a/crates/ir/src/ir_writer.rs
+++ b/crates/ir/src/ir_writer.rs
@@ -317,8 +317,8 @@ impl IrWrite for Insn {
                 writer.write_insn_args(args, &mut *w)?;
             }
 
-            Jump { code, dests } => {
-                write!(w, "{}", code)?;
+            Jump { dests } => {
+                write!(w, "jump")?;
                 writer.space(&mut *w)?;
                 writer.write_iter_with_delim(dests.iter(), " ", &mut *w)?;
             }

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -252,7 +252,6 @@ impl<'a> Lexer<'a> {
             (b"store", Code::Store),
             (b"call", Code::Call),
             (b"jump", Code::Jump),
-            (b"fallthrough", Code::FallThrough),
             (b"br_table", Code::BrTable),
             (b"br", Code::Br),
             (b"alloca", Code::Alloca),
@@ -504,7 +503,6 @@ pub(super) enum Code {
 
     // Jump ops.
     Jump,
-    FallThrough,
 
     // Branch ops.
     Br,
@@ -552,7 +550,6 @@ impl fmt::Display for Code {
             Store => "store",
             Call => "call",
             Jump => "jump",
-            FallThrough => "fallthrough",
             Gep => "gep",
             Alloca => "alloca",
             Br => "br",

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -8,7 +8,7 @@ use sonatina_ir::{
     builder::ModuleBuilder,
     func_cursor::{CursorLocation, FuncCursor},
     global_variable::ConstantValue,
-    insn::{BinaryOp, CastOp, DataLocationKind, JumpOp, UnaryOp},
+    insn::{BinaryOp, CastOp, DataLocationKind, UnaryOp},
     isa::IsaBuilder,
     module::{FuncRef, ModuleCtx},
     Block, BlockData, Function, GlobalVariableData, Immediate, Insn, InsnData, Linkage, Module,
@@ -622,13 +622,10 @@ macro_rules! make_cast {
 }
 
 macro_rules! make_jump {
-    ($parser:ident, $code:path) => {{
+    ($parser:ident) => {{
         let dest = $parser.expect_block()?;
         expect_token!($parser.lexer, Token::SemiColon, ";")?;
-        InsnData::Jump {
-            code: $code,
-            dests: [dest],
-        }
+        InsnData::Jump { dests: [dest] }
     }};
 }
 
@@ -722,8 +719,7 @@ impl Code {
                 InsnData::Call { func, args, ret_ty }
             }
 
-            Self::Jump => make_jump!(parser, JumpOp::Jump),
-            Self::FallThrough => make_jump!(parser, JumpOp::FallThrough),
+            Self::Jump => make_jump!(parser),
 
             Self::Br => {
                 let cond = parser.expect_insn_arg(inserter, 0, &mut undefs)?;
@@ -1044,7 +1040,7 @@ mod tests {
     fn test_with_struct_type() {
         let input = "
             target = \"evm-ethereum-london\"
-            
+
             type %s1 = {i32, i64};
             type %s2_packed = <{i32, i64, *%s1}>;
 
@@ -1084,7 +1080,7 @@ mod tests {
     fn test_with_gv() {
         let input = "
             target = \"evm-ethereum-london\"
-            
+
             gv public const %CONST_PUBLIC: i32 = 1;
             gv external %GLOBAL_EXTERNAL: i32;
 


### PR DESCRIPTION
The JumpOp fallthrough/jump distinction doesn't seem useful. Block order may change during optimization; rather than ensuring that optimizations update the JumpOp accordingly, codegen should instead check if the jumped-to block follows the current block to determine whether a jump operation is necessary.