### PR TITLE
add single-block inliner

### DIFF
--- a/crates/codegen/src/optim/inliner.rs
+++ b/crates/codegen/src/optim/inliner.rs
@@ -1,0 +1,898 @@
+//! Module-level inliner pass (single-block callees).
+//!
+//! This pass intentionally avoids CFG surgery: it only removes calls, rewrites
+//! wrapper calls, or splices a straight-line single-block callee body into the
+//! caller block. Purity filtering is optional (`splice_require_pure`).
+
+use std::collections::BTreeMap;
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
+use sonatina_ir::{
+    Function, GlobalVariableRef, Immediate, Inst, InstDowncast, InstId, Module, Type, Value,
+    ValueId,
+    inst::{SideEffect, control_flow},
+    module::{FuncRef, ModuleCtx},
+};
+
+use crate::cfg_edit::{CfgEditor, CleanupMode};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ValueTemplate {
+    Arg(usize),
+    Imm(Immediate),
+    Global(GlobalVariableRef),
+    Undef(Type),
+}
+
+enum InlinePlan {
+    /// Delete the call; optionally alias its result to a materialized value.
+    RemoveCall { returned: Option<ValueTemplate> },
+    /// Rewrite the call into a call to a different direct callee.
+    RewriteCall {
+        new_callee: FuncRef,
+        new_args: Vec<ValueTemplate>,
+    },
+    /// Splice a pure, single-block body into caller before callsite.
+    SpliceSingleBlock(SplicePlan),
+    /// Splice a single-block callee that terminates the caller (e.g. `evm_revert`).
+    SpliceSingleBlockTerminator(TerminatorSplicePlan),
+}
+
+struct TemplateInst {
+    inst: Box<dyn Inst>,
+    old_result: Option<(ValueId, Type)>,
+}
+
+#[derive(Clone, Copy)]
+struct TemplateInstSummary {
+    inst_id: InstId,
+    old_result: Option<(ValueId, Type)>,
+}
+
+struct SplicePlan {
+    callee_args: Vec<ValueId>,
+    const_values: BTreeMap<ValueId, ValueTemplate>,
+    body: Vec<TemplateInst>,
+    ret_value: Option<ValueId>,
+}
+
+struct TerminatorSplicePlan {
+    callee_args: Vec<ValueId>,
+    const_values: BTreeMap<ValueId, ValueTemplate>,
+    body: Vec<TemplateInst>,
+    terminator: Box<dyn Inst>,
+}
+
+#[derive(Clone)]
+struct SplicePlanSummary {
+    callee_args: Vec<ValueId>,
+    const_values: BTreeMap<ValueId, ValueTemplate>,
+    body: Vec<TemplateInstSummary>,
+    ret_value: Option<ValueId>,
+}
+
+#[derive(Clone)]
+struct TerminatorSplicePlanSummary {
+    callee_args: Vec<ValueId>,
+    const_values: BTreeMap<ValueId, ValueTemplate>,
+    body: Vec<TemplateInstSummary>,
+    term_inst_id: InstId,
+}
+
+#[derive(Clone)]
+enum InlinePlanSummary {
+    RemoveCall {
+        returned: Option<ValueTemplate>,
+    },
+    RewriteCall {
+        new_callee: FuncRef,
+        new_args: Vec<ValueTemplate>,
+    },
+    SpliceSingleBlock(SplicePlanSummary),
+    SpliceSingleBlockTerminator(TerminatorSplicePlanSummary),
+}
+
+struct CollectedSpliceBody {
+    const_values: BTreeMap<ValueId, ValueTemplate>,
+    body: Vec<TemplateInstSummary>,
+}
+
+#[derive(Clone, Copy)]
+struct CallSite {
+    call_inst: InstId,
+    callee: FuncRef,
+}
+
+pub struct InlinerConfig {
+    pub enable_noop: bool,
+    pub enable_return_alias: bool,
+    pub enable_wrapper_rewrite: bool,
+    pub enable_single_block_splice: bool,
+
+    pub splice_max_insts: usize,
+    pub splice_require_pure: bool,
+
+    // Future multi-block inlining knobs (kept for API continuity).
+    pub max_inlinee_blocks: usize,
+    pub max_inlinee_insts: usize,
+    pub max_growth_per_caller: usize,
+    pub allow_inline_recursive: bool,
+}
+
+impl Default for InlinerConfig {
+    fn default() -> Self {
+        Self {
+            enable_noop: true,
+            enable_return_alias: true,
+            enable_wrapper_rewrite: true,
+            enable_single_block_splice: true,
+
+            splice_max_insts: 8,
+            splice_require_pure: false,
+
+            max_inlinee_blocks: 0,
+            max_inlinee_insts: 0,
+            max_growth_per_caller: 0,
+            allow_inline_recursive: false,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct InlineStats {
+    pub calls_removed: usize,
+    pub calls_rewritten: usize,
+    pub calls_spliced: usize,
+    pub skipped_no_body: usize,
+    pub skipped_multi_block: usize,
+    pub skipped_non_straight_line: usize,
+    pub skipped_not_pure: usize,
+    /// Aggregate of non-straight-line and not-pure skips.
+    pub skipped_effectful: usize,
+    pub skipped_too_large: usize,
+}
+
+pub struct Inliner {
+    pub config: InlinerConfig,
+}
+
+impl Inliner {
+    pub fn new(config: InlinerConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn run(&mut self, module: &mut Module) -> InlineStats {
+        const MAX_ITERS: usize = 8;
+        let mut stats = InlineStats::default();
+
+        let mut iter = 0;
+        while iter < MAX_ITERS {
+            let mut changed = false;
+            let funcs = module.funcs();
+            let (sites_by_caller, call_counts) = collect_iteration_call_data(module, &funcs);
+            let mut callee_summary_cache: FxHashMap<FuncRef, Option<InlinePlanSummary>> =
+                FxHashMap::default();
+
+            for caller in funcs {
+                let sites = sites_by_caller.get(&caller).cloned().unwrap_or_default();
+                let mut caller_changed = false;
+
+                for site in sites {
+                    if site.callee == caller && !self.config.allow_inline_recursive {
+                        continue;
+                    }
+
+                    let plan_summary = if let Some(cached) = callee_summary_cache.get(&site.callee)
+                    {
+                        cached.clone()
+                    } else {
+                        let callee_call_count = call_counts.get(&site.callee).copied().unwrap_or(0);
+                        let analyzed = module.func_store.view(site.callee, |callee_func| {
+                            analyze_callee(
+                                module,
+                                site.callee,
+                                callee_func,
+                                callee_call_count,
+                                &self.config,
+                                &mut stats,
+                            )
+                        });
+                        callee_summary_cache.insert(site.callee, analyzed.clone());
+                        analyzed
+                    };
+
+                    let Some(plan_summary) = plan_summary else {
+                        continue;
+                    };
+                    let plan = module.func_store.view(site.callee, |callee_func| {
+                        materialize_plan(callee_func, &plan_summary)
+                    });
+
+                    let applied = module.func_store.modify(caller, |caller_func| {
+                        apply_plan(caller_func, site.call_inst, plan, &mut stats)
+                    });
+
+                    changed |= applied;
+                    caller_changed |= applied;
+                    if applied {
+                        callee_summary_cache.remove(&caller);
+                    }
+                }
+
+                if caller_changed {
+                    callee_summary_cache.remove(&caller);
+                }
+            }
+
+            if !changed {
+                break;
+            }
+
+            iter += 1;
+        }
+
+        stats
+    }
+}
+
+fn collect_call_sites(func: &Function) -> Vec<CallSite> {
+    let is = func.inst_set();
+    let mut sites = Vec::new();
+
+    for block in func.layout.iter_block() {
+        for inst_id in func.layout.iter_inst(block) {
+            let inst = func.dfg.inst(inst_id);
+            let Some(call) = <&control_flow::Call as InstDowncast>::downcast(is, inst) else {
+                continue;
+            };
+
+            sites.push(CallSite {
+                call_inst: inst_id,
+                callee: *call.callee(),
+            });
+        }
+    }
+
+    sites
+}
+
+fn collect_iteration_call_data(
+    module: &Module,
+    funcs: &[FuncRef],
+) -> (FxHashMap<FuncRef, Vec<CallSite>>, FxHashMap<FuncRef, usize>) {
+    let mut sites_by_caller: FxHashMap<FuncRef, Vec<CallSite>> = FxHashMap::default();
+    let mut counts: FxHashMap<FuncRef, usize> = FxHashMap::default();
+
+    for &caller in funcs {
+        let sites = module.func_store.view(caller, collect_call_sites);
+        for site in &sites {
+            *counts.entry(site.callee).or_insert(0) += 1;
+        }
+        sites_by_caller.insert(caller, sites);
+    }
+
+    (sites_by_caller, counts)
+}
+
+fn analyze_callee(
+    module: &Module,
+    callee_ref: FuncRef,
+    callee: &Function,
+    callee_call_count: usize,
+    config: &InlinerConfig,
+    stats: &mut InlineStats,
+) -> Option<InlinePlanSummary> {
+    if !module.ctx.func_linkage(callee_ref).has_definition() {
+        stats.skipped_no_body += 1;
+        return None;
+    }
+
+    let mut blocks = callee.layout.iter_block();
+    let Some(block) = blocks.next() else {
+        let callee_name = module
+            .ctx
+            .func_sig(callee_ref, |sig| sig.name().to_string());
+        panic!("inliner: defined function %{callee_name} ({callee_ref:?}) has empty body");
+    };
+    if blocks.next().is_some() {
+        stats.skipped_multi_block += 1;
+        return None;
+    }
+
+    let insts: Vec<_> = callee.layout.iter_inst(block).collect();
+    let Some(&term_inst_id) = insts.last() else {
+        let callee_name = module
+            .ctx
+            .func_sig(callee_ref, |sig| sig.name().to_string());
+        panic!(
+            "inliner: defined function %{callee_name} ({callee_ref:?}) has an empty entry block"
+        );
+    };
+    if !callee.dfg.is_terminator(term_inst_id) {
+        let callee_name = module
+            .ctx
+            .func_sig(callee_ref, |sig| sig.name().to_string());
+        panic!(
+            "inliner: defined function %{callee_name} ({callee_ref:?}) has a non-terminator last inst"
+        );
+    }
+
+    let is = callee.inst_set();
+    let Some(ret_inst) =
+        <&control_flow::Return as InstDowncast>::downcast(is, callee.dfg.inst(term_inst_id))
+    else {
+        return analyze_terminator_splice(
+            callee,
+            callee_call_count,
+            config,
+            stats,
+            term_inst_id,
+            &insts,
+        );
+    };
+    let ret_value = *ret_inst.arg();
+
+    // Pattern A/B/C: single return-only block.
+    if insts.len() == 1 {
+        if ret_value.is_none() {
+            if config.enable_noop {
+                return Some(InlinePlanSummary::RemoveCall { returned: None });
+            }
+            return None;
+        }
+
+        if !config.enable_return_alias {
+            return None;
+        }
+
+        let template = classify_value_template(callee, ret_value?)?;
+        return Some(InlinePlanSummary::RemoveCall {
+            returned: Some(template),
+        });
+    }
+
+    // Pattern D: wrapper forwarding (call; return).
+    if insts.len() == 2 && config.enable_wrapper_rewrite {
+        let call_inst_id = insts[0];
+        let Some(call_inst) =
+            <&control_flow::Call as InstDowncast>::downcast(is, callee.dfg.inst(call_inst_id))
+        else {
+            // Not a wrapper; fall through to splicing.
+            return analyze_splice(callee, callee_call_count, config, stats, ret_value, &insts);
+        };
+
+        let call_res = callee.dfg.inst_result(call_inst_id);
+        if call_res != ret_value {
+            return None;
+        }
+
+        // Signature sanity: wrapper signature equals inner callee signature.
+        if !signatures_match(&module.ctx, callee_ref, *call_inst.callee()) {
+            return None;
+        }
+
+        let new_args = call_inst
+            .args()
+            .iter()
+            .map(|&arg| classify_value_template(callee, arg))
+            .collect::<Option<Vec<_>>>()?;
+
+        return Some(InlinePlanSummary::RewriteCall {
+            new_callee: *call_inst.callee(),
+            new_args,
+        });
+    }
+
+    analyze_splice(callee, callee_call_count, config, stats, ret_value, &insts)
+}
+
+fn analyze_splice(
+    callee: &Function,
+    callee_call_count: usize,
+    config: &InlinerConfig,
+    stats: &mut InlineStats,
+    ret_value: Option<ValueId>,
+    insts: &[InstId],
+) -> Option<InlinePlanSummary> {
+    if !config.enable_single_block_splice {
+        return None;
+    }
+
+    let (_, body_insts) = insts.split_last()?;
+    let mut collected = collect_splice_body(callee, callee_call_count, config, stats, body_insts)?;
+
+    if let Some(ret_value) = ret_value
+        && let Some(tpl) = classify_value_template(callee, ret_value)
+    {
+        record_const_value(&mut collected.const_values, ret_value, tpl);
+    }
+
+    let callee_args: Vec<ValueId> = callee.arg_values.iter().copied().collect();
+    let plan = SplicePlanSummary {
+        callee_args,
+        const_values: collected.const_values,
+        body: collected.body,
+        ret_value,
+    };
+
+    Some(InlinePlanSummary::SpliceSingleBlock(plan))
+}
+
+fn analyze_terminator_splice(
+    callee: &Function,
+    callee_call_count: usize,
+    config: &InlinerConfig,
+    stats: &mut InlineStats,
+    term_inst_id: InstId,
+    insts: &[InstId],
+) -> Option<InlinePlanSummary> {
+    if !config.enable_single_block_splice {
+        return None;
+    }
+
+    // Can't remap/split CFG here; only inline "exit" terminators.
+    if callee.dfg.is_branch(term_inst_id) {
+        return None;
+    }
+
+    let (_, body_insts) = insts.split_last()?;
+    let mut collected = collect_splice_body(callee, callee_call_count, config, stats, body_insts)?;
+
+    extend_const_values_from_inst_operands(callee, term_inst_id, &mut collected.const_values);
+    let callee_args: Vec<ValueId> = callee.arg_values.iter().copied().collect();
+    let plan = TerminatorSplicePlanSummary {
+        callee_args,
+        const_values: collected.const_values,
+        body: collected.body,
+        term_inst_id,
+    };
+
+    Some(InlinePlanSummary::SpliceSingleBlockTerminator(plan))
+}
+
+fn collect_splice_body(
+    callee: &Function,
+    callee_call_count: usize,
+    config: &InlinerConfig,
+    stats: &mut InlineStats,
+    body_insts: &[InstId],
+) -> Option<CollectedSpliceBody> {
+    let is_single_use = callee_call_count == 1;
+    if !is_single_use && body_insts.len() > config.splice_max_insts {
+        stats.skipped_too_large += 1;
+        return None;
+    }
+
+    let mut const_values: BTreeMap<ValueId, ValueTemplate> = BTreeMap::new();
+    let mut body: Vec<TemplateInstSummary> = Vec::with_capacity(body_insts.len());
+    let is = callee.inst_set();
+    for &inst_id in body_insts {
+        if callee.dfg.is_phi(inst_id)
+            || callee.dfg.is_branch(inst_id)
+            || callee.dfg.is_terminator(inst_id)
+        {
+            stats.skipped_non_straight_line += 1;
+            stats.skipped_effectful += 1;
+            return None;
+        }
+
+        if config.splice_require_pure
+            && (callee.dfg.side_effect(inst_id) != SideEffect::None
+                || <&control_flow::Call as InstDowncast>::downcast(is, callee.dfg.inst(inst_id))
+                    .is_some())
+        {
+            stats.skipped_not_pure += 1;
+            stats.skipped_effectful += 1;
+            return None;
+        }
+        extend_const_values_from_inst_operands(callee, inst_id, &mut const_values);
+        let old_result = callee
+            .dfg
+            .inst_result(inst_id)
+            .map(|res| (res, callee.dfg.value_ty(res)));
+        body.push(TemplateInstSummary {
+            inst_id,
+            old_result,
+        });
+    }
+
+    Some(CollectedSpliceBody { const_values, body })
+}
+
+fn materialize_plan(callee: &Function, summary: &InlinePlanSummary) -> InlinePlan {
+    match summary {
+        InlinePlanSummary::RemoveCall { returned } => InlinePlan::RemoveCall {
+            returned: *returned,
+        },
+        InlinePlanSummary::RewriteCall {
+            new_callee,
+            new_args,
+        } => InlinePlan::RewriteCall {
+            new_callee: *new_callee,
+            new_args: new_args.clone(),
+        },
+        InlinePlanSummary::SpliceSingleBlock(summary) => {
+            InlinePlan::SpliceSingleBlock(SplicePlan {
+                callee_args: summary.callee_args.clone(),
+                const_values: summary.const_values.clone(),
+                body: materialize_body_templates(callee, &summary.body),
+                ret_value: summary.ret_value,
+            })
+        }
+        InlinePlanSummary::SpliceSingleBlockTerminator(summary) => {
+            InlinePlan::SpliceSingleBlockTerminator(TerminatorSplicePlan {
+                callee_args: summary.callee_args.clone(),
+                const_values: summary.const_values.clone(),
+                body: materialize_body_templates(callee, &summary.body),
+                terminator: callee.dfg.clone_inst(summary.term_inst_id),
+            })
+        }
+    }
+}
+
+fn materialize_body_templates(
+    callee: &Function,
+    body: &[TemplateInstSummary],
+) -> Vec<TemplateInst> {
+    body.iter()
+        .map(|summary| TemplateInst {
+            inst: callee.dfg.clone_inst(summary.inst_id),
+            old_result: summary.old_result,
+        })
+        .collect()
+}
+
+fn apply_plan(
+    caller: &mut Function,
+    call_inst_id: InstId,
+    plan: InlinePlan,
+    stats: &mut InlineStats,
+) -> bool {
+    if !caller.layout.is_inst_inserted(call_inst_id) {
+        return false;
+    }
+
+    let is = caller.inst_set();
+    let Some((call_args, original_callee)) =
+        <&control_flow::Call as InstDowncast>::downcast(is, caller.dfg.inst(call_inst_id))
+            .map(|call_inst| (call_inst.args().clone(), *call_inst.callee()))
+    else {
+        return false;
+    };
+    let call_res = caller.dfg.inst_result(call_inst_id);
+
+    match plan {
+        InlinePlan::RemoveCall { returned } => {
+            if call_res.is_some() && returned.is_none() {
+                return false;
+            }
+
+            if let Some((call_res, tpl)) = call_res.zip(returned.as_ref()) {
+                let Some(alias) = materialize(tpl, caller, &call_args) else {
+                    return false;
+                };
+                debug_assert_alias_type_match(caller, call_res, alias);
+                caller.dfg.change_to_alias(call_res, alias);
+            }
+
+            caller.dfg.untrack_inst(call_inst_id);
+            caller.layout.remove_inst(call_inst_id);
+            stats.calls_removed += 1;
+            true
+        }
+        InlinePlan::RewriteCall {
+            new_callee,
+            new_args,
+        } => {
+            let Some(args) = new_args
+                .iter()
+                .map(|tpl| materialize(tpl, caller, &call_args))
+                .collect::<Option<SmallVec<[ValueId; 8]>>>()
+            else {
+                return false;
+            };
+            if original_callee == new_callee && call_args.as_slice() == args.as_slice() {
+                return false;
+            }
+
+            let has_call = caller
+                .inst_set()
+                .has_call()
+                .expect("target ISA must support `call`");
+            let new_call = control_flow::Call::new(has_call, new_callee, args);
+            caller.dfg.replace_inst(call_inst_id, Box::new(new_call));
+            stats.calls_rewritten += 1;
+            true
+        }
+        InlinePlan::SpliceSingleBlock(splice_plan) => apply_splice_single_block(
+            caller,
+            call_inst_id,
+            &call_args,
+            call_res,
+            splice_plan,
+            stats,
+        ),
+        InlinePlan::SpliceSingleBlockTerminator(splice_plan) => {
+            apply_splice_single_block_terminator(
+                caller,
+                call_inst_id,
+                &call_args,
+                call_res,
+                splice_plan,
+                stats,
+            )
+        }
+    }
+}
+
+fn apply_splice_single_block(
+    caller: &mut Function,
+    call_inst_id: InstId,
+    call_args: &[ValueId],
+    call_res: Option<ValueId>,
+    splice_plan: SplicePlan,
+    stats: &mut InlineStats,
+) -> bool {
+    if call_res.is_some() && splice_plan.ret_value.is_none() {
+        return false;
+    }
+
+    let Some(mut value_map) = build_splice_value_map(
+        &splice_plan.callee_args,
+        &splice_plan.const_values,
+        caller,
+        call_args,
+    ) else {
+        return false;
+    };
+
+    if !validate_splice_value_flow(&splice_plan.body, splice_plan.ret_value, None, &value_map) {
+        return false;
+    }
+
+    apply_splice_body(splice_plan.body, &mut value_map, |new_inst, result_ty| {
+        let new_inst_id = caller.dfg.make_inst_dyn(new_inst);
+        caller.layout.insert_inst_before(new_inst_id, call_inst_id);
+        result_ty.map(|ty| {
+            let new_res = caller.dfg.make_value(Value::Inst {
+                inst: new_inst_id,
+                ty,
+            });
+            caller.dfg.attach_result(new_inst_id, new_res);
+            new_res
+        })
+    });
+
+    if let Some((old_ret, call_res)) = splice_plan.ret_value.zip(call_res) {
+        let new_ret = *value_map
+            .get(&old_ret)
+            .expect("validated splice return value must be mapped");
+        debug_assert_alias_type_match(caller, call_res, new_ret);
+        caller.dfg.change_to_alias(call_res, new_ret);
+    }
+
+    caller.dfg.untrack_inst(call_inst_id);
+    caller.layout.remove_inst(call_inst_id);
+    stats.calls_spliced += 1;
+    true
+}
+
+fn apply_splice_single_block_terminator(
+    caller: &mut Function,
+    call_inst_id: InstId,
+    call_args: &[ValueId],
+    call_res: Option<ValueId>,
+    splice_plan: TerminatorSplicePlan,
+    stats: &mut InlineStats,
+) -> bool {
+    if call_res.is_some() {
+        return false;
+    }
+
+    let call_block = caller.layout.inst_block(call_inst_id);
+    let Some(caller_term_inst) = caller.layout.last_inst_of(call_block) else {
+        return false;
+    };
+
+    // Can't fix up successor phis. Only inline a terminating callee
+    // into a caller block that already has no successors.
+    if caller.dfg.is_branch(caller_term_inst) {
+        return false;
+    }
+
+    let Some(mut value_map) = build_splice_value_map(
+        &splice_plan.callee_args,
+        &splice_plan.const_values,
+        caller,
+        call_args,
+    ) else {
+        return false;
+    };
+
+    if !validate_splice_value_flow(
+        &splice_plan.body,
+        None,
+        Some(splice_plan.terminator.as_ref()),
+        &value_map,
+    ) {
+        return false;
+    }
+
+    let mut editor = CfgEditor::new(caller, CleanupMode::Strict);
+    let call_block = editor.truncate_block_from_inst(call_inst_id);
+    apply_splice_body(splice_plan.body, &mut value_map, |new_inst, result_ty| {
+        let (_, new_result) = editor.append_inst_with_result(call_block, new_inst, result_ty);
+        new_result
+    });
+
+    let mut new_term = splice_plan.terminator;
+    rewrite_inst_values_checked(new_term.as_mut(), &value_map);
+    editor.append_inst_with_result(call_block, new_term, None);
+    editor.recompute_cfg();
+
+    stats.calls_spliced += 1;
+    true
+}
+
+fn build_splice_value_map(
+    callee_args: &[ValueId],
+    const_values: &BTreeMap<ValueId, ValueTemplate>,
+    caller: &mut Function,
+    call_args: &[ValueId],
+) -> Option<FxHashMap<ValueId, ValueId>> {
+    if callee_args.len() != call_args.len() {
+        return None;
+    }
+
+    let mut value_map: FxHashMap<ValueId, ValueId> = FxHashMap::default();
+    value_map.extend(callee_args.iter().copied().zip(call_args.iter().copied()));
+    for (old_value, tpl) in const_values {
+        let new_value = materialize(tpl, caller, call_args)?;
+        value_map.insert(*old_value, new_value);
+    }
+
+    Some(value_map)
+}
+
+fn apply_splice_body(
+    body: Vec<TemplateInst>,
+    value_map: &mut FxHashMap<ValueId, ValueId>,
+    mut insert: impl FnMut(Box<dyn Inst>, Option<Type>) -> Option<ValueId>,
+) {
+    for template_inst in body {
+        let mut new_inst = template_inst.inst;
+        rewrite_inst_values_checked(new_inst.as_mut(), value_map);
+        let inserted_result = insert(new_inst, template_inst.old_result.map(|(_, ty)| ty));
+
+        if let Some((old_res, _)) = template_inst.old_result {
+            let new_res =
+                inserted_result.expect("instruction result type provided when old result exists");
+            value_map.insert(old_res, new_res);
+        }
+    }
+}
+
+fn validate_splice_value_flow(
+    body: &[TemplateInst],
+    required_value: Option<ValueId>,
+    trailing_inst: Option<&dyn Inst>,
+    initial_map: &FxHashMap<ValueId, ValueId>,
+) -> bool {
+    let mut available: FxHashSet<ValueId> = initial_map.keys().copied().collect();
+    for template_inst in body {
+        if !inst_values_available(template_inst.inst.as_ref(), &available) {
+            return false;
+        }
+        if let Some((old_res, _)) = template_inst.old_result {
+            available.insert(old_res);
+        }
+    }
+
+    if let Some(required_value) = required_value
+        && !available.contains(&required_value)
+    {
+        return false;
+    }
+
+    if let Some(trailing_inst) = trailing_inst
+        && !inst_values_available(trailing_inst, &available)
+    {
+        return false;
+    }
+
+    true
+}
+
+fn inst_values_available(inst: &dyn Inst, available: &FxHashSet<ValueId>) -> bool {
+    let mut all_available = true;
+    inst.for_each_value(&mut |value| {
+        if !available.contains(&value) {
+            all_available = false;
+        }
+    });
+    all_available
+}
+
+fn rewrite_inst_values_checked(inst: &mut dyn Inst, value_map: &FxHashMap<ValueId, ValueId>) {
+    assert!(
+        rewrite_inst_values(inst, value_map),
+        "validated splice instruction had unmapped operand"
+    );
+}
+
+fn materialize(
+    template: &ValueTemplate,
+    caller: &mut Function,
+    call_args: &[ValueId],
+) -> Option<ValueId> {
+    match template {
+        ValueTemplate::Arg(i) => call_args.get(*i).copied(),
+        ValueTemplate::Imm(imm) => Some(caller.dfg.make_imm_value(*imm)),
+        ValueTemplate::Global(gv) => Some(caller.dfg.make_global_value(*gv)),
+        ValueTemplate::Undef(ty) => Some(caller.dfg.make_undef_value(*ty)),
+    }
+}
+
+fn classify_value_template(func: &Function, value: ValueId) -> Option<ValueTemplate> {
+    match func.dfg.value(value) {
+        Value::Arg { idx, .. } => Some(ValueTemplate::Arg(*idx)),
+        Value::Immediate { imm, .. } => Some(ValueTemplate::Imm(*imm)),
+        Value::Global { gv, .. } => Some(ValueTemplate::Global(*gv)),
+        Value::Undef { ty } => Some(ValueTemplate::Undef(*ty)),
+        Value::Inst { .. } => None,
+    }
+}
+
+fn signatures_match(ctx: &ModuleCtx, a: FuncRef, b: FuncRef) -> bool {
+    ctx.func_sig(a, |a_sig| {
+        ctx.func_sig(b, |b_sig| {
+            a_sig.args() == b_sig.args() && a_sig.ret_ty() == b_sig.ret_ty()
+        })
+    })
+}
+
+fn extend_const_values_from_inst_operands(
+    func: &Function,
+    inst_id: InstId,
+    const_values: &mut BTreeMap<ValueId, ValueTemplate>,
+) {
+    func.dfg.inst(inst_id).for_each_value(&mut |value| {
+        if let Some(tpl) = classify_value_template(func, value) {
+            record_const_value(const_values, value, tpl);
+        }
+    });
+}
+
+fn record_const_value(
+    const_values: &mut BTreeMap<ValueId, ValueTemplate>,
+    value_id: ValueId,
+    template: ValueTemplate,
+) {
+    if matches!(
+        template,
+        ValueTemplate::Imm(..) | ValueTemplate::Global(..) | ValueTemplate::Undef(..)
+    ) {
+        const_values.entry(value_id).or_insert(template);
+    }
+}
+
+fn debug_assert_alias_type_match(func: &Function, value: ValueId, alias: ValueId) {
+    debug_assert_eq!(
+        func.dfg.value_ty(value),
+        func.dfg.value_ty(alias),
+        "alias type mismatch: {value:?} and {alias:?}"
+    );
+}
+
+fn rewrite_inst_values(inst: &mut dyn Inst, value_map: &FxHashMap<ValueId, ValueId>) -> bool {
+    let mut all_mapped = true;
+    inst.for_each_value_mut(&mut |value| {
+        if let Some(&mapped) = value_map.get(value) {
+            *value = mapped;
+        } else {
+            all_mapped = false;
+        }
+    });
+    all_mapped
+}

--- a/crates/codegen/src/optim/mod.rs
+++ b/crates/codegen/src/optim/mod.rs
@@ -1,6 +1,7 @@
 pub mod adce;
 pub mod cfg_cleanup;
 pub mod egraph;
+pub mod inliner;
 pub mod licm;
 pub mod sccp;
 mod sccp_simplify;

--- a/crates/codegen/test_files/inliner/call_once_large.snap
+++ b/crates/codegen/test_files/inliner/call_once_large.snap
@@ -1,0 +1,32 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/call_once_large.sntn
+---
+func private %large(v0.i32) -> i32 {
+    block0:
+        v1.i32 = add v0 1.i32;
+        v2.i32 = add v1 2.i32;
+        v3.i32 = add v2 3.i32;
+        v4.i32 = add v3 4.i32;
+        v5.i32 = add v4 5.i32;
+        v6.i32 = add v5 6.i32;
+        v7.i32 = add v6 7.i32;
+        v8.i32 = add v7 8.i32;
+        v9.i32 = add v8 9.i32;
+        return v9;
+}
+
+
+func public %caller(v0.i32) -> i32 {
+    block0:
+        v11.i32 = add v0 1.i32;
+        v12.i32 = add v11 2.i32;
+        v13.i32 = add v12 3.i32;
+        v14.i32 = add v13 4.i32;
+        v15.i32 = add v14 5.i32;
+        v16.i32 = add v15 6.i32;
+        v17.i32 = add v16 7.i32;
+        v18.i32 = add v17 8.i32;
+        v19.i32 = add v18 9.i32;
+        return v19;
+}

--- a/crates/codegen/test_files/inliner/call_once_large.sntn
+++ b/crates/codegen/test_files/inliner/call_once_large.sntn
@@ -1,0 +1,22 @@
+target = "evm-ethereum-london"
+
+func private %large(v0.i32) -> i32 {
+    block0:
+        v1.i32 = add v0 1.i32;
+        v2.i32 = add v1 2.i32;
+        v3.i32 = add v2 3.i32;
+        v4.i32 = add v3 4.i32;
+        v5.i32 = add v4 5.i32;
+        v6.i32 = add v5 6.i32;
+        v7.i32 = add v6 7.i32;
+        v8.i32 = add v7 8.i32;
+        v9.i32 = add v8 9.i32;
+        return v9;
+}
+
+func public %caller(v0.i32) -> i32 {
+    block0:
+        v1.i32 = call %large v0;
+        return v1;
+}
+

--- a/crates/codegen/test_files/inliner/const_return.snap
+++ b/crates/codegen/test_files/inliner/const_return.snap
@@ -1,0 +1,14 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/const_return.sntn
+---
+func private %const() -> i32 {
+    block0:
+        return 42.i32;
+}
+
+
+func public %caller() -> i32 {
+    block0:
+        return 42.i32;
+}

--- a/crates/codegen/test_files/inliner/const_return.sntn
+++ b/crates/codegen/test_files/inliner/const_return.sntn
@@ -1,0 +1,13 @@
+target = "evm-ethereum-london"
+
+func private %const() -> i32 {
+    block0:
+        return 42.i32;
+}
+
+func public %caller() -> i32 {
+    block0:
+        v0.i32 = call %const;
+        return v0;
+}
+

--- a/crates/codegen/test_files/inliner/identity.snap
+++ b/crates/codegen/test_files/inliner/identity.snap
@@ -1,0 +1,14 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/identity.sntn
+---
+func private %id(v0.i32) -> i32 {
+    block0:
+        return v0;
+}
+
+
+func public %caller(v0.i32) -> i32 {
+    block0:
+        return v0;
+}

--- a/crates/codegen/test_files/inliner/identity.sntn
+++ b/crates/codegen/test_files/inliner/identity.sntn
@@ -1,0 +1,13 @@
+target = "evm-ethereum-london"
+
+func private %id(v0.i32) -> i32 {
+    block0:
+        return v0;
+}
+
+func public %caller(v0.i32) -> i32 {
+    block0:
+        v1.i32 = call %id v0;
+        return v1;
+}
+

--- a/crates/codegen/test_files/inliner/inline_evm_revert.snap
+++ b/crates/codegen/test_files/inliner/inline_evm_revert.snap
@@ -1,0 +1,15 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/inline_evm_revert.sntn
+---
+func private %revert() {
+    block0:
+        evm_revert 0.i32 0.i32;
+}
+
+
+func public %caller() {
+    block0:
+        evm_revert 0.i32 0.i32;
+}
+

--- a/crates/codegen/test_files/inliner/inline_evm_revert.sntn
+++ b/crates/codegen/test_files/inliner/inline_evm_revert.sntn
@@ -1,0 +1,13 @@
+target = "evm-ethereum-london"
+
+func private %revert() {
+    block0:
+        evm_revert 0.i32 0.i32;
+}
+
+func public %caller() {
+    block0:
+        call %revert;
+        return;
+}
+

--- a/crates/codegen/test_files/inliner/inline_evm_revert_chain.snap
+++ b/crates/codegen/test_files/inliner/inline_evm_revert_chain.snap
@@ -1,0 +1,21 @@
+---
+source: crates/codegen/tests/inliner.rs
+assertion_line: 29
+input_file: test_files/inliner/inline_evm_revert_chain.sntn
+---
+func private %abort_chain(v0.i32) {
+    block0:
+        v1.i32 = add v0 1.i32;
+        v2.i32 = mul v1 2.i32;
+        v3.i32 = add v2 v1;
+        evm_revert v2 v3;
+}
+
+
+func public %caller(v0.i32) {
+    block0:
+        v3.i32 = add v0 1.i32;
+        v4.i32 = mul v3 2.i32;
+        v5.i32 = add v4 v3;
+        evm_revert v4 v5;
+}

--- a/crates/codegen/test_files/inliner/inline_evm_revert_chain.sntn
+++ b/crates/codegen/test_files/inliner/inline_evm_revert_chain.sntn
@@ -1,0 +1,15 @@
+target = "evm-ethereum-london"
+
+func private %abort_chain(v0.i32) {
+    block0:
+        v1.i32 = add v0 1.i32;
+        v2.i32 = mul v1 2.i32;
+        v3.i32 = add v2 v1;
+        evm_revert v2 v3;
+}
+
+func public %caller(v0.i32) {
+    block0:
+        call %abort_chain v0;
+        return;
+}

--- a/crates/codegen/test_files/inliner/inline_evm_revert_dead_tail.snap
+++ b/crates/codegen/test_files/inliner/inline_evm_revert_dead_tail.snap
@@ -1,0 +1,18 @@
+---
+source: crates/codegen/tests/inliner.rs
+assertion_line: 29
+input_file: test_files/inliner/inline_evm_revert_dead_tail.sntn
+---
+func private %revert(v0.i32) {
+    block0:
+        v1.i32 = add v0 4.i32;
+        evm_revert v0 v1;
+}
+
+
+func public %caller() {
+    block0:
+        v0.i32 = add 1.i32 2.i32;
+        v8.i32 = add v0 4.i32;
+        evm_revert v0 v8;
+}

--- a/crates/codegen/test_files/inliner/inline_evm_revert_dead_tail.sntn
+++ b/crates/codegen/test_files/inliner/inline_evm_revert_dead_tail.sntn
@@ -1,0 +1,16 @@
+target = "evm-ethereum-london"
+
+func private %revert(v0.i32) {
+    block0:
+        v1.i32 = add v0 4.i32;
+        evm_revert v0 v1;
+}
+
+func public %caller() {
+    block0:
+        v0.i32 = add 1.i32 2.i32;
+        call %revert v0;
+        v1.i32 = mul v0 7.i32;
+        v2.i32 = sub v1 3.i32;
+        return;
+}

--- a/crates/codegen/test_files/inliner/malformed_call_result_void_callee.snap
+++ b/crates/codegen/test_files/inliner/malformed_call_result_void_callee.snap
@@ -1,0 +1,16 @@
+---
+source: crates/codegen/tests/inliner.rs
+assertion_line: 29
+input_file: test_files/inliner/malformed_call_result_void_callee.sntn
+---
+func private %noop() {
+    block0:
+        return;
+}
+
+
+func public %caller() -> i32 {
+    block0:
+        v0.i32 = call %noop;
+        return v0;
+}

--- a/crates/codegen/test_files/inliner/malformed_call_result_void_callee.sntn
+++ b/crates/codegen/test_files/inliner/malformed_call_result_void_callee.sntn
@@ -1,0 +1,12 @@
+target = "evm-ethereum-london"
+
+func private %noop() {
+    block0:
+        return;
+}
+
+func public %caller() -> i32 {
+    block0:
+        v0.i32 = call %noop;
+        return v0;
+}

--- a/crates/codegen/test_files/inliner/noop.snap
+++ b/crates/codegen/test_files/inliner/noop.snap
@@ -1,0 +1,14 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/noop.sntn
+---
+func private %noop() {
+    block0:
+        return;
+}
+
+
+func public %caller() {
+    block0:
+        return;
+}

--- a/crates/codegen/test_files/inliner/noop.sntn
+++ b/crates/codegen/test_files/inliner/noop.sntn
@@ -1,0 +1,13 @@
+target = "evm-ethereum-london"
+
+func private %noop() {
+    block0:
+        return;
+}
+
+func public %caller() {
+    block0:
+        call %noop;
+        return;
+}
+

--- a/crates/codegen/test_files/inliner/reject_effectful.snap
+++ b/crates/codegen/test_files/inliner/reject_effectful.snap
@@ -1,0 +1,20 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/reject_effectful.sntn
+---
+func private %effectful() -> i32 {
+    block0:
+        v0.*i32 = alloca i32;
+        mstore v0 1.i32 i32;
+        v1.i32 = mload v0 i32;
+        return v1;
+}
+
+
+func public %caller() -> i32 {
+    block0:
+        v2.*i32 = alloca i32;
+        mstore v2 1.i32 i32;
+        v3.i32 = mload v2 i32;
+        return v3;
+}

--- a/crates/codegen/test_files/inliner/reject_effectful.sntn
+++ b/crates/codegen/test_files/inliner/reject_effectful.sntn
@@ -1,0 +1,16 @@
+target = "evm-ethereum-london"
+
+func private %effectful() -> i32 {
+    block0:
+        v0.*i32 = alloca i32;
+        mstore v0 1.i32 i32;
+        v1.i32 = mload v0 i32;
+        return v1;
+}
+
+func public %caller() -> i32 {
+    block0:
+        v0.i32 = call %effectful;
+        return v0;
+}
+

--- a/crates/codegen/test_files/inliner/reject_multi_block.snap
+++ b/crates/codegen/test_files/inliner/reject_multi_block.snap
@@ -1,0 +1,21 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/reject_multi_block.sntn
+---
+func private %multi(v0.i1) -> i32 {
+    block0:
+        br v0 block1 block2;
+
+    block1:
+        return 1.i32;
+
+    block2:
+        return 2.i32;
+}
+
+
+func public %caller(v0.i1) -> i32 {
+    block0:
+        v1.i32 = call %multi v0;
+        return v1;
+}

--- a/crates/codegen/test_files/inliner/reject_multi_block.sntn
+++ b/crates/codegen/test_files/inliner/reject_multi_block.sntn
@@ -1,0 +1,19 @@
+target = "evm-ethereum-london"
+
+func private %multi(v0.i1) -> i32 {
+    block0:
+        br v0 block1 block2;
+
+    block1:
+        return 1.i32;
+
+    block2:
+        return 2.i32;
+}
+
+func public %caller(v0.i1) -> i32 {
+    block0:
+        v1.i32 = call %multi v0;
+        return v1;
+}
+

--- a/crates/codegen/test_files/inliner/reject_terminator_splice_branchy_caller.snap
+++ b/crates/codegen/test_files/inliner/reject_terminator_splice_branchy_caller.snap
@@ -1,0 +1,22 @@
+---
+source: crates/codegen/tests/inliner.rs
+assertion_line: 29
+input_file: test_files/inliner/reject_terminator_splice_branchy_caller.sntn
+---
+func private %revert_now() {
+    block0:
+        evm_revert 0.i32 0.i32;
+}
+
+
+func public %caller(v0.i1) {
+    block0:
+        call %revert_now;
+        br v0 block1 block2;
+
+    block1:
+        return;
+
+    block2:
+        return;
+}

--- a/crates/codegen/test_files/inliner/reject_terminator_splice_branchy_caller.sntn
+++ b/crates/codegen/test_files/inliner/reject_terminator_splice_branchy_caller.sntn
@@ -1,0 +1,18 @@
+target = "evm-ethereum-london"
+
+func private %revert_now() {
+    block0:
+        evm_revert 0.i32 0.i32;
+}
+
+func public %caller(v0.i1) {
+    block0:
+        call %revert_now;
+        br v0 block1 block2;
+
+    block1:
+        return;
+
+    block2:
+        return;
+}

--- a/crates/codegen/test_files/inliner/splice_pure.snap
+++ b/crates/codegen/test_files/inliner/splice_pure.snap
@@ -1,0 +1,19 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/splice_pure.sntn
+---
+func private %add_mul(v0.i32, v1.i32) -> i32 {
+    block0:
+        v2.i32 = add v0 v1;
+        v3.i32 = mul v2 v0;
+        return v3;
+}
+
+
+func public %caller(v0.i32, v1.i32) -> i32 {
+    block0:
+        v5.i32 = add v0 v1;
+        v6.i32 = mul v5 v0;
+        v3.i32 = sub v6 1.i32;
+        return v3;
+}

--- a/crates/codegen/test_files/inliner/splice_pure.sntn
+++ b/crates/codegen/test_files/inliner/splice_pure.sntn
@@ -1,0 +1,16 @@
+target = "evm-ethereum-london"
+
+func private %add_mul(v0.i32, v1.i32) -> i32 {
+    block0:
+        v2.i32 = add v0 v1;
+        v3.i32 = mul v2 v0;
+        return v3;
+}
+
+func public %caller(v0.i32, v1.i32) -> i32 {
+    block0:
+        v2.i32 = call %add_mul v0 v1;
+        v3.i32 = sub v2 1.i32;
+        return v3;
+}
+

--- a/crates/codegen/test_files/inliner/splice_return_const_only.snap
+++ b/crates/codegen/test_files/inliner/splice_return_const_only.snap
@@ -1,0 +1,20 @@
+---
+source: crates/codegen/tests/inliner.rs
+assertion_line: 29
+input_file: test_files/inliner/splice_return_const_only.sntn
+---
+func private %const_after_work(v0.i32) -> i32 {
+    block0:
+        v1.i32 = add v0 1.i32;
+        v2.i32 = mul v1 3.i32;
+        return 9.i32;
+}
+
+
+func public %caller(v0.i32) -> i32 {
+    block0:
+        v6.i32 = add v0 1.i32;
+        v7.i32 = mul v6 3.i32;
+        v2.i32 = sub 9.i32 1.i32;
+        return v2;
+}

--- a/crates/codegen/test_files/inliner/splice_return_const_only.sntn
+++ b/crates/codegen/test_files/inliner/splice_return_const_only.sntn
@@ -1,0 +1,15 @@
+target = "evm-ethereum-london"
+
+func private %const_after_work(v0.i32) -> i32 {
+    block0:
+        v1.i32 = add v0 1.i32;
+        v2.i32 = mul v1 3.i32;
+        return 9.i32;
+}
+
+func public %caller(v0.i32) -> i32 {
+    block0:
+        v1.i32 = call %const_after_work v0;
+        v2.i32 = sub v1 1.i32;
+        return v2;
+}

--- a/crates/codegen/test_files/inliner/wrapper_rewrite.snap
+++ b/crates/codegen/test_files/inliner/wrapper_rewrite.snap
@@ -1,0 +1,20 @@
+---
+source: crates/codegen/tests/inliner.rs
+input_file: test_files/inliner/wrapper_rewrite.sntn
+---
+func external %ext_add(v0.i32, v1.i32) -> i32 {
+}
+
+
+func private %wrapper(v0.i32, v1.i32) -> i32 {
+    block0:
+        v2.i32 = call %ext_add v0 1.i32;
+        return v2;
+}
+
+
+func public %caller(v0.i32, v1.i32) -> i32 {
+    block0:
+        v2.i32 = call %ext_add v0 1.i32;
+        return v2;
+}

--- a/crates/codegen/test_files/inliner/wrapper_rewrite.sntn
+++ b/crates/codegen/test_files/inliner/wrapper_rewrite.sntn
@@ -1,0 +1,16 @@
+target = "evm-ethereum-london"
+
+declare external %ext_add(i32, i32) -> i32;
+
+func private %wrapper(v0.i32, v1.i32) -> i32 {
+    block0:
+        v2.i32 = call %ext_add v0 1.i32;
+        return v2;
+}
+
+func public %caller(v0.i32, v1.i32) -> i32 {
+    block0:
+        v2.i32 = call %wrapper v0 v1;
+        return v2;
+}
+

--- a/crates/codegen/tests/inliner.rs
+++ b/crates/codegen/tests/inliner.rs
@@ -1,0 +1,71 @@
+mod common;
+
+use dir_test::{Fixture, dir_test};
+use sonatina_codegen::optim::inliner::{Inliner, InlinerConfig};
+use sonatina_ir::ir_writer::FuncWriter;
+use sonatina_parser::ParsedModule;
+
+#[dir_test(
+    dir: "$CARGO_MANIFEST_DIR/test_files/inliner/",
+    glob: "*.sntn"
+    loader: common::parse_module,
+)]
+fn test(fixture: Fixture<ParsedModule>) {
+    let fixture_path = fixture.path();
+    let mut parsed = fixture.into_content();
+    let module = &mut parsed.module;
+
+    let mut inliner = Inliner::new(InlinerConfig::default());
+    inliner.run(module);
+
+    let mut result = String::new();
+    for func_ref in module.funcs() {
+        module.func_store.view(func_ref, |func| {
+            result.push_str(&FuncWriter::new(func_ref, func).dump_string());
+        });
+        result.push_str("\n\n");
+    }
+
+    snap_test!(result, fixture_path);
+}
+
+#[test]
+fn no_op_rewrite_self_wrapper_is_not_counted_as_rewrite() {
+    let source = r#"
+target = "evm-ethereum-london"
+
+func private %foo(v0.i32) -> i32 {
+    block0:
+        v1.i32 = call %foo v0;
+        return v1;
+}
+
+func public %caller(v0.i32) -> i32 {
+    block0:
+        v1.i32 = call %foo v0;
+        return v1;
+}
+"#;
+
+    let mut parsed = sonatina_parser::parse_module(source)
+        .unwrap_or_else(|errs| panic!("parse failed: {errs:?}"));
+    let module = &mut parsed.module;
+    let before = dump_module(module);
+
+    let mut inliner = Inliner::new(InlinerConfig::default());
+    let stats = inliner.run(module);
+
+    assert_eq!(stats.calls_rewritten, 0);
+    assert_eq!(before, dump_module(module));
+}
+
+fn dump_module(module: &sonatina_ir::Module) -> String {
+    let mut result = String::new();
+    for func_ref in module.funcs() {
+        module.func_store.view(func_ref, |func| {
+            result.push_str(&FuncWriter::new(func_ref, func).dump_string());
+        });
+        result.push_str("\n\n");
+    }
+    result
+}

--- a/crates/ir/src/dfg.rs
+++ b/crates/ir/src/dfg.rs
@@ -2,6 +2,7 @@
 use std::{collections::BTreeSet, io};
 
 use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl, packed_option::PackedOption};
+use dyn_clone::clone_box;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::{Immediate, Type, Value, ValueId};
@@ -58,6 +59,10 @@ impl DataFlowGraph {
         let inst_id = self.insts.push(inst);
         self.attach_user(inst_id);
         inst_id
+    }
+
+    pub fn clone_inst(&self, inst_id: InstId) -> Box<dyn Inst> {
+        clone_box(self.inst(inst_id))
     }
 
     pub fn make_imm_value<Imm>(&mut self, imm: Imm) -> ValueId


### PR DESCRIPTION
Deliberately simple. Doesn't inline any multi-block functions. Fe generates a lot of calls to simple functions (trait methods with trivial implementations are common), and we need to eliminate them.