### PR TITLE
Flexible inst cast

### DIFF
--- a/crates/ir/src/inst/control_flow.rs
+++ b/crates/ir/src/inst/control_flow.rs
@@ -4,11 +4,13 @@ use smallvec::SmallVec;
 use crate::{module::FuncRef, Block, Type, Value};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Inst)]
+#[inst(terminator)]
 pub struct Jump {
     dest: Block,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Inst)]
+#[inst(terminator)]
 pub struct Br {
     #[inst(value)]
     cond: Value,
@@ -18,6 +20,7 @@ pub struct Br {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Inst)]
+#[inst(terminator)]
 pub struct BrTable {
     #[inst(value)]
     scrutinee: Value,
@@ -36,6 +39,7 @@ pub struct Phi {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Inst)]
 #[inst(has_side_effect)]
+#[inst(terminator)]
 pub struct Call {
     #[inst(value)]
     args: SmallVec<[Value; 8]>,
@@ -45,6 +49,7 @@ pub struct Call {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Inst)]
 #[inst(has_side_effect)]
+#[inst(terminator)]
 pub struct Return {
     #[inst(value)]
     arg: Option<Value>,

--- a/crates/ir/src/inst/control_flow.rs
+++ b/crates/ir/src/inst/control_flow.rs
@@ -64,7 +64,7 @@ pub enum BranchInfo<'i> {
 }
 
 impl<'i> BranchInfo<'i> {
-    pub fn iter_dets(self) -> impl Iterator<Item = Block> + 'i {
+    pub fn iter_dests(self) -> impl Iterator<Item = Block> + 'i {
         BranchDestIter {
             branch_info: self,
             idx: 0,

--- a/crates/ir/src/inst/evm/mod.rs
+++ b/crates/ir/src/inst/evm/mod.rs
@@ -5,6 +5,7 @@ use crate::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Inst)]
 #[inst(has_side_effect)]
+#[inst(terminator)]
 pub struct EvmStop {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Inst)]
@@ -327,6 +328,7 @@ pub struct EvmCall {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Inst)]
 #[inst(has_side_effect)]
+#[inst(terminator)]
 pub struct EvmReturn {
     #[inst(value)]
     addr: Value,
@@ -383,6 +385,7 @@ pub struct EvmStaticCall {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Inst)]
 #[inst(has_side_effect)]
+#[inst(terminator)]
 pub struct EvmRevert {
     #[inst(value)]
     addr: Value,
@@ -392,6 +395,7 @@ pub struct EvmRevert {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Inst)]
 #[inst(has_side_effect)]
