### PR TITLE
Define `sonatina_verifier::ErrorStack`

### DIFF
--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -17,3 +17,5 @@ keywords = ["compiler", "evm", "wasm", "smart-contract"]
 [dependencies]
 sonatina-ir = { path = "../ir", version = "0.0.3-alpha" }
 cranelift-entity = "0.111"
+rustc-hash = "2.0.0"
+smallvec = "1.13.2"

--- a/crates/verifier/src/error/kind.rs
+++ b/crates/verifier/src/error/kind.rs
@@ -33,6 +33,30 @@ pub enum ErrorKind {
     CalleeResultWrongType(Type),
 }
 
+impl ErrorKind {
+    pub fn ir_source(&self) -> IrSource {
+        use ErrorKind::*;
+
+        match *self {
+            PhiInEntryBlock(i) => IrSource::Insn(i),
+            EmptyBlock(b) => IrSource::Block(b),
+            TerminatorBeforeEnd(i)
+            | NotEndedByTerminator(i)
+            | InstructionMapMismatched(i)
+            | BranchBrokenLink(i) => IrSource::Insn(i),
+            ValueIsNullReference(v) => IrSource::Value(v),
+            BlockIsNullReference(b) | BranchToEntryBlock(b) => IrSource::Block(b),
+            FunctionIsNullReference(f) => IrSource::Callee(f),
+            CompoundTypeIsNullReference(cmpd_ty) => IrSource::CompoundType(cmpd_ty),
+            ValueLeak(v) => IrSource::Value(v),
+            InsnArgWrongType(_)
+            | InsnResultWrongType(_)
+            | CalleeArgWrongType(_)
+            | CalleeResultWrongType(_) => IrSource::Type,
+        }
+    }
+}
+
 pub struct DisplayErrorKind<'a> {
     kind: ErrorKind,
     func: &'a Function,
@@ -113,4 +137,14 @@ impl<'a> fmt::Display for DisplayErrorKind<'a> {
             }
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum IrSource {
+    Callee(FuncRef),
+    Block(Block),
+    Insn(Insn),
+    Value(Value),
+    Type,
+    CompoundType(CompoundType),
 }

--- a/crates/verifier/src/error/mod.rs
+++ b/crates/verifier/src/error/mod.rs
@@ -1,21 +1,26 @@
-mod kind;
+pub mod kind;
+
 mod trace_info;
 
 pub use kind::ErrorKind;
 pub use trace_info::{TraceInfo, TraceInfoBuilder};
 
+use kind::DisplayErrorKind;
 use trace_info::DisplayTraceInfo;
 
 use std::{error, fmt};
 
+use cranelift_entity::entity_impl;
 use sonatina_ir::Function;
 
-use crate::error::kind::DisplayErrorKind;
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ErrorRef(u32);
+entity_impl!(ErrorRef, "err");
 
 /// Verifier error.
 #[derive(Debug, Clone, Copy)]
 pub struct ErrorData {
-    kind: ErrorKind,
+    pub kind: ErrorKind,
     trace_info: TraceInfo,
 }
 

--- a/crates/verifier/src/error_stack.rs
+++ b/crates/verifier/src/error_stack.rs
@@ -2,17 +2,21 @@ use cranelift_entity::{PrimaryMap, SecondaryMap};
 use smallvec::SmallVec;
 use sonatina_ir::{module::FuncRef, types::CompoundType, Block, Function, Insn, Value};
 
