### PR TITLE
Define `InstExt`

### DIFF
--- a/crates/ir/src/dfg.rs
+++ b/crates/ir/src/dfg.rs
@@ -223,13 +223,11 @@ impl DataFlowGraph {
     }
 
     pub fn make_phi(&self, args: Vec<(ValueId, BlockId)>) -> Phi {
-        let has_phi = self.inst_set().phi();
-        Phi::new(has_phi, args)
+        Phi::new(self.inst_set().phi(), args)
     }
 
     pub fn make_jump(&self, to: BlockId) -> Jump {
-        let has_jump = self.inst_set().jump();
-        Jump::new(has_jump, to)
+        Jump::new(self.inst_set().jump(), to)
     }
 
     pub fn change_to_alias(&mut self, value: ValueId, alias: ValueId) {

--- a/crates/ir/src/inst/control_flow.rs
+++ b/crates/ir/src/inst/control_flow.rs
@@ -216,8 +216,7 @@ impl Branch for Br {
             return Box::new(self.clone());
         };
 
-        let has_jump = isb.jump();
-        let jump = Jump::new(has_jump, remain);
+        let jump = Jump::new(isb.jump(), remain);
         Box::new(jump)
     }
 
@@ -272,8 +271,7 @@ impl Branch for BrTable {
 
         let dest_num = brt.dests().len();
         if dest_num == 1 {
-            let has_jump = isb.jump();
-            let jump = Jump::new(has_jump, brt.dests()[0]);
+            let jump = Jump::new(isb.jump(), brt.dests()[0]);
             Box::new(jump)
         } else {
             Box::new(brt)
@@ -317,8 +315,7 @@ fn try_convert_branch_to_jump(isb: &dyn InstSetBase, branch: &dyn Branch) -> Opt
         .skip(1)
         .all(|dest| *dest == first_dest);
     if is_dest_unique {
-        let has_jump = isb.jump();
-        let jump = Jump::new(has_jump, first_dest);
+        let jump = Jump::new(isb.jump(), first_dest);
         Some(Box::new(jump))
     } else {
         None

--- a/crates/ir/src/inst/inst_set.rs
+++ b/crates/ir/src/inst/inst_set.rs
@@ -4,9 +4,6 @@ use super::{arith, cast, cmp, control_flow, data, evm, logic, Inst};
 
 define_inst_set_base! {
     /// This trait is used to determine whether a certain instruction set includes a specific inst in runtime.
-    /// If a certain instruction set `IS` implements `HasInst<I>`,
-    /// the corresponding `has_i(&self) -> Option<&dyn HasInst<I>>` method always returns `Some`.
-    ///
     /// Since all instruction set implements `HasInst<Inst>` if it contains `Inst`,
     /// this trait is naturally intended to be used as a trait object.
     ///

--- a/crates/ir/src/inst/mod.rs
+++ b/crates/ir/src/inst/mod.rs
@@ -51,6 +51,17 @@ pub trait Inst: inst_set::sealed::Registered + Any {
     }
 }
 
+pub trait InstExt: Inst {
+    /// Checks if the this instruction type belongs to the given `InstSetBase`.
+    ///
+    /// # Returns
+    ///
+    /// * `Option<&dyn HasInst<Self>>` - If this instruction type belongs to the
+    ///   set, returns `Some` with a reference to the corresponding `HasInst`.
+    ///   Otherwise, returns `None`.
+    fn belongs_to(isb: &dyn InstSetBase) -> Option<&dyn HasInst<Self>>;
+}
+
 impl WriteWithFunc for InstId {
     fn write(&self, ctx: &FuncWriteCtx, w: &mut impl io::Write) -> io::Result<()> {
         let inst = ctx.func.dfg.inst(*self);

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -27,7 +27,7 @@ pub use graphviz::render_to;
 pub(crate) use inst::ValueVisitable;
 pub use inst::{
     inst_set::{InstSetBase, InstSetExt},
-    HasInst, Inst, InstDowncast, InstDowncastMut, InstId,
+    HasInst, Inst, InstDowncast, InstDowncastMut, InstExt, InstId,
 };
 pub use layout::Layout;
 pub use linkage::Linkage;
@@ -39,7 +39,7 @@ pub mod prelude {
     pub use crate::{
         inst::{
             inst_set::{InstSetBase, InstSetExt},
-            HasInst, Inst, InstDowncast, InstDowncastMut,
+            HasInst, Inst, InstDowncast, InstDowncastMut, InstExt,
         },
         isa::Isa,
     };

--- a/crates/macros/src/inst.rs
+++ b/crates/macros/src/inst.rs
@@ -55,11 +55,13 @@ impl InstStruct {
     fn build(self) -> syn::Result<proc_macro2::TokenStream> {
         let impl_method = self.impl_method();
         let impl_inst = self.impl_inst();
+        let impl_inst_ext = self.impl_inst_ext();
         let impl_inst_cast = self.impl_inst_cast();
         Ok(quote! {
            #impl_method
            #impl_inst_cast
            #impl_inst
+           #impl_inst_ext
         })
     }
 
@@ -258,6 +260,19 @@ impl InstStruct {
 
                 fn as_text(&self) -> &'static str {
                     Self::inst_name()
+                }
+            }
+        }
+    }
+
+    fn impl_inst_ext(&self) -> proc_macro2::TokenStream {
+        let struct_name = &self.struct_name;
+        let has_inst_method = ty_name_to_method_name(struct_name);
+
+        quote! {
+            impl crate::InstExt for #struct_name {
+                fn belongs_to(isb: &dyn crate::InstSetBase) -> Option<&dyn crate::HasInst<Self>> {
+                    isb.#has_inst_method()
                 }
             }
         }

--- a/crates/macros/src/inst_set_base.rs
+++ b/crates/macros/src/inst_set_base.rs
@@ -32,6 +32,7 @@ impl TraitDefinition {
         let methods = self.insts.iter().map(|path| {
             let method_name = path_to_method_name(path);
             quote! {
+                #[doc(hidden)]
                 fn #method_name(&self) -> Option<&dyn crate::HasInst<#path>> { None }
             }
         });

--- a/crates/parser/src/inst/arith.rs
+++ b/crates/parser/src/inst/arith.rs
@@ -1,13 +1,13 @@
 use ir::inst::arith::*;
 
-super::impl_inst_build! {Neg, has_neg, (arg: ValueId)}
-super::impl_inst_build! {Add, has_add, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Mul, has_mul, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Sub, has_sub, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Sdiv, has_sdiv, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Udiv, has_udiv, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Umod, has_umod, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Smod, has_smod, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Shl, has_shl, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Shr, has_shr, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Sar, has_sar, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Neg, (arg: ValueId)}
+super::impl_inst_build! {Add, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Mul, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Sub, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Sdiv, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Udiv, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Umod, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Smod, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Shl, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Shr, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Sar, (lhs: ValueId, rhs: ValueId)}

--- a/crates/parser/src/inst/cast.rs
+++ b/crates/parser/src/inst/cast.rs
@@ -1,8 +1,8 @@
 use ir::inst::cast::*;
 
-super::impl_inst_build! {Sext, has_sext, (from: ValueId, ty: Type)}
-super::impl_inst_build! {Zext, has_zext, (from: ValueId, ty: Type)}
-super::impl_inst_build! {Trunc, has_trunc, (from: ValueId, ty: Type)}
-super::impl_inst_build! {Bitcast, has_bitcast, (from: ValueId, ty: Type)}
-super::impl_inst_build! {IntToPtr, has_int_to_ptr, (from: ValueId, ty: Type)}
-super::impl_inst_build! {PtrToInt, has_ptr_to_int, (from: ValueId, ty: Type)}
+super::impl_inst_build! {Sext, (from: ValueId, ty: Type)}
+super::impl_inst_build! {Zext, (from: ValueId, ty: Type)}
+super::impl_inst_build! {Trunc, (from: ValueId, ty: Type)}
+super::impl_inst_build! {Bitcast, (from: ValueId, ty: Type)}
+super::impl_inst_build! {IntToPtr, (from: ValueId, ty: Type)}
+super::impl_inst_build! {PtrToInt, (from: ValueId, ty: Type)}

--- a/crates/parser/src/inst/cmp.rs
+++ b/crates/parser/src/inst/cmp.rs
@@ -1,13 +1,13 @@
 use ir::inst::cmp::*;
 
-super::impl_inst_build! {Lt, has_lt, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Gt, has_gt, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Slt, has_slt, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Sgt, has_sgt, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Le, has_le, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Ge, has_ge, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Sle, has_sle, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Sge, has_sge, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Eq, has_eq, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Ne, has_ne, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {IsZero, has_is_zero, (lhs: ValueId)}
+super::impl_inst_build! {Lt, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Gt, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Slt, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Sgt, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Le, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Ge, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Sle,  (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Sge,  (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Eq,  (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Ne,  (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {IsZero, (lhs: ValueId)}

--- a/crates/parser/src/inst/control_flow.rs
+++ b/crates/parser/src/inst/control_flow.rs
@@ -3,12 +3,12 @@ use smallvec::SmallVec;
 
 use crate::{ast, error::ArityBound, BuildCtx, Error};
 
-super::impl_inst_build! {Jump, has_jump, (dest: BlockId)}
-super::impl_inst_build! {Br, has_br, (cond: ValueId, nz_dest: BlockId, z_dest: BlockId)}
-super::impl_inst_build_common! {BrTable, has_br_table, ArityBound::AtLeast(1), build_br_table}
-super::impl_inst_build_common! {Phi, has_phi, ArityBound::AtLeast(1), build_phi}
-super::impl_inst_build_common! {Call, has_call, ArityBound::AtLeast(1), build_call}
-super::impl_inst_build_common! {Return, has_return, ArityBound::AtMost(1), build_return}
+super::impl_inst_build! {Jump, (dest: BlockId)}
+super::impl_inst_build! {Br, (cond: ValueId, nz_dest: BlockId, z_dest: BlockId)}
+super::impl_inst_build_common! {BrTable, ArityBound::AtLeast(1), build_br_table}
+super::impl_inst_build_common! {Phi, ArityBound::AtLeast(1), build_phi}
+super::impl_inst_build_common! {Call, ArityBound::AtLeast(1), build_call}
+super::impl_inst_build_common! {Return, ArityBound::AtMost(1), build_return}
 
 fn build_br_table(
     ctx: &mut BuildCtx,

--- a/crates/parser/src/inst/data.rs
+++ b/crates/parser/src/inst/data.rs
@@ -3,9 +3,9 @@ use smallvec::SmallVec;
 
 use crate::{ast, error::ArityBound, BuildCtx, Error};
 
-super::impl_inst_build! {Mload, has_mload, (addr: ValueId, ty: Type)}
-super::impl_inst_build! {Mstore, has_mstore, (addr: ValueId, value: ValueId, ty: Type)}
-super::impl_inst_build_common! {Gep, has_gep, ArityBound::AtLeast(2), build_gep}
+super::impl_inst_build! {Mload, (addr: ValueId, ty: Type)}
+super::impl_inst_build! {Mstore, (addr: ValueId, value: ValueId, ty: Type)}
+super::impl_inst_build_common! {Gep, ArityBound::AtLeast(2), build_gep}
 
 fn build_gep(
     ctx: &mut BuildCtx,

--- a/crates/parser/src/inst/evm/mod.rs
+++ b/crates/parser/src/inst/evm/mod.rs
@@ -1,54 +1,54 @@
 use ir::inst::evm::*;
 
-super::impl_inst_build! {EvmStop, has_evm_stop, ()}
-super::impl_inst_build! {EvmAddMod, has_evm_add_mod, (lhs: ValueId, rhs: ValueId, modulus: ValueId)}
-super::impl_inst_build! {EvmMulMod, has_evm_mul_mod, (lhs: ValueId, rhs: ValueId, modulus: ValueId)}
-super::impl_inst_build! {EvmExp, has_evm_exp, (base: ValueId, exponent: ValueId)}
-super::impl_inst_build! {EvmByte, has_evm_byte, (pos: ValueId, value: ValueId)}
-super::impl_inst_build! {EvmKeccak256, has_evm_keccak256, (addr: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmAddress, has_evm_address, ()}
-super::impl_inst_build! {EvmBalance, has_evm_balance, (contract_addr: ValueId)}
-super::impl_inst_build! {EvmOrigin, has_evm_origin, ()}
-super::impl_inst_build! {EvmCaller, has_evm_caller, ()}
-super::impl_inst_build! {EvmCallValue, has_evm_call_value, ()}
-super::impl_inst_build! {EvmCallDataLoad, has_evm_call_data_load, (data_offset: ValueId)}
-super::impl_inst_build! {EvmCallDataCopy, has_evm_call_data_copy, (dst_addr: ValueId, data_offset: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmCodeSize, has_evm_code_size, ()}
-super::impl_inst_build! {EvmCodeCopy, has_evm_code_copy, (dst_addr: ValueId, code_offset: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmGasPrice, has_evm_gas_price, ()}
-super::impl_inst_build! {EvmExtCodeSize, has_evm_ext_code_size, (ext_addr: ValueId)}
-super::impl_inst_build! {EvmExtCodeCopy, has_evm_ext_code_copy, (ext_addr: ValueId, dst_addr: ValueId, code_offset: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmReturnDataSize, has_evm_return_data_size, ()}
-super::impl_inst_build! {EvmReturnDataCopy, has_evm_return_data_copy, (dst_addr: ValueId, data_offset: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmExtCodeHash, has_evm_ext_code_hash, (ext_addr: ValueId)}
-super::impl_inst_build! {EvmBlockHash, has_evm_block_hash, (block_num: ValueId)}
-super::impl_inst_build! {EvmCoinBase, has_evm_coin_base, (block_num: ValueId)}
-super::impl_inst_build! {EvmTimestamp, has_evm_timestamp, ()}
-super::impl_inst_build! {EvmNumber, has_evm_number, ()}
-super::impl_inst_build! {EvmPrevRandao, has_evm_prev_randao, ()}
-super::impl_inst_build! {EvmGasLimit, has_evm_gas_limit, ()}
-super::impl_inst_build! {EvmChainId, has_evm_chain_id, ()}
-super::impl_inst_build! {EvmSelfBalance, has_evm_self_balance, ()}
-super::impl_inst_build! {EvmBaseFee, has_evm_base_fee, ()}
-super::impl_inst_build! {EvmBlobHash, has_evm_blob_hash, (idx: ValueId)}
-super::impl_inst_build! {EvmBlobBaseFee, has_evm_blob_base_fee, ()}
-super::impl_inst_build! {EvmMstore8, has_evm_mstore8, (addr: ValueId, val: ValueId)}
-super::impl_inst_build! {EvmSload, has_evm_sload, (key: ValueId)}
-super::impl_inst_build! {EvmSstore, has_evm_sstore, (key: ValueId, val: ValueId)}
-super::impl_inst_build! {EvmMsize, has_evm_msize, ()}
-super::impl_inst_build! {EvmGas, has_evm_gas, ()}
-super::impl_inst_build! {EvmTload, has_evm_tload, (key: ValueId)}
-super::impl_inst_build! {EvmTstore, has_evm_tstore, (key: ValueId, val: ValueId)}
-super::impl_inst_build! {EvmLog0, has_evm_log0, (addr: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmLog1, has_evm_log1, (addr: ValueId, len: ValueId, topic0: ValueId)}
-super::impl_inst_build! {EvmLog2, has_evm_log2, (addr: ValueId, len: ValueId, topic0: ValueId, topic1: ValueId)}
-super::impl_inst_build! {EvmLog3, has_evm_log3, (addr: ValueId, len: ValueId, topic0: ValueId, topic1: ValueId, topic2: ValueId)}
-super::impl_inst_build! {EvmLog4, has_evm_log4, (addr: ValueId, len: ValueId, topic0: ValueId, topic1: ValueId, topic2: ValueId, topic3: ValueId)}
-super::impl_inst_build! {EvmCreate, has_evm_create, (val: ValueId, addr: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmCall, has_evm_call, (gas: ValueId, addr: ValueId, val: ValueId, arg_addr: ValueId, arg_len: ValueId, ret_addr: ValueId, ret_offset: ValueId)}
-super::impl_inst_build! {EvmReturn, has_evm_return, (addr: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmDelegateCall, has_evm_delegate_call, (gas: ValueId, ext_addr: ValueId, arg_addr: ValueId, arg_len: ValueId, ret_addr: ValueId, ret_len: ValueId)}
-super::impl_inst_build! {EvmCreate2, has_evm_create2, (val: ValueId, addr: ValueId, len: ValueId, salt: ValueId)}
-super::impl_inst_build! {EvmStaticCall, has_evm_static_call, (gas: ValueId, ext_addr: ValueId, arg_addr: ValueId, arg_len: ValueId, ret_addr: ValueId, ret_len: ValueId)}
-super::impl_inst_build! {EvmRevert, has_evm_revert, (addr: ValueId, len: ValueId)}
-super::impl_inst_build! {EvmSelfDestruct, has_evm_self_destruct, (addr: ValueId)}
+super::impl_inst_build! {EvmStop, ()}
+super::impl_inst_build! {EvmAddMod, (lhs: ValueId, rhs: ValueId, modulus: ValueId)}
+super::impl_inst_build! {EvmMulMod, (lhs: ValueId, rhs: ValueId, modulus: ValueId)}
+super::impl_inst_build! {EvmExp, (base: ValueId, exponent: ValueId)}
+super::impl_inst_build! {EvmByte, (pos: ValueId, value: ValueId)}
+super::impl_inst_build! {EvmKeccak256, (addr: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmAddress, ()}
+super::impl_inst_build! {EvmBalance, (contract_addr: ValueId)}
+super::impl_inst_build! {EvmOrigin, ()}
+super::impl_inst_build! {EvmCaller, ()}
+super::impl_inst_build! {EvmCallValue, ()}
+super::impl_inst_build! {EvmCallDataLoad, (data_offset: ValueId)}
+super::impl_inst_build! {EvmCallDataCopy, (dst_addr: ValueId, data_offset: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmCodeSize, ()}
+super::impl_inst_build! {EvmCodeCopy, (dst_addr: ValueId, code_offset: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmGasPrice, ()}
+super::impl_inst_build! {EvmExtCodeSize, (ext_addr: ValueId)}
+super::impl_inst_build! {EvmExtCodeCopy, (ext_addr: ValueId, dst_addr: ValueId, code_offset: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmReturnDataSize, ()}
+super::impl_inst_build! {EvmReturnDataCopy, (dst_addr: ValueId, data_offset: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmExtCodeHash, (ext_addr: ValueId)}
+super::impl_inst_build! {EvmBlockHash, (block_num: ValueId)}
+super::impl_inst_build! {EvmCoinBase, (block_num: ValueId)}
+super::impl_inst_build! {EvmTimestamp, ()}
+super::impl_inst_build! {EvmNumber, ()}
+super::impl_inst_build! {EvmPrevRandao, ()}
+super::impl_inst_build! {EvmGasLimit, ()}
+super::impl_inst_build! {EvmChainId, ()}
+super::impl_inst_build! {EvmSelfBalance, ()}
+super::impl_inst_build! {EvmBaseFee, ()}
+super::impl_inst_build! {EvmBlobHash, (idx: ValueId)}
+super::impl_inst_build! {EvmBlobBaseFee, ()}
+super::impl_inst_build! {EvmMstore8, (addr: ValueId, val: ValueId)}
+super::impl_inst_build! {EvmSload, (key: ValueId)}
+super::impl_inst_build! {EvmSstore, (key: ValueId, val: ValueId)}
+super::impl_inst_build! {EvmMsize, ()}
+super::impl_inst_build! {EvmGas, ()}
+super::impl_inst_build! {EvmTload, (key: ValueId)}
+super::impl_inst_build! {EvmTstore, (key: ValueId, val: ValueId)}
+super::impl_inst_build! {EvmLog0, (addr: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmLog1, (addr: ValueId, len: ValueId, topic0: ValueId)}
+super::impl_inst_build! {EvmLog2, (addr: ValueId, len: ValueId, topic0: ValueId, topic1: ValueId)}
+super::impl_inst_build! {EvmLog3, (addr: ValueId, len: ValueId, topic0: ValueId, topic1: ValueId, topic2: ValueId)}
+super::impl_inst_build! {EvmLog4, (addr: ValueId, len: ValueId, topic0: ValueId, topic1: ValueId, topic2: ValueId, topic3: ValueId)}
+super::impl_inst_build! {EvmCreate, (val: ValueId, addr: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmCall, (gas: ValueId, addr: ValueId, val: ValueId, arg_addr: ValueId, arg_len: ValueId, ret_addr: ValueId, ret_offset: ValueId)}
+super::impl_inst_build! {EvmReturn, (addr: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmDelegateCall, (gas: ValueId, ext_addr: ValueId, arg_addr: ValueId, arg_len: ValueId, ret_addr: ValueId, ret_len: ValueId)}
+super::impl_inst_build! {EvmCreate2, (val: ValueId, addr: ValueId, len: ValueId, salt: ValueId)}
+super::impl_inst_build! {EvmStaticCall, (gas: ValueId, ext_addr: ValueId, arg_addr: ValueId, arg_len: ValueId, ret_addr: ValueId, ret_len: ValueId)}
+super::impl_inst_build! {EvmRevert, (addr: ValueId, len: ValueId)}
+super::impl_inst_build! {EvmSelfDestruct, (addr: ValueId)}

--- a/crates/parser/src/inst/logic.rs
+++ b/crates/parser/src/inst/logic.rs
@@ -1,6 +1,6 @@
 use ir::inst::logic::*;
 
-super::impl_inst_build! {Not, has_not, (arg: ValueId)}
-super::impl_inst_build! {And, has_and, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Or, has_or, (lhs: ValueId, rhs: ValueId)}
-super::impl_inst_build! {Xor, has_xor, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Not, (arg: ValueId)}
+super::impl_inst_build! {And, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Or, (lhs: ValueId, rhs: ValueId)}
+super::impl_inst_build! {Xor, (lhs: ValueId, rhs: ValueId)}

--- a/crates/parser/src/inst/mod.rs
+++ b/crates/parser/src/inst/mod.rs
@@ -47,10 +47,9 @@ impl InstBuild for Box<dyn Inst> {
 }
 
 macro_rules! impl_inst_build {
-    ($ty:ty, $has_inst:ident, ($($arg_name:ident: $arg_kind:ident ),*)) => {
+    ($ty:ty, ($($arg_name:ident: $arg_kind:ident ),*)) => {
         crate::inst::impl_inst_build_common!(
             $ty,
-            $has_inst,
             crate::error::ArityBound::Exact(crate::inst::__count_args!($( $arg_kind ),*)),
             |ctx: &mut crate::BuildCtx,
             fb: &mut ir::builder::FunctionBuilder<ir::func_cursor::InstInserter>,
@@ -67,7 +66,7 @@ macro_rules! impl_inst_build {
 }
 
 macro_rules! impl_inst_build_common {
-    ($ty:ty, $has_inst:ident, $expected_args:expr, $build_expr:expr) => {
+    ($ty:ty, $expected_args:expr, $build_expr:expr) => {
         impl crate::inst::InstBuild for $ty {
             #[allow(unused)]
             fn build(
@@ -77,7 +76,7 @@ macro_rules! impl_inst_build_common {
             ) -> Result<Self, Box<crate::Error>> {
                 assert_eq!(Self::inst_name(), ast_inst.name.name.as_str());
 
-                let Some(has_inst) = fb.inst_set().$has_inst() else {
+                let Some(has_inst) = <$ty as ir::InstExt>::belongs_to(fb.inst_set()) else {
                     return Err(Box::new(crate::Error::UnsupportedInst {
                         triple: fb.ctx().triple.clone(),
                         inst: ast_inst.name.name.clone(),


### PR DESCRIPTION
Define `InstExt` that contains a method that can't be included in `Inst` for trait object safety(currently, only the `belongs_to` method is defined. `Inst` macro implements `InstExt` internally.