+#[inst(terminator)]
 pub struct EvmSelfDestruct {
     #[inst(value)]
     addr: Value,

--- a/crates/ir/src/inst/inst_set.rs
+++ b/crates/ir/src/inst/inst_set.rs
@@ -135,7 +135,6 @@ define_inst_set_base! {
 ///
 /// This macro provides the way to these safe downcast, and allow us to focus on the
 /// restricted concrete instruction set, instead of "all possible" instructions.
-///
 pub trait InstSetExt: InstSetBase {
     type InstKind<'i>;
     type InstKindMut<'i>;

--- a/crates/ir/src/inst/mod.rs
+++ b/crates/ir/src/inst/mod.rs
@@ -11,11 +11,11 @@ use std::any::{Any, TypeId};
 
 use smallvec::SmallVec;
 
-use crate::Value;
+use crate::{InstSetBase, Value};
 
 pub trait Inst: inst_set::sealed::Registered + Any {
-    fn visit_values(&self, f: &mut dyn FnMut(Value));
-    fn visit_values_mut(&mut self, f: &mut dyn FnMut(&mut Value));
+    fn visit_values(&self, f: &mut dyn Fn(Value));
+    fn visit_values_mut(&mut self, f: &mut dyn Fn(&mut Value));
     fn has_side_effect(&self) -> bool;
     fn as_text(&self) -> &'static str;
     fn is_terminator(&self) -> bool;
@@ -30,16 +30,16 @@ pub trait HasInst<I: Inst> {
 }
 
 pub(crate) trait ValueVisitable {
-    fn visit_with(&self, f: &mut dyn FnMut(Value));
-    fn visit_mut_with(&mut self, f: &mut dyn FnMut(&mut Value));
+    fn visit_with(&self, f: &mut dyn Fn(Value));
+    fn visit_mut_with(&mut self, f: &mut dyn Fn(&mut Value));
 }
 
 impl ValueVisitable for Value {
-    fn visit_with(&self, f: &mut dyn FnMut(Value)) {
+    fn visit_with(&self, f: &mut dyn Fn(Value)) {
         f(*self)
     }
 
-    fn visit_mut_with(&mut self, f: &mut dyn FnMut(&mut Value)) {
+    fn visit_mut_with(&mut self, f: &mut dyn Fn(&mut Value)) {
         f(self)
     }
 }
@@ -48,13 +48,13 @@ impl<V> ValueVisitable for Option<V>
 where
     V: ValueVisitable,
 {
-    fn visit_with(&self, f: &mut dyn FnMut(Value)) {
+    fn visit_with(&self, f: &mut dyn Fn(Value)) {
         if let Some(value) = self {
             value.visit_with(f)
         }
     }
 
-    fn visit_mut_with(&mut self, f: &mut dyn FnMut(&mut Value)) {
+    fn visit_mut_with(&mut self, f: &mut dyn Fn(&mut Value)) {
         if let Some(value) = self.as_mut() {
             value.visit_mut_with(f)
         }
@@ -65,11 +65,11 @@ impl<V, T> ValueVisitable for (V, T)
 where
     V: ValueVisitable,
 {
-    fn visit_with(&self, f: &mut dyn FnMut(Value)) {
+    fn visit_with(&self, f: &mut dyn Fn(Value)) {
         self.0.visit_with(f)
     }
 
-    fn visit_mut_with(&mut self, f: &mut dyn FnMut(&mut Value)) {
+    fn visit_mut_with(&mut self, f: &mut dyn Fn(&mut Value)) {
         self.0.visit_mut_with(f)
     }
 }
@@ -78,11 +78,11 @@ impl<V> ValueVisitable for Vec<V>
 where
     V: ValueVisitable,
 {
-    fn visit_with(&self, f: &mut dyn FnMut(Value)) {
+    fn visit_with(&self, f: &mut dyn Fn(Value)) {
         self.iter().for_each(|v| v.visit_with(f))
     }
 
-    fn visit_mut_with(&mut self, f: &mut dyn FnMut(&mut Value)) {
+    fn visit_mut_with(&mut self, f: &mut dyn Fn(&mut Value)) {
         self.iter_mut().for_each(|v| v.visit_mut_with(f))
     }
 }
@@ -91,11 +91,11 @@ impl<V> ValueVisitable for [V]
 where
     V: ValueVisitable,
 {
-    fn visit_with(&self, f: &mut dyn FnMut(Value)) {
+    fn visit_with(&self, f: &mut dyn Fn(Value)) {
         self.iter().for_each(|v| v.visit_with(f))
     }
 
-    fn visit_mut_with(&mut self, f: &mut dyn FnMut(&mut Value)) {
+    fn visit_mut_with(&mut self, f: &mut dyn Fn(&mut Value)) {
         self.iter_mut().for_each(|v| v.visit_mut_with(f))
     }
 }
@@ -105,11 +105,11 @@ where
     V: ValueVisitable,
     [V; N]: smallvec::Array<Item = V>,
 {
-    fn visit_with(&self, f: &mut dyn FnMut(Value)) {
+    fn visit_with(&self, f: &mut dyn Fn(Value)) {
         self.iter().for_each(|v| v.visit_with(f))
     }
 
-    fn visit_mut_with(&mut self, f: &mut dyn FnMut(&mut Value)) {
+    fn visit_mut_with(&mut self, f: &mut dyn Fn(&mut Value)) {
         self.iter_mut().for_each(|v| v.visit_mut_with(f))
     }
 }

--- a/crates/ir/src/inst/mod.rs
+++ b/crates/ir/src/inst/mod.rs
@@ -18,6 +18,7 @@ pub trait Inst: inst_set::sealed::Registered + Any {
     fn visit_values_mut(&mut self, f: &mut dyn FnMut(&mut Value));
     fn has_side_effect(&self) -> bool;
     fn as_text(&self) -> &'static str;
+    fn is_terminator(&self) -> bool;
 }
 
 /// This trait works as a "proof" that a specific ISA contains `I`,

--- a/crates/ir/src/inst/mod.rs
+++ b/crates/ir/src/inst/mod.rs
@@ -115,26 +115,28 @@ where
 }
 
 pub trait InstCast: Inst + Sized {
-    fn downcast<'i>(is: &dyn InstSetBase, inst: &'i dyn Inst) -> Option<&'i Self>;
-    fn downcast_mut<'i>(is: &dyn InstSetBase, inst: &'i mut dyn Inst) -> Option<&'i mut Self>;
+    fn downcast<'i>(_hi: &dyn HasInst<Self>, inst: &'i dyn Inst) -> Option<&'i Self>;
+    fn downcast_mut<'i>(_hi: &dyn HasInst<Self>, inst: &'i mut dyn Inst) -> Option<&'i mut Self>;
 
-    fn upcast(self) -> Box<dyn Inst> {
-        Box::new(self)
-    }
+    fn downcast_with_isb<'i>(isb: &dyn InstSetBase, inst: &'i dyn Inst) -> Option<&'i Self>;
+    fn downcast_mut_with_isb<'i>(
+        is: &dyn InstSetBase,
+        inst: &'i mut dyn Inst,
+    ) -> Option<&'i mut Self>;
 
-    fn map<'i, F, R>(is: &dyn InstSetBase, inst: &'i dyn Inst, f: F) -> Option<R>
+    fn map_with_isb<'i, F, R>(isb: &dyn InstSetBase, inst: &'i dyn Inst, f: F) -> Option<R>
     where
         F: Fn(&'i Self) -> R,
     {
-        let data = Self::downcast(is, inst)?;
+        let data = Self::downcast_with_isb(isb, inst)?;
         Some(f(data))
     }
 
-    fn map_mut<'i, F, R>(is: &dyn InstSetBase, inst: &'i mut dyn Inst, f: F) -> Option<R>
+    fn map_mut_with_isb<'i, F, R>(isb: &dyn InstSetBase, inst: &'i mut dyn Inst, f: F) -> Option<R>
     where
         F: Fn(&'i mut Self) -> R,
     {
-        let data = Self::downcast_mut(is, inst)?;
+        let data = Self::downcast_mut_with_isb(isb, inst)?;
         Some(f(data))
     }
 }

--- a/crates/ir/src/inst/mod.rs
+++ b/crates/ir/src/inst/mod.rs
@@ -115,9 +115,9 @@ where
 }
 
 pub trait InstDowncast: Sized {
-    fn downcast<'i>(isb: &dyn InstSetBase, inst: &'i dyn Inst) -> Option<Self>;
+    fn downcast(isb: &dyn InstSetBase, inst: &dyn Inst) -> Option<Self>;
 
-    fn map<'i, F, R>(isb: &dyn InstSetBase, inst: &'i dyn Inst, f: F) -> Option<R>
+    fn map<F, R>(isb: &dyn InstSetBase, inst: &dyn Inst, f: F) -> Option<R>
     where
         F: Fn(Self) -> R,
     {
@@ -126,10 +126,19 @@ pub trait InstDowncast: Sized {
     }
 }
 
-pub trait InstDowncastMut: Sized {
-    fn downcast_mut<'i>(isb: &dyn InstSetBase, inst: &'i mut dyn Inst) -> Option<Self>;
+impl<T> InstDowncastMut for T
+where
+    T: InstDowncast,
+{
+    fn downcast_mut(isb: &dyn InstSetBase, inst: &mut dyn Inst) -> Option<Self> {
+        InstDowncast::downcast(isb, inst)
+    }
+}
 
-    fn map_mut<'i, F, R>(isb: &dyn InstSetBase, inst: &'i mut dyn Inst, f: F) -> Option<R>
+pub trait InstDowncastMut: Sized {
+    fn downcast_mut(isb: &dyn InstSetBase, inst: &mut dyn Inst) -> Option<Self>;
+
+    fn map_mut<F, R>(isb: &dyn InstSetBase, inst: &mut dyn Inst, f: F) -> Option<R>
     where
         F: Fn(Self) -> R,
     {

--- a/crates/ir/src/inst/mod.rs
+++ b/crates/ir/src/inst/mod.rs
@@ -114,29 +114,26 @@ where
     }
 }
 
-pub trait InstCast: Inst + Sized {
-    fn downcast<'i>(_hi: &dyn HasInst<Self>, inst: &'i dyn Inst) -> Option<&'i Self>;
-    fn downcast_mut<'i>(_hi: &dyn HasInst<Self>, inst: &'i mut dyn Inst) -> Option<&'i mut Self>;
+pub trait InstDowncast: Sized {
+    fn downcast<'i>(isb: &dyn InstSetBase, inst: &'i dyn Inst) -> Option<Self>;
 
-    fn downcast_with_isb<'i>(isb: &dyn InstSetBase, inst: &'i dyn Inst) -> Option<&'i Self>;
-    fn downcast_mut_with_isb<'i>(
-        is: &dyn InstSetBase,
-        inst: &'i mut dyn Inst,
-    ) -> Option<&'i mut Self>;
-
-    fn map_with_isb<'i, F, R>(isb: &dyn InstSetBase, inst: &'i dyn Inst, f: F) -> Option<R>
+    fn map<'i, F, R>(isb: &dyn InstSetBase, inst: &'i dyn Inst, f: F) -> Option<R>
     where
-        F: Fn(&'i Self) -> R,
+        F: Fn(Self) -> R,
     {
-        let data = Self::downcast_with_isb(isb, inst)?;
+        let data = Self::downcast(isb, inst)?;
         Some(f(data))
     }
+}
 
-    fn map_mut_with_isb<'i, F, R>(isb: &dyn InstSetBase, inst: &'i mut dyn Inst, f: F) -> Option<R>
+pub trait InstDowncastMut: Sized {
+    fn downcast_mut<'i>(isb: &dyn InstSetBase, inst: &'i mut dyn Inst) -> Option<Self>;
+
+    fn map_mut<'i, F, R>(isb: &dyn InstSetBase, inst: &'i mut dyn Inst, f: F) -> Option<R>
     where