-use crate::error::{kind::IrSource, Error, ErrorData, ErrorRef};
+use crate::{
+    error::{kind::IrSource, Error, ErrorData, ErrorRef},
+    pass::PassRef,
+};
 
 #[derive(Debug, Default)]
 pub struct ErrorStack {
+    pub errors: PrimaryMap<ErrorRef, ErrorData>,
+    pub pass: SecondaryMap<PassRef, SmallVec<[ErrorRef; 8]>>,
     pub block: SecondaryMap<Block, SmallVec<[ErrorRef; 8]>>,
     pub insn: SecondaryMap<Insn, SmallVec<[ErrorRef; 8]>>,
     pub callee: SecondaryMap<FuncRef, SmallVec<[ErrorRef; 8]>>,
     pub ssa: SecondaryMap<Value, SmallVec<[ErrorRef; 8]>>,
     pub ty: SmallVec<[ErrorRef; 8]>,
     pub cmpd_ty: SecondaryMap<CompoundType, SmallVec<[ErrorRef; 8]>>,
-    pub errors: PrimaryMap<ErrorRef, ErrorData>,
 }
 
 impl ErrorStack {

--- a/crates/verifier/src/error_stack.rs
+++ b/crates/verifier/src/error_stack.rs
@@ -10,7 +10,7 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct ErrorStack {
     pub errors: PrimaryMap<ErrorRef, ErrorData>,
-    pub pass: SecondaryMap<PassRef, SmallVec<[ErrorRef; 8]>>,
+    pub pass: PrimaryMap<PassRef, SmallVec<[ErrorRef; 8]>>,
     pub block: SecondaryMap<Block, SmallVec<[ErrorRef; 8]>>,
     pub insn: SecondaryMap<Insn, SmallVec<[ErrorRef; 8]>>,
     pub callee: SecondaryMap<FuncRef, SmallVec<[ErrorRef; 8]>>,

--- a/crates/verifier/src/error_stack.rs
+++ b/crates/verifier/src/error_stack.rs
@@ -1,0 +1,82 @@
+use cranelift_entity::{PrimaryMap, SecondaryMap};
+use smallvec::SmallVec;
+use sonatina_ir::{module::FuncRef, types::CompoundType, Block, Function, Insn, Value};
+
+use crate::error::{kind::IrSource, Error, ErrorData, ErrorRef};
+
+#[derive(Debug, Default)]
+pub struct ErrorStack {
+    pub block: SecondaryMap<Block, SmallVec<[ErrorRef; 8]>>,
+    pub insn: SecondaryMap<Insn, SmallVec<[ErrorRef; 8]>>,
+    pub callee: SecondaryMap<FuncRef, SmallVec<[ErrorRef; 8]>>,
+    pub ssa: SecondaryMap<Value, SmallVec<[ErrorRef; 8]>>,
+    pub ty: SmallVec<[ErrorRef; 8]>,
+    pub cmpd_ty: SecondaryMap<CompoundType, SmallVec<[ErrorRef; 8]>>,
+    pub errors: PrimaryMap<ErrorRef, ErrorData>,
+}
+
+impl ErrorStack {
+    pub fn push(&mut self, err: ErrorData) -> ErrorRef {
+        let ir_src = err.kind.ir_source();
+        let err_ref = self.errors.push(err);
+        match ir_src {
+            IrSource::Block(b) => self.block[b].push(err_ref),
+            IrSource::Insn(i) => self.insn[i].push(err_ref),
+            IrSource::Callee(f) => self.callee[f].push(err_ref),
+            IrSource::Value(v) => self.ssa[v].push(err_ref),
+            IrSource::Type => self.ty.push(err_ref),
+            IrSource::CompoundType(cmpd_ty) => self.cmpd_ty[cmpd_ty].push(err_ref),
+        }
+
+        err_ref
+    }
+
+    pub fn block_errs_iter<'a: 'b, 'b>(
+        &'b self,
+        func: &'a Function,
+    ) -> impl Iterator<Item = Error<'a>> + 'b {
+        self.block.values().flat_map(|errs| {
+            errs.iter()
+                .map(|err_ref| Error::new(self.errors[*err_ref], func))
+        })
+    }
+
+    pub fn insn_errs_iter<'a: 'b, 'b>(
+        &'b self,
+        func: &'a Function,
+    ) -> impl Iterator<Item = Error<'a>> + 'b {
+        self.insn.values().flat_map(|errs| {
+            errs.iter()
+                .map(|err_ref| Error::new(self.errors[*err_ref], func))
+        })
+    }
+
+    pub fn callee_errs_iter<'a: 'b, 'b>(
+        &'b self,
+        func: &'a Function,
+    ) -> impl Iterator<Item = Error<'a>> + 'b {
+        self.callee.values().flat_map(|errs| {
+            errs.iter()
+                .map(|err_ref| Error::new(self.errors[*err_ref], func))
+        })
+    }
+
+    pub fn ssa_errs_iter<'a: 'b, 'b>(
+        &'b self,
+        func: &'a Function,
+    ) -> impl Iterator<Item = Error<'a>> + 'b {
+        self.ssa.values().flat_map(|errs| {
+            errs.iter()
+                .map(|err_ref| Error::new(self.errors[*err_ref], func))
+        })
+    }
+
+    pub fn ty_errs_iter<'a: 'b, 'b>(
+        &'b self,
+        func: &'a Function,
+    ) -> impl Iterator<Item = Error<'a>> + 'b {
+        self.ty
+            .iter()
+            .map(|err_ref| Error::new(self.errors[*err_ref], func))
+    }
+}

--- a/crates/verifier/src/error_stack.rs
+++ b/crates/verifier/src/error_stack.rs
@@ -1,86 +1,21 @@
-use cranelift_entity::{PrimaryMap, SecondaryMap};
-use smallvec::SmallVec;
-use sonatina_ir::{module::FuncRef, types::CompoundType, Block, Function, Insn, Value};
+use cranelift_entity::PrimaryMap;
+use sonatina_ir::Function;
 
