### PR TITLE
Implement `cranelift_entity::ReservedValue` for `Type`

### DIFF
--- a/crates/ir/src/types.rs
+++ b/crates/ir/src/types.rs
@@ -1,7 +1,7 @@
 //! This module contains Sonatina IR types definitions.
 use std::{cmp, fmt};
 
-use cranelift_entity::PrimaryMap;
+use cranelift_entity::{packed_option::ReservedValue, PrimaryMap};
 use indexmap::IndexMap;
 use rustc_hash::FxHashMap;
 
@@ -133,6 +133,17 @@ pub enum Type {
     Compound(CompoundType),
     #[default]
     Void,
+}
+
+impl ReservedValue for Type {
+    fn reserved_value() -> Self {
+        Type::Compound(CompoundType::reserved_value())
+    }
+
+    fn is_reserved_value(&self) -> bool {
+        matches!(self,
+            Type::Compound(cmpd_ty) if cmpd_ty.is_reserved_value())
+    }
 }
 
 /// An opaque reference to [`CompoundTypeData`].


### PR DESCRIPTION
Implements `cranelift_entity::ReservedValue` for `Type`, to use as `PackedOption`