-        F: Fn(&'i mut Self) -> R,
+        F: Fn(Self) -> R,
     {
-        let data = Self::downcast_mut_with_isb(isb, inst)?;
+        let data = Self::downcast_mut(isb, inst)?;
         Some(f(data))
     }
 }

--- a/crates/ir/src/inst/mod.rs
+++ b/crates/ir/src/inst/mod.rs
@@ -113,3 +113,28 @@ where
         self.iter_mut().for_each(|v| v.visit_mut_with(f))
     }
 }
+
+pub trait InstCast: Inst + Sized {
+    fn downcast<'i>(is: &dyn InstSetBase, inst: &'i dyn Inst) -> Option<&'i Self>;
+    fn downcast_mut<'i>(is: &dyn InstSetBase, inst: &'i mut dyn Inst) -> Option<&'i mut Self>;
+
+    fn upcast(self) -> Box<dyn Inst> {
+        Box::new(self)
+    }
+
+    fn map<'i, F, R>(is: &dyn InstSetBase, inst: &'i dyn Inst, f: F) -> Option<R>
+    where
+        F: Fn(&'i Self) -> R,
+    {
+        let data = Self::downcast(is, inst)?;
+        Some(f(data))
+    }
+
+    fn map_mut<'i, F, R>(is: &dyn InstSetBase, inst: &'i mut dyn Inst, f: F) -> Option<R>
+    where
+        F: Fn(&'i mut Self) -> R,
+    {
+        let data = Self::downcast_mut(is, inst)?;
+        Some(f(data))
+    }
+}

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -27,7 +27,7 @@ pub use graphviz::render_to;
 pub use insn::{BranchInfo, DataLocationKind, Insn, InsnData};
 pub use inst::{
     inst_set::{InstSetBase, InstSetExt},
-    HasInst, Inst, InstCast,
+    HasInst, Inst, InstDowncast, InstDowncastMut,
 };
 pub use layout::Layout;
 pub use linkage::Linkage;