-use crate::{
-    error::{kind::IrSource, Error, ErrorData, ErrorRef},
-    pass::PassRef,
-};
+use crate::error::{Error, ErrorData, ErrorRef};
 
 #[derive(Debug, Default)]
 pub struct ErrorStack {
     pub errors: PrimaryMap<ErrorRef, ErrorData>,
-    pub pass: PrimaryMap<PassRef, SmallVec<[ErrorRef; 8]>>,
-    pub block: SecondaryMap<Block, SmallVec<[ErrorRef; 8]>>,
-    pub insn: SecondaryMap<Insn, SmallVec<[ErrorRef; 8]>>,
-    pub callee: SecondaryMap<FuncRef, SmallVec<[ErrorRef; 8]>>,
-    pub ssa: SecondaryMap<Value, SmallVec<[ErrorRef; 8]>>,
-    pub ty: SmallVec<[ErrorRef; 8]>,
-    pub cmpd_ty: SecondaryMap<CompoundType, SmallVec<[ErrorRef; 8]>>,
 }
 
 impl ErrorStack {
     pub fn push(&mut self, err: ErrorData) -> ErrorRef {
-        let ir_src = err.kind.ir_source();
-        let err_ref = self.errors.push(err);
-        match ir_src {
-            IrSource::Block(b) => self.block[b].push(err_ref),
-            IrSource::Insn(i) => self.insn[i].push(err_ref),
-            IrSource::Callee(f) => self.callee[f].push(err_ref),
-            IrSource::Value(v) => self.ssa[v].push(err_ref),
-            IrSource::Type => self.ty.push(err_ref),
-            IrSource::CompoundType(cmpd_ty) => self.cmpd_ty[cmpd_ty].push(err_ref),
-        }
-
-        err_ref
+        self.errors.push(err)
     }
 
-    pub fn block_errs_iter<'a: 'b, 'b>(
-        &'b self,
-        func: &'a Function,
-    ) -> impl Iterator<Item = Error<'a>> + 'b {
-        self.block.values().flat_map(|errs| {
-            errs.iter()
-                .map(|err_ref| Error::new(self.errors[*err_ref], func))
-        })
-    }
-
-    pub fn insn_errs_iter<'a: 'b, 'b>(
-        &'b self,
-        func: &'a Function,
-    ) -> impl Iterator<Item = Error<'a>> + 'b {
-        self.insn.values().flat_map(|errs| {
-            errs.iter()
-                .map(|err_ref| Error::new(self.errors[*err_ref], func))
-        })
-    }
-
-    pub fn callee_errs_iter<'a: 'b, 'b>(
-        &'b self,
-        func: &'a Function,
-    ) -> impl Iterator<Item = Error<'a>> + 'b {
-        self.callee.values().flat_map(|errs| {
-            errs.iter()
-                .map(|err_ref| Error::new(self.errors[*err_ref], func))
-        })
-    }
-
-    pub fn ssa_errs_iter<'a: 'b, 'b>(
-        &'b self,
-        func: &'a Function,
-    ) -> impl Iterator<Item = Error<'a>> + 'b {
-        self.ssa.values().flat_map(|errs| {
-            errs.iter()
-                .map(|err_ref| Error::new(self.errors[*err_ref], func))
-        })
-    }
-
-    pub fn ty_errs_iter<'a: 'b, 'b>(
-        &'b self,
-        func: &'a Function,
-    ) -> impl Iterator<Item = Error<'a>> + 'b {
-        self.ty
-            .iter()
-            .map(|err_ref| Error::new(self.errors[*err_ref], func))
+    pub fn into_errs_iter<'a>(self, func: &'a Function) -> impl IntoIterator<Item = Error<'a>> {
+        self.errors
+            .into_iter()
+            .map(|(_, err)| Error::new(err, func))
     }
 }

--- a/crates/verifier/src/error_stack.rs
+++ b/crates/verifier/src/error_stack.rs
@@ -13,7 +13,7 @@ impl ErrorStack {
         self.errors.push(err)
     }
 
-    pub fn into_errs_iter<'a>(self, func: &'a Function) -> impl IntoIterator<Item = Error<'a>> {
+    pub fn into_errs_iter(self, func: &Function) -> impl IntoIterator<Item = Error<'_>> {
         self.errors
             .into_iter()
             .map(|(_, err)| Error::new(err, func))

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -1,3 +1,2 @@
 pub mod error;
 pub mod error_stack;
-pub mod pass;

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod error;
+pub mod error_stack;

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod error;
 pub mod error_stack;
+pub mod pass;

--- a/crates/verifier/src/pass/mod.rs
+++ b/crates/verifier/src/pass/mod.rs
@@ -1,5 +1,0 @@
-use cranelift_entity::entity_impl;
-
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
-pub struct PassRef(pub u32);
-entity_impl!(PassRef, "pass");

--- a/crates/verifier/src/pass/mod.rs
+++ b/crates/verifier/src/pass/mod.rs
@@ -1,0 +1,5 @@
+use cranelift_entity::entity_impl;
+
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub struct PassRef(pub u32);
+entity_impl!(PassRef, "pass");


### PR DESCRIPTION
- Defines verifier `ErrorStack`.
- Adds mappings from `ErrorKind` to `IrSource` (function, block, instruction, etc.)