### PR TITLE
Add newlines properly in `ModuleWriter`

### DIFF
--- a/crates/codegen/src/critical_edge.rs
+++ b/crates/codegen/src/critical_edge.rs
@@ -165,7 +165,7 @@ mod tests {
         let module = mb.build();
         let func_ref = module.funcs()[0];
         let mut cfg = ControlFlowGraph::default();
-        module.funcs.modify(func_ref, |func| {
+        module.func_store.modify(func_ref, |func| {
             cfg.compute(func);
             CriticalEdgeSplitter::new().run(func, &mut cfg);
         });
@@ -189,7 +189,9 @@ mod tests {
         );
 
         let mut cfg_split = ControlFlowGraph::default();
-        module.funcs.view(func_ref, |func| cfg_split.compute(func));
+        module
+            .func_store
+            .view(func_ref, |func| cfg_split.compute(func));
         assert_eq!(cfg, cfg_split);
     }
 
@@ -233,7 +235,7 @@ mod tests {
         let module = mb.build();
         let func_ref = module.funcs()[0];
         let mut cfg = ControlFlowGraph::default();
-        module.funcs.modify(func_ref, |func| {
+        module.func_store.modify(func_ref, |func| {
             cfg.compute(func);
             CriticalEdgeSplitter::new().run(func, &mut cfg);
         });
@@ -266,7 +268,9 @@ mod tests {
         );
 
         let mut cfg_split = ControlFlowGraph::default();
-        module.funcs.view(func_ref, |func| cfg_split.compute(func));
+        module
+            .func_store
+            .view(func_ref, |func| cfg_split.compute(func));
         assert_eq!(cfg, cfg_split);
     }
 
@@ -300,7 +304,7 @@ mod tests {
         let module = mb.build();
         let func_ref = module.funcs()[0];
         let mut cfg = ControlFlowGraph::default();
-        module.funcs.modify(func_ref, |func| {
+        module.func_store.modify(func_ref, |func| {
             cfg.compute(func);
             CriticalEdgeSplitter::new().run(func, &mut cfg);
         });
@@ -325,7 +329,9 @@ mod tests {
         );
 
         let mut cfg_split = ControlFlowGraph::default();
-        module.funcs.view(func_ref, |func| cfg_split.compute(func));
+        module
+            .func_store
+            .view(func_ref, |func| cfg_split.compute(func));
         assert_eq!(cfg, cfg_split);
     }
 
@@ -367,7 +373,7 @@ mod tests {
         let module = mb.build();
         let func_ref = module.funcs()[0];
         let mut cfg = ControlFlowGraph::default();
-        module.funcs.modify(func_ref, |func| {
+        module.func_store.modify(func_ref, |func| {
             cfg.compute(func);
             CriticalEdgeSplitter::new().run(func, &mut cfg);
         });
@@ -403,7 +409,9 @@ mod tests {
         );
 
         let mut cfg_split = ControlFlowGraph::default();
-        module.funcs.view(func_ref, |func| cfg_split.compute(func));
+        module
+            .func_store
+            .view(func_ref, |func| cfg_split.compute(func));
         assert_eq!(cfg, cfg_split);
     }
 }

--- a/crates/codegen/src/domtree.rs
+++ b/crates/codegen/src/domtree.rs
@@ -262,7 +262,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let (dom_tree, df) = module.funcs.view(func_ref, calc_dom);
+        let (dom_tree, df) = module.func_store.view(func_ref, calc_dom);
 
         assert_eq!(dom_tree.idom_of(entry_block), None);
         assert_eq!(dom_tree.idom_of(then_block), Some(entry_block));
@@ -308,7 +308,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let (dom_tree, df) = module.funcs.view(func_ref, calc_dom);
+        let (dom_tree, df) = module.func_store.view(func_ref, calc_dom);
 
         assert_eq!(dom_tree.idom_of(a), None);
         assert_eq!(dom_tree.idom_of(b), Some(a));
@@ -389,7 +389,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let (dom_tree, df) = module.funcs.view(func_ref, calc_dom);
+        let (dom_tree, df) = module.func_store.view(func_ref, calc_dom);
 
         assert_eq!(dom_tree.idom_of(a), None);
         assert_eq!(dom_tree.idom_of(b), Some(a));
@@ -459,7 +459,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let (dom_tree, df) = module.funcs.view(func_ref, calc_dom);
+        let (dom_tree, df) = module.func_store.view(func_ref, calc_dom);
 
         assert_eq!(dom_tree.idom_of(a), None);
         assert_eq!(dom_tree.idom_of(b), Some(a));

--- a/crates/codegen/src/loop_analysis.rs
+++ b/crates/codegen/src/loop_analysis.rs
@@ -306,7 +306,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let lpt = &module.funcs.view(func_ref, compute_loop);
+        let lpt = &module.func_store.view(func_ref, compute_loop);
 
         debug_assert_eq!(lpt.loop_num(), 1);
         let lp0 = lpt.loops().next().unwrap();
@@ -371,7 +371,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let lpt = &module.funcs.view(func_ref, compute_loop);
+        let lpt = &module.func_store.view(func_ref, compute_loop);
 
         debug_assert_eq!(lpt.loop_num(), 1);
         let lp0 = lpt.loops().next().unwrap();
@@ -413,7 +413,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let lpt = &module.funcs.view(func_ref, compute_loop);
+        let lpt = &module.func_store.view(func_ref, compute_loop);
 
         debug_assert_eq!(lpt.loop_num(), 1);
         let lp0 = lpt.loops().next().unwrap();
@@ -485,7 +485,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let lpt = &module.funcs.view(func_ref, compute_loop);
+        let lpt = &module.func_store.view(func_ref, compute_loop);
 
         debug_assert_eq!(lpt.loop_num(), 4);
         let l0 = lpt.loop_of_block(b1).unwrap();

--- a/crates/codegen/src/post_domtree.rs
+++ b/crates/codegen/src/post_domtree.rs
@@ -214,7 +214,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let (post_dom_tree, pdf) = module.funcs.view(func_ref, calc_dom);
+        let (post_dom_tree, pdf) = module.func_store.view(func_ref, calc_dom);
 
         assert!(post_dom_tree.is_reachable(entry_block));
         assert!(post_dom_tree.is_reachable(else_block));
@@ -242,7 +242,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let (post_dom_tree, pdf) = module.funcs.view(func_ref, calc_dom);
+        let (post_dom_tree, pdf) = module.func_store.view(func_ref, calc_dom);
 
         assert!(!post_dom_tree.is_reachable(a));
         assert!(test_pdf(&pdf, a, &[]));
@@ -281,7 +281,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let (post_dom_tree, pdf) = module.funcs.view(func_ref, calc_dom);
+        let (post_dom_tree, pdf) = module.func_store.view(func_ref, calc_dom);
 
         assert!(post_dom_tree.is_reachable(a));
         assert!(post_dom_tree.is_reachable(b));
@@ -341,7 +341,7 @@ mod tests {
 
         let module = mb.build();
         let func_ref = module.funcs()[0];
-        let (post_dom_tree, pdf) = module.funcs.view(func_ref, calc_dom);
+        let (post_dom_tree, pdf) = module.func_store.view(func_ref, calc_dom);
 
         assert!(post_dom_tree.is_reachable(a));
         assert!(post_dom_tree.is_reachable(b));

--- a/crates/filecheck/src/lib.rs
+++ b/crates/filecheck/src/lib.rs
@@ -142,7 +142,7 @@ impl<'a> FileChecker<'a> {
     fn check_func(&mut self, parsed_module: &ParsedModule, func_ref: FuncRef) -> FileCheckResult {
         let comments = &parsed_module.debug.func_comments[func_ref];
 
-        let (func_ir, func_name) = parsed_module.module.funcs.modify(func_ref, |func| {
+        let (func_ir, func_name) = parsed_module.module.func_store.modify(func_ref, |func| {
             self.transformer.transform(func);
             (
                 FuncWriter::with_debug_provider(func, func_ref, &parsed_module.debug).dump_string(),

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -25,7 +25,7 @@ impl Machine {
             // Dummy pc
             pc: InstId(0),
             action: Action::Continue,
-            funcs: module.funcs.into_read_only(),
+            funcs: module.func_store.into_read_only(),
             module_ctx: module.ctx,
             memory: Vec::new(),
             free_region: 0,

--- a/crates/interpreter/tests/common.rs
+++ b/crates/interpreter/tests/common.rs
@@ -85,7 +85,7 @@ impl TestCase {
 
     fn parse(module: &ParsedModule, func_ref: FuncRef, comment: &str) -> Result<Self, String> {
         let Some(caps) = PATTERN.captures(comment) else {
-            return module.module.funcs.view(func_ref, |func| {
+            return module.module.func_store.view(func_ref, |func| {
                 let func_name = func.sig.name();
                 Err(format_error(
                     func_name,
@@ -142,7 +142,7 @@ fn parse_value(module: &ParsedModule, func_ref: FuncRef, input: &str) -> Result<
 
         Err(err) => {
             let err = err.to_string();
-            return module.module.funcs.view(func_ref, |func| {
+            return module.module.func_store.view(func_ref, |func| {
                 let func_name = func.sig.name();
                 Err(format_error(func_name, &err.to_string()))
             });

--- a/crates/ir/src/builder/mod.rs
+++ b/crates/ir/src/builder/mod.rs
@@ -44,7 +44,7 @@ pub mod test_util {
     }
 
     pub fn dump_func(module: &Module, func_ref: FuncRef) -> String {
-        module.funcs.view(func_ref, |func| {
+        module.func_store.view(func_ref, |func| {
             FuncWriter::new(func_ref, func).dump_string()
         })
     }

--- a/crates/ir/src/builder/module_builder.rs
+++ b/crates/ir/src/builder/module_builder.rs
@@ -92,7 +92,7 @@ impl ModuleBuilder {
 
     pub fn build(self) -> Module {
         Module {
-            funcs: Arc::into_inner(self.funcs).unwrap(),
+            func_store: Arc::into_inner(self.funcs).unwrap(),
             ctx: self.ctx,
         }
     }

--- a/crates/ir/src/global_variable.rs
+++ b/crates/ir/src/global_variable.rs
@@ -48,6 +48,14 @@ impl GlobalVariableStore {
     pub fn all_gv_data(&self) -> impl Iterator<Item = &GlobalVariableData> {
         self.gv_data.values()
     }
+
+    pub fn len(&self) -> usize {
+        self.gv_data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.gv_data.is_empty()
+    }
 }
 
 /// An opaque reference to [`GlobalVariableData`].

--- a/crates/ir/src/graphviz/mod.rs
+++ b/crates/ir/src/graphviz/mod.rs
@@ -77,7 +77,7 @@ mod test {
         let func_ref = module.funcs()[0];
 
         let mut text = vec![];
-        module.funcs.view(func_ref, |func| {
+        module.func_store.view(func_ref, |func| {
             render_to(func, func_ref, &mut text).unwrap();
         });
         let text = String::from_utf8(text).unwrap();

--- a/crates/ir/src/inst/data.rs
+++ b/crates/ir/src/inst/data.rs
@@ -24,7 +24,7 @@ pub struct Mstore {
     value: ValueId,
     ty: Type,
 }
-impl_inst_write!(Mstore, (value: ValueId, addr: ValueId, ty: Type));
+impl_inst_write!(Mstore, (addr: ValueId, value: ValueId, ty: Type));
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Inst)]
 pub struct Gep {

--- a/crates/ir/src/inst/evm/mod.rs
+++ b/crates/ir/src/inst/evm/mod.rs
@@ -1,7 +1,10 @@
+use std::io;
+
 use macros::Inst;
 pub mod inst_set;
 
-use crate::{inst::impl_inst_write, module::FuncRef, value::ValueId};
+use super::{Inst, InstWrite};
+use crate::{inst::impl_inst_write, ir_writer::FuncWriteCtx, module::FuncRef, value::ValueId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Inst)]
 pub struct EvmUdiv {
@@ -570,4 +573,13 @@ impl_inst_write!(EvmMalloc);
 pub struct EvmContractSize {
     contract: FuncRef,
 }
-impl_inst_write!(EvmContractSize);
+impl InstWrite for EvmContractSize {
+    fn write(&self, ctx: &FuncWriteCtx, w: &mut dyn io::Write) -> io::Result<()> {
+        let name = self.as_text();
+        ctx.func.ctx().func_sig(self.contract, |sig| {
+            let callee = sig.name();
+            write!(w, "{name} %{callee}")
+        })?;
+        Ok(())
+    }
+}

--- a/crates/ir/src/module.rs
+++ b/crates/ir/src/module.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub struct Module {
-    pub funcs: FuncStore,
+    pub func_store: FuncStore,
     pub ctx: ModuleCtx,
 }
 
@@ -21,13 +21,13 @@ impl Module {
     #[doc(hidden)]
     pub fn new<T: Isa>(isa: &T) -> Self {
         Self {
-            funcs: FuncStore::new(),
+            func_store: FuncStore::new(),
             ctx: ModuleCtx::new(isa),
         }
     }
 
     pub fn funcs(&self) -> Vec<FuncRef> {
-        self.funcs.funcs()
+        self.func_store.funcs()
     }
 }
 

--- a/crates/parser/test_files/syntax/module/func_type.ir.snap
+++ b/crates/parser/test_files/syntax/module/func_type.ir.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/parser/tests/syntax.rs
 input_file: test_files/syntax/module/func_type.sntn
-snapshot_kind: text
 ---
 target = evm-ethereum-london
+
 func public %higher_order(v0.*(i256, i256) -> i32) -> unit {
     block0:
         return;

--- a/crates/parser/test_files/syntax/module/global_variable.ir.snap
+++ b/crates/parser/test_files/syntax/module/global_variable.ir.snap
@@ -3,12 +3,15 @@ source: crates/parser/tests/syntax.rs
 input_file: test_files/syntax/module/global_variable.sntn
 ---
 target = evm-ethereum-cancun
+
 type @foo = {i8, i16, *i64};
+
 global private const i256 $ZERO = 0
 global public *i256 $PTR = 1
 global private [i8; 4] $ARRAY = [0, 1, 2, 3]
 global private @foo $FOO = {1, 2, 3}
 global private [@foo; 2] $FOO_ARRAY = [{1, 2, 3}, {3, 4, 5}]
+
 func public %main() -> unit {
     block0:
         v0.i256 = mload $PTR i256;

--- a/crates/parser/test_files/syntax/module/newlines.ir.snap
+++ b/crates/parser/test_files/syntax/module/newlines.ir.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/parser/tests/syntax.rs
 input_file: test_files/syntax/module/newlines.sntn
-snapshot_kind: text
 ---
 target = evm-ethereum-london
+
 func public %main() -> unit {
     block0:
         v0.i8 = add 1.i8 2.i8;

--- a/crates/parser/test_files/syntax/module/simple.ir.snap
+++ b/crates/parser/test_files/syntax/module/simple.ir.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/parser/tests/syntax.rs
 input_file: test_files/syntax/module/simple.sntn
-snapshot_kind: text
 ---
 target = evm-ethereum-london
+
 type @foo = {i8, i16, *i64};
 type @bar = {i8, [i8; 31]};
+
 func external %add_i8(v0.i8, v1.i8) -> i8 {
 }
 

--- a/crates/verifier/src/error/mod.rs
+++ b/crates/verifier/src/error/mod.rs
@@ -88,7 +88,7 @@ mod test {
         let module = mb.build();
         let func_ref = module.funcs()[0];
 
-        let err_msg = module.funcs.view(func_ref, |func| {
+        let err_msg = module.func_store.view(func_ref, |func| {
             let inst = func.layout.iter_inst(b0).next().unwrap();
 
             let trace_info = TraceInfoBuilder::new(func_ref)


### PR DESCRIPTION
@sbillig Sorry, I forgot to include this fix in #85.
* Rename `Module::funcs` -> `Module::func_store`
* Insert newlines properly between declarations
* Fix `InstWrite` impl for `EvmContractSize/GetFunctionPtr`

Regarding to `InstWrite` macro, I'll tweak `impl_inst_write` macro a little bit in another PR.