@@ -40,6 +40,6 @@ pub(crate) use inst::ValueVisitable;
 pub mod prelude {
     pub use crate::inst::{
         inst_set::{InstSetBase, InstSetExt},
-        HasInst, Inst, InstCast,
+        HasInst, Inst, InstDowncast, InstDowncastMut,
     };
 }

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -27,7 +27,7 @@ pub use graphviz::render_to;
 pub use insn::{BranchInfo, DataLocationKind, Insn, InsnData};
 pub use inst::{
     inst_set::{InstSetBase, InstSetExt},
-    HasInst, Inst,
+    HasInst, Inst, InstCast,
 };
 pub use layout::Layout;
 pub use linkage::Linkage;
@@ -40,6 +40,6 @@ pub(crate) use inst::ValueVisitable;
 pub mod prelude {
     pub use crate::inst::{
         inst_set::{InstSetBase, InstSetExt},
-        HasInst, Inst,
+        HasInst, Inst, InstCast,
     };
 }

--- a/crates/macros/src/inst.rs
+++ b/crates/macros/src/inst.rs
@@ -184,7 +184,7 @@ impl InstStruct {
         let has_inst_method = ty_name_to_method_name(struct_name);
         quote! {
             impl crate::InstDowncast for &#struct_name {
-                fn downcast<'i>(isb: &dyn crate::InstSetBase, inst: &'i dyn crate::Inst) -> Option<Self> {
+                fn downcast(isb: &dyn crate::InstSetBase, inst: &dyn crate::Inst) -> Option<Self> {
                     let hi = isb.#has_inst_method()?;
                     if hi.is(inst) {
                         unsafe { Some(&*(inst as *const dyn crate::Inst as *const Self)) }
@@ -195,7 +195,7 @@ impl InstStruct {
             }
 
             impl crate::InstDowncastMut for &mut #struct_name {
-                fn downcast_mut<'i>(isb: &dyn crate::InstSetBase, inst: &'i mut dyn crate::Inst) -> Option<Self> {
+                fn downcast_mut(isb: &dyn crate::InstSetBase, inst: &mut dyn crate::Inst) -> Option<Self> {
                     let hi = isb.#has_inst_method()?;
                     if hi.is(inst) {
                         unsafe { Some(*(inst as *mut dyn crate::Inst as *mut Self)) }

--- a/crates/macros/src/inst.rs
+++ b/crates/macros/src/inst.rs
@@ -183,34 +183,25 @@ impl InstStruct {
         let struct_name = &self.struct_name;
         let has_inst_method = ty_name_to_method_name(struct_name);
         quote! {
-            impl crate::InstCast for #struct_name {
-                fn downcast<'i>(hi: &dyn crate::HasInst<Self>, inst: &'i dyn crate::Inst) -> Option<&'i Self> {
+            impl crate::InstDowncast for &#struct_name {
+                fn downcast<'i>(isb: &dyn crate::InstSetBase, inst: &'i dyn crate::Inst) -> Option<Self> {
+                    let hi = isb.#has_inst_method()?;
                     if hi.is(inst) {
                         unsafe { Some(&*(inst as *const dyn crate::Inst as *const Self)) }
                     } else {
                         None
                     }
                 }
+            }
 
-                fn downcast_mut<'i>(
-                    hi: &dyn crate::HasInst<Self>,
-                    inst: &'i mut dyn crate::Inst,
-                ) -> Option<&'i mut Self> {
+            impl crate::InstDowncastMut for &mut #struct_name {
+                fn downcast_mut<'i>(isb: &dyn crate::InstSetBase, inst: &'i mut dyn crate::Inst) -> Option<Self> {
+                    let hi = isb.#has_inst_method()?;
                     if hi.is(inst) {
-                        unsafe { Some(&mut *(inst as *mut dyn crate::Inst as *mut Self)) }
+                        unsafe { Some(*(inst as *mut dyn crate::Inst as *mut Self)) }
                     } else {
                         None
                     }
-                }
-
-                fn downcast_with_isb<'i>(is: &dyn crate::InstSetBase, inst: &'i dyn crate::Inst) -> Option<&'i Self> {
-                    let hi = is.#has_inst_method()?;
-                    Self::downcast(hi, inst)
-                }
-
-                fn downcast_mut_with_isb<'i>(is: &dyn crate::InstSetBase, inst: &'i mut dyn crate::Inst) -> Option<&'i mut Self> {
-                    let hi = is.#has_inst_method()?;
-                    Self::downcast_mut(hi, inst)
                 }
             }
         }

