### PR TITLE
Remove ValueData::Alias

### DIFF
--- a/crates/codegen/src/optim/gvn.rs
+++ b/crates/codegen/src/optim/gvn.rs
@@ -504,7 +504,7 @@ impl GvnSolver {
         value: Value,
         edge: Edge,
     ) -> Value {
-        let mut rep_value = self.leader(func.dfg.resolve_alias(value));
+        let mut rep_value = self.leader(value);
 
         if let Some(inferred_value) = self.infer_value_impl(edge, rep_value) {
             rep_value = inferred_value;

--- a/crates/codegen/src/optim/licm.rs
+++ b/crates/codegen/src/optim/licm.rs
@@ -87,7 +87,7 @@ impl LicmSolver {
 
     /// Returns preheader of the loop.
     /// 1. If there is natural preheader for the loop, then returns it without any modification of
-    /// function.
+    ///    function.
     /// 2. If no natural preheader for the loop, then create the preheader and modify function
     ///    layout, `cfg`, and `lpt`.
     fn create_preheader(

--- a/crates/codegen/src/optim/sccp.rs
+++ b/crates/codegen/src/optim/sccp.rs
@@ -140,8 +140,6 @@ impl SccpSolver {
         for (i, from) in func.dfg.phi_blocks(insn).iter().enumerate() {
             if self.is_reachable(func, *from, block) {
                 let phi_arg = func.dfg.insn_arg(insn, i);
-                let phi_arg = func.dfg.resolve_alias(phi_arg);
-
                 let v_cell = self.lattice[phi_arg];
                 eval_result = eval_result.join(v_cell);
             }

--- a/crates/codegen/src/optim/simplify_impl.rs
+++ b/crates/codegen/src/optim/simplify_impl.rs
@@ -17,7 +17,7 @@ use generated_code::{Context, SimplifyRawResult};
 
 pub fn simplify_insn(dfg: &mut DataFlowGraph, insn: Insn) -> Option<SimplifyResult> {
     if dfg.is_phi(insn) {
-        return simplify_phi(dfg, dfg.insn_data(insn));
+        return simplify_phi(dfg.insn_data(insn));
     }
 
     let mut ctx = SimplifyContext::new(dfg);
@@ -27,7 +27,7 @@ pub fn simplify_insn(dfg: &mut DataFlowGraph, insn: Insn) -> Option<SimplifyResu
 
 pub fn simplify_insn_data(dfg: &mut DataFlowGraph, data: InsnData) -> Option<SimplifyResult> {
     if matches!(data, InsnData::Phi { .. }) {
-        return simplify_phi(dfg, &data);
+        return simplify_phi(&data);
     }
 
     let mut ctx = SimplifyContext::new(dfg);
@@ -40,12 +40,12 @@ pub enum SimplifyResult {
     Insn(InsnData),
 }
 
-fn simplify_phi(dfg: &DataFlowGraph, insn_data: &InsnData) -> Option<SimplifyResult> {
+fn simplify_phi(insn_data: &InsnData) -> Option<SimplifyResult> {
     match insn_data {
         InsnData::Phi { values, .. } => {
             let mut values = values.iter().copied();
             let first_value = values.next().unwrap();
-            if values.all(|value| dfg.is_same_value(first_value, value)) {
+            if values.all(|value| value == first_value) {
                 Some(SimplifyResult::Value(first_value))
             } else {
                 None
@@ -499,7 +499,7 @@ impl<'a> generated_code::Context for SimplifyContext<'a> {
 
     fn is_eq(&mut self, arg0: ExprValue, arg1: ExprValue) -> Option<()> {
         match (arg0.as_value(), arg1.as_value()) {
-            (Some(val1), Some(val2)) => self.dfg.is_same_value(val1, val2),
+            (Some(val1), Some(val2)) => val1 == val2,
             _ => arg0 == arg1,
         }
         .then_some(())

--- a/crates/filecheck/fixtures/adce/all_dests_remove.sntn
+++ b/crates/filecheck/fixtures/adce/all_dests_remove.sntn
@@ -29,15 +29,15 @@ func public %all_dests_removed() -> i8 {
 }
 
 # check:    block0:
-# nextln:        v1.i32 = add v0 v0;
+# nextln:        v1.i8 = add v0 v0;
 # nextln:        jump block3;
 # nextln: 
 # nextln:    block3:
 # nextln:        return v1;
-func public %all_dests_removed2(v0.i32) -> i8 {
+func public %all_dests_removed2(v0.i8) -> i8 {
     block0:
-        v1.i32 = add v0 v0;
-        br_table v0 (v1 block1) (2.i32 block2);
+        v1.i8 = add v0 v0;
+        br_table v0 (v1 block1) (2.i8 block2);
 
     block1:
         v3.i8 = add v0 -10.i8;

--- a/crates/filecheck/fixtures/adce/whole_loop_removed.sntn
+++ b/crates/filecheck/fixtures/adce/whole_loop_removed.sntn
@@ -5,7 +5,7 @@ target = "evm-ethereum-london"
 # nextln:        return 1.i8;
 func public %whole_loop_removed() -> i8 {
     block0:
-        v0.i1 = or 1.i8 0.i8;
+        v0.i8 = or 1.i8 0.i8;
         v1.i8 = sext v0;
         jump block2;
 

--- a/crates/filecheck/fixtures/gvn/fold_predicted_value.sntn
+++ b/crates/filecheck/fixtures/gvn/fold_predicted_value.sntn
@@ -4,15 +4,15 @@ target = "evm-ethereum-london"
 # nextln:   return 1.i1;
 # check:  block2:
 # nextln:   return 0.i1;
-func public %fold_with_predicted_value(v0.i1) -> i8 {
+func public %fold_with_predicted_value(v0.i1) -> i1 {
     block0:
         br v0 block1 block2;
 
     block1:
-        v1.i8 = or v0 v0;
+        v1.i1 = or v0 v0;
         return v1;
 
     block2:
-        v2.i8 = or v0 v0;
+        v2.i1 = or v0 v0;
         return v2;
 }

--- a/crates/filecheck/fixtures/insn_simplify/neg.sntn
+++ b/crates/filecheck/fixtures/insn_simplify/neg.sntn
@@ -13,7 +13,7 @@ func public %neg0(v0.i8) -> i8 {
 # check: v2.i16 = add v0 1.i16;
 func public %neg1(v0.i16) -> i16 {
     block0:
-        v1.i8 = not v0;
-        v2.i8 = neg v1;
+        v1.i16 = not v0;
+        v2.i16 = neg v1;
         return v2;
 }

--- a/crates/interpreter/src/state.rs
+++ b/crates/interpreter/src/state.rs
@@ -321,7 +321,7 @@ mod test {
                 v0.i16 = add 3.i16 4.i16;
                 v1.i16 = sub v0 1.i16;
                 v2.i16 = udiv v1 2.i16;
-                v3.i8 =  sdiv v2 65535.i16;
+                v3.i16 =  sdiv v2 65535.i16;
                 return v3;
         }
         ";
@@ -380,7 +380,7 @@ mod test {
             block0:
                 v0.*i32 = alloca i32;
                 store @memory v0 1.i32;
-                v1.*i32 = load @memory v0;
+                v1.i32 = load @memory v0;
                 return v1;
         }
         ";
@@ -559,10 +559,10 @@ mod test {
         let input = "
         target = \"evm-ethereum-london\"
 
-        func private %test() -> *i1 {
+        func private %test() -> **i32 {
             block0:
                 v0.*[*i32; 3] = alloca [*i32; 3];
-                v1.*i32 = gep v0 2.i8;
+                v1.**i32 = gep v0 2.i8;
                 return v1;
         }
         ";
@@ -581,10 +581,10 @@ mod test {
 
         type %s1 = {i32, [i16; 3], [i8; 2]};
 
-        func private %test() -> *i1 {
+        func private %test() -> *i8 {
             block0:
                 v0.*%s1 = alloca %s1;
-                v1.*i1 = gep v0 2.i8 1.i8;
+                v1.*i8 = gep v0 2.i8 1.i8;
                 return v1;
         }
         ";

--- a/crates/ir/src/dfg.rs
+++ b/crates/ir/src/dfg.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 
 use cranelift_entity::{entity_impl, packed_option::PackedOption, PrimaryMap, SecondaryMap};
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 
 use crate::{global_variable::ConstantValue, module::ModuleCtx, GlobalVariable};
 
@@ -249,8 +250,57 @@ impl DataFlowGraph {
     }
 
     pub fn remove_branch_dest(&mut self, insn: Insn, dest: Block) {
-        // xxx remove user
-        self.insns[insn].remove_branch_dest(dest)
+        let this = &mut self.insns[insn];
+        match this {
+            InsnData::Jump { .. } => panic!("can't remove destination from `Jump` insn"),
+
+            InsnData::Branch { dests, args } => {
+                let remain = if dests[0] == dest {
+                    dests[1]
+                } else if dests[1] == dest {
+                    dests[0]
+                } else {
+                    panic!("no dests found in the branch destination")
+                };
+                self.users[args[0]].remove(&insn);
+                *this = InsnData::jump(remain);
+            }
+
+            InsnData::BrTable {
+                default,
+                table,
+                args,
+            } => {
+                if Some(dest) == *default {
+                    *default = None;
+                } else if let Some((lhs, rest)) = args.split_first() {
+                    type V<T> = SmallVec<[T; 8]>;
+                    let (keep, drop): (V<_>, V<_>) = table
+                        .iter()
+                        .copied()
+                        .zip(rest.iter().copied())
+                        .partition(|(b, _)| *b != dest);
+                    let (b, mut a): (V<_>, V<_>) = keep.into_iter().unzip();
+                    a.insert(0, *lhs);
+                    *args = a;
+                    *table = b;
+
+                    for (_, val) in drop {
+                        self.users[val].remove(&insn);
+                    }
+                }
+
+                let branch_info = this.analyze_branch();
+                if branch_info.dests_num() == 1 {
+                    for val in this.args() {
+                        self.users[*val].remove(&insn);
+                    }
+                    *this = InsnData::jump(branch_info.iter_dests().next().unwrap());
+                }
+            }
+
+            _ => panic!("not a branch"),
+        }
     }
 
     pub fn rewrite_branch_dest(&mut self, insn: Insn, from: Block, to: Block) {

--- a/crates/ir/src/dfg.rs
+++ b/crates/ir/src/dfg.rs
@@ -249,6 +249,7 @@ impl DataFlowGraph {
     }
 
     pub fn remove_branch_dest(&mut self, insn: Insn, dest: Block) {
+        // xxx remove user
         self.insns[insn].remove_branch_dest(dest)
     }
 

--- a/crates/ir/src/insn.rs
+++ b/crates/ir/src/insn.rs
@@ -183,7 +183,7 @@ impl InsnData {
 
     pub fn analyze_branch(&self) -> BranchInfo {
         match self {
-            Self::Jump { dests, .. } => BranchInfo::Jump { dest: dests[0] },
+            Self::Jump { dests } => BranchInfo::Jump { dest: dests[0] },
 
             Self::Branch { args, dests } => BranchInfo::Br {
                 cond: args[0],
@@ -201,39 +201,6 @@ impl InsnData {
             },
 
             _ => BranchInfo::NotBranch,
-        }
-    }
-
-    pub fn remove_branch_dest(&mut self, dest: Block) {
-        match self {
-            Self::Jump { .. } => panic!("can't remove destination from `Jump` insn"),
-
-            Self::Branch { dests, .. } => {
-                let remain = if dests[0] == dest {
-                    dests[1]
-                } else if dests[1] == dest {
-                    dests[0]
-                } else {
-                    panic!("no dests found in the branch destination")
-                };
-                *self = Self::jump(remain);
-            }
-
-            Self::BrTable { default, table, .. } => {
-                if Some(dest) == *default {
-                    *default = None;
-                } else {
-                    // xxx remove user
-                    table.retain(|block| dest != *block);
-                }
-
-                let branch_info = self.analyze_branch();
-                if branch_info.dests_num() == 1 {
-                    *self = Self::jump(branch_info.iter_dests().next().unwrap());
-                }
-            }
-
-            _ => panic!("not a branch"),
         }
     }
 

--- a/crates/ir/src/insn.rs
+++ b/crates/ir/src/insn.rs
@@ -48,16 +48,10 @@ impl<'a> fmt::Display for DisplayInsn<'a> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum InsnData {
     /// Unary instructions.
-    Unary {
-        code: UnaryOp,
-        args: [Value; 1],
-    },
+    Unary { code: UnaryOp, args: [Value; 1] },
 
     /// Binary instructions.
-    Binary {
-        code: BinaryOp,
-        args: [Value; 2],
-    },
+    Binary { code: BinaryOp, args: [Value; 2] },
 
     /// Cast operations.
     Cast {
@@ -86,15 +80,10 @@ pub enum InsnData {
     },
 
     /// Unconditional jump instruction.
-    Jump {
-        dests: [Block; 1],
-    },
+    Jump { dests: [Block; 1] },
 
     /// Conditional jump instruction.
-    Branch {
-        args: [Value; 1],
-        dests: [Block; 2],
-    },
+    Branch { args: [Value; 1], dests: [Block; 2] },
 
     /// Indirect jump instruction.
     BrTable {
@@ -104,18 +93,13 @@ pub enum InsnData {
     },
 
     /// Allocate a memory on the stack frame for the given type.
-    Alloca {
-        ty: Type,
-    },
+    Alloca { ty: Type },
 
     /// Return.
-    Return {
-        args: Option<Value>,
-    },
+    Return { args: Option<Value> },
 
-    Gep {
-        args: SmallVec<[Value; 8]>,
-    },
+    /// Get element pointer.
+    Gep { args: SmallVec<[Value; 8]> },
 
     /// Phi function.
     Phi {
@@ -239,6 +223,7 @@ impl InsnData {
                 if Some(dest) == *default {
                     *default = None;
                 } else {
+                    // xxx remove user
                     table.retain(|block| dest != *block);
                 }
 
@@ -372,10 +357,6 @@ impl InsnData {
             InsnData::Phi { blocks, .. } => blocks,
             _ => panic!("insn is not a phi function"),
         }
-    }
-
-    pub fn replace_arg(&mut self, new_arg: Value, idx: usize) {
-        self.args_mut()[idx] = new_arg;
     }
 
     pub fn is_phi(&self) -> bool {

--- a/crates/ir/src/ir_writer.rs
+++ b/crates/ir/src/ir_writer.rs
@@ -205,7 +205,7 @@ trait IrWrite {
 
 impl IrWrite for Value {
     fn write(&self, writer: &mut FuncWriter, w: &mut impl io::Write) -> io::Result<()> {
-        let value = writer.func.dfg.resolve_alias(*self);
+        let value = *self;
         if let Some(imm) = writer.func.dfg.value_imm(value) {
             write!(w, "{}.", imm)?;
             let ty = writer.func.dfg.value_ty(value);

--- a/crates/ir/src/types.rs
+++ b/crates/ir/src/types.rs
@@ -232,6 +232,10 @@ impl Type {
             Self::I1 | Self::I8 | Self::I16 | Self::I32 | Self::I64 | Self::I128 | Self::I256
         )
     }
+
+    pub fn to_string(&self, dfg: &DataFlowGraph) -> String {
+        DisplayType { ty: *self, dfg }.to_string()
+    }
 }
 
 impl cmp::PartialOrd for Type {

--- a/crates/ir/src/value.rs
+++ b/crates/ir/src/value.rs
@@ -80,8 +80,6 @@ pub enum ValueData {
 
     /// The value is a function argument.
     Arg { ty: Type, idx: usize },
-    /// The value is alias to another value.
-    Alias { alias: Value },
 
     /// The value is immediate value.
     Immediate { imm: Immediate, ty: Type },

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -24,6 +24,7 @@ annotate-snippets = "0.11.4"
 rustc-hash = "2.0.0"
 bimap = "0.6.3"
 derive_more = { version = "=1.0.0-beta.6", default-features = false, features = ["debug"] }
+smallvec = "1.13.2"
 
 [dev-dependencies]
 dir-test = "0.3"

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -13,6 +13,11 @@ pub enum Error {
     SyntaxError(pest::error::Error<Rule>),
     Undefined(UndefinedKind, Span),
     DuplicateValueName(SmolStr, Span),
+    TypeMismatch {
+        specified: SmolStr,
+        inferred: SmolStr,
+        span: Span,
+    },
 }
 
 #[derive(Debug)]
@@ -35,6 +40,7 @@ impl Error {
                 pest::error::InputLocation::Pos(p) => Span(p as u32, p as u32),
                 pest::error::InputLocation::Span((s, e)) => Span(s as u32, e as u32),
             },
+            Error::TypeMismatch { span, .. } => *span,
         }
     }
 
@@ -56,6 +62,13 @@ impl Error {
                 UndefinedKind::Value(name) => format!("undefined value: `{name}`"),
             },
             Error::DuplicateValueName(name, _) => format!("value name `{name}` is already defined"),
+            Error::TypeMismatch {
+                specified,
+                inferred,
+                ..
+            } => format!(
+                "type mismatch: value declared as `{specified}`, but inferred type is `{inferred}`",
+            ),
         };
         let snippet = Level::Error.title("parse error").snippet(
             Snippet::source(content)

--- a/crates/parser/test_files/errors/type_err.snap
+++ b/crates/parser/test_files/errors/type_err.snap
@@ -1,0 +1,16 @@
+---
+source: crates/parser/tests/errors.rs
+expression: s
+input_file: crates/parser/test_files/errors/type_err.sntn
+---
+error: parse error
+ --> type_err.sntn:4:12
+  |
+4 |         v0.i16 = add 2.i8 3.i8;
+  |            ^^^ type mismatch: value declared as `i16`, but inferred type is `i8`
+  |error: parse error
+ --> type_err.sntn:5:12
+  |
+5 |         v1.i8 = call %foo;
+  |            ^^ type mismatch: value declared as `i8`, but inferred type is `i16`
+  |

--- a/crates/parser/test_files/errors/type_err.sntn
+++ b/crates/parser/test_files/errors/type_err.sntn
@@ -1,0 +1,13 @@
+target = "evm-ethereum-london"
+
+func public %main() -> i8 {
+    block0:
+        v0.i16 = add 2.i8 3.i8;
+        v1.i8 = call %foo;
+        return 1.i8;
+}
+
+func %foo() -> i16 {
+    block0:
+        return 100.i16;
+}

--- a/crates/parser/test_files/errors/undefined.snap
+++ b/crates/parser/test_files/errors/undefined.snap
@@ -14,13 +14,23 @@ error: parse error
 6 |         v0.i8 = call %foo 100.i8;
   |                      ^^^^ undefined function: `%foo`
   |error: parse error
- --> undefined.sntn:9:14
-  |
-9 |         jump block2;
-  |              ^^^^^^ undefined block: `block2`
-  |error: parse error
  --> undefined.sntn:7:24
   |
 7 |         v2.i8 = add v0 v1;
   |                        ^^ undefined value: `v1`
+  |error: parse error
+ --> undefined.sntn:8:21
+  |
+8 |         v3.i8 = add v1 v1;
+  |                     ^^ undefined value: `v1`
+  |error: parse error
+ --> undefined.sntn:8:24
+  |
+8 |         v3.i8 = add v1 v1;
+  |                        ^^ undefined value: `v1`
+  |error: parse error
+ --> undefined.sntn:9:14
+  |
+9 |         jump block2;
+  |              ^^^^^^ undefined block: `block2`
   |


### PR DESCRIPTION
The new parser's use of aliases revealed some alias-related bugs in some of the optimizations. The cleanest fix for this is to just remove `ValueData::Alias`, and instead replace the uses of the alias `Value` with the original `Value` (which is easy, because the dfg already tracks which instructions use each `Value`.)

I also changed the parser so that it no longer uses aliases. The prior method of handling values in the parser lead to the wrong type being assigned to some insn result values (in cases where the first argument to some insn was a value whose definition had not yet been seen by the parser). The new method is to first do a pass over all statements in a function to "declare" all values with their proper types (by calling `dfg.make_value` with dummy `ValueData`).