--- a/crates/macros/src/inst.rs
+++ b/crates/macros/src/inst.rs
@@ -214,11 +214,11 @@ impl InstStruct {
 
         quote! {
             impl crate::Inst for #struct_name {
-                fn visit_values(&self, f: &mut dyn FnMut(crate::Value)) {
+                fn visit_values(&self, f: &mut dyn Fn(crate::Value)) {
                     #(crate::ValueVisitable::visit_with(&self.#visit_fields, (f));)*
                 }
 
-                fn visit_values_mut(&mut self, f: &mut dyn FnMut(&mut crate::Value)) {
+                fn visit_values_mut(&mut self, f: &mut dyn Fn(&mut crate::Value)) {
                     #(crate::ValueVisitable::visit_mut_with(&mut self.#visit_fields, (f));)*
                 }
 

--- a/crates/macros/src/inst.rs
+++ b/crates/macros/src/inst.rs
@@ -221,11 +221,11 @@ impl InstStruct {
 
         quote! {
             impl crate::Inst for #struct_name {
-                fn visit_values(&self, f: &mut dyn Fn(crate::Value)) {
+                fn visit_values(&self, f: &mut dyn FnMut(crate::Value)) {
                     #(crate::ValueVisitable::visit_with(&self.#visit_fields, (f));)*
                 }
 
-                fn visit_values_mut(&mut self, f: &mut dyn Fn(&mut crate::Value)) {
+                fn visit_values_mut(&mut self, f: &mut dyn FnMut(&mut crate::Value)) {
                     #(crate::ValueVisitable::visit_mut_with(&mut self.#visit_fields, (f));)*
                 }
 

--- a/crates/macros/src/inst_set.rs
+++ b/crates/macros/src/inst_set.rs
@@ -180,12 +180,12 @@ impl InstSet {
                 let tid = std::any::TypeId::of::<#p>();
                 fn #cast_fn_name<'i>(self_: &#ident, inst: &'i dyn crate::Inst) -> #inst_kind_name<'i> {
                     use crate::prelude::*;
-                    let inst = #p::downcast(self_, inst).unwrap();
+                    let inst = InstDowncast::downcast(self_, inst).unwrap();
                     #inst_kind_name::#variant_name(inst)
                 }
                 fn #cast_mut_fn_name<'i>(self_: &#ident, inst: &'i mut dyn crate::Inst) -> #inst_kind_mut_name<'i> {
                     use crate::prelude::*;
-                    let inst = #p::downcast_mut(self_, inst).unwrap();
+                    let inst = InstDowncastMut::downcast_mut(self_, inst).unwrap();
                     #inst_kind_mut_name::#variant_name(inst)
                 }
 

--- a/crates/macros/src/inst_set.rs
+++ b/crates/macros/src/inst_set.rs
@@ -179,11 +179,13 @@ impl InstSet {
             quote! {
                 let tid = std::any::TypeId::of::<#p>();
                 fn #cast_fn_name<'i>(self_: &#ident, inst: &'i dyn crate::Inst) -> #inst_kind_name<'i> {
-                    let inst = #p::cast(self_, inst).unwrap();
+                    use crate::prelude::*;
+                    let inst = #p::downcast(self_, inst).unwrap();
                     #inst_kind_name::#variant_name(inst)
                 }
                 fn #cast_mut_fn_name<'i>(self_: &#ident, inst: &'i mut dyn crate::Inst) -> #inst_kind_mut_name<'i> {
-                    let inst = #p::cast_mut(self_, inst).unwrap();
+                    use crate::prelude::*;
+                    let inst = #p::downcast_mut(self_, inst).unwrap();
                     #inst_kind_mut_name::#variant_name(inst)
                 }
 

--- a/crates/macros/src/inst_set_base.rs
+++ b/crates/macros/src/inst_set_base.rs
@@ -77,8 +77,14 @@ impl syn::parse::Parse for TraitDefinition {
     }
 }
 
+/// convert path to the inst struct to `has_inst` method name.
+/// e.g., `foo::Add` => `has_add`
 pub(super) fn path_to_method_name(p: &syn::Path) -> syn::Ident {
     let ident = &p.segments.last().as_ref().unwrap().ident;
+    ty_name_to_method_name(ident)
+}
+
+pub(super) fn ty_name_to_method_name(ident: &syn::Ident) -> syn::Ident {
     let s_ident = convert_to_snake(&ident.to_string());
     quote::format_ident!("has_{s_ident}")
 }


### PR DESCRIPTION
The new implementation of `BranchInfo` would be a nice example of this change.
```rust
pub trait InstDowncast: Sized {
    fn downcast(isb: &dyn InstSetBase, inst: &dyn Inst) -> Option<Self>;

    fn map<F, R>(isb: &dyn InstSetBase, inst: &dyn Inst, f: F) -> Option<R>
    where
        F: Fn(Self) -> R,
    {
        let data = Self::downcast(isb, inst)?;
        Some(f(data))
    }
}

#[derive(Clone, Copy)]
pub enum BranchInfo<'i> {
    Jump(&'i Jump),
    Br(&'i Br),
    BrTable(&'i BrTable),
}

impl<'i> InstDowncast for BranchInfo<'i> {
    fn downcast(isb: &dyn crate::InstSetBase, inst: &dyn super::Inst) -> Option<Self> {
        InstDowncast::map(isb, inst, BranchInfo::Jump)
            .or_else(|| InstDowncast::map(isb, inst, BranchInfo::Br))
            .or_else(|| InstDowncast::map(isb, inst, BranchInfo::BrTable))
    }
}
```
NOTE: `Inst` derive macro automatically implements `InstDowncast for &YourInst` and `InstDowncastMut for &mut YourInst`.