### PR TITLE
support current-section symbol for sym_addr/sym_size

### DIFF
--- a/crates/codegen/src/object/artifact.rs
+++ b/crates/codegen/src/object/artifact.rs
@@ -17,6 +17,7 @@ pub enum SymbolId {
     Func(FuncRef),
     Global(GlobalVariableRef),
     Embed(EmbedSymbol),
+    CurrentSection,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/codegen/src/object/compile.rs
+++ b/crates/codegen/src/object/compile.rs
@@ -309,6 +309,7 @@ fn record_symbol(sym: &SymbolRef, membership: &mut SectionMembership, worklist: 
         SymbolRef::Embed(sym) => {
             membership.used_embed_symbols.insert(sym.clone());
         }
+        SymbolRef::CurrentSection => {}
     }
 }
 
@@ -715,6 +716,82 @@ object @Contract {
         assert_eq!(init[5], 0x63);
         assert_eq!(&init[6..10], &13u32.to_be_bytes());
         assert_eq!(&init[10..], runtime.as_slice());
+    }
+
+    #[test]
+    fn compile_object_resolves_current_section_symbols() {
+        let s = r#"
+target = "evm-ethereum-london"
+
+global public const [i8; 3] $blob = [1, 2, 3];
+
+func public %runtime() {
+    block0:
+        v0.i256 = sym_addr $blob;
+        v1.i256 = sym_size $blob;
+        return;
+}
+
+func public %init() {
+    block0:
+        v0.i256 = sym_addr .;
+        v1.i256 = sym_size .;
+        v2.i256 = sym_addr &runtime;
+        v3.i256 = sym_size &runtime;
+        return;
+}
+
+object @Contract {
+  section init {
+    entry %init;
+    embed .runtime as &runtime;
+  }
+  section runtime {
+    entry %runtime;
+    data $blob;
+  }
+}
+"#;
+
+        let parsed = parse_module(s).unwrap();
+        let backend = FakeBackend;
+        let opts = CompileOptions {
+            fixup_policy: PushWidthPolicy::Push4,
+            emit_symtab: true,
+            emit_observability: false,
+            verifier_cfg: VerifierConfig::for_level(VerificationLevel::Standard),
+        };
+
+        let artifact = compile_object(&parsed.module, &backend, "Contract", &opts).unwrap();
+
+        let runtime = artifact
+            .sections
+            .iter()
+            .find(|(name, _)| name.0.as_str() == "runtime")
+            .unwrap()
+            .1
+            .bytes
+            .clone();
+        assert_eq!(runtime.len(), 13);
+
+        let init = artifact
+            .sections
+            .iter()
+            .find(|(name, _)| name.0.as_str() == "init")
+            .unwrap()
+            .1
+            .bytes
+            .clone();
+        assert_eq!(init.len(), 33);
+        assert_eq!(init[0], 0x63);
+        assert_eq!(&init[1..5], &0u32.to_be_bytes());
+        assert_eq!(init[5], 0x63);
+        assert_eq!(&init[6..10], &33u32.to_be_bytes());
+        assert_eq!(init[10], 0x63);
+        assert_eq!(&init[11..15], &20u32.to_be_bytes());
+        assert_eq!(init[15], 0x63);
+        assert_eq!(&init[16..20], &13u32.to_be_bytes());
+        assert_eq!(&init[20..], runtime.as_slice());
     }
 
     #[test]

--- a/crates/codegen/src/object/link.rs
+++ b/crates/codegen/src/object/link.rs
@@ -70,7 +70,7 @@ pub fn link_section<B: LowerBackend>(
     for _ in 0..MAX_ITERS {
         while layout.resize(backend, 0) {}
 
-        let symtab =
+        let (symtab, section_size) =
             build_section_symtab(&layout, funcs, data, embeds).map_err(LinkSectionError::Link)?;
 
         let mut layout_changed = false;
@@ -91,8 +91,7 @@ pub fn link_section<B: LowerBackend>(
         if !layout_changed {
             while layout.resize(backend, 0) {}
 
-            let section_size: usize = symtab.values().map(|def| def.size as usize).sum();
-            let mut bytes = Vec::with_capacity(section_size);
+            let mut bytes = Vec::with_capacity(section_size as usize);
             layout.emit(backend, &mut bytes);
             for (_, blob) in data {
                 bytes.extend_from_slice(blob);
@@ -146,7 +145,7 @@ fn build_section_symtab<Op>(
     funcs: &[FuncRef],
     data: &[(GlobalVariableRef, Vec<u8>)],
     embeds: &[(EmbedSymbol, Vec<u8>)],
-) -> Result<FxHashMap<SymbolId, SymbolDef>, String> {
+) -> Result<(FxHashMap<SymbolId, SymbolDef>, u32), String> {
     let mut symtab: FxHashMap<SymbolId, SymbolDef> = FxHashMap::default();
 
     let mut code_end: u32 = 0;
@@ -188,7 +187,16 @@ fn build_section_symtab<Op>(
         symtab.insert(SymbolId::Embed(symbol.clone()), SymbolDef { offset, size });
     }
 
-    Ok(symtab)
+    let section_size = cursor;
+    symtab.insert(
+        SymbolId::CurrentSection,
+        SymbolDef {
+            offset: 0,
+            size: section_size,
+        },
+    );
+
+    Ok((symtab, section_size))
 }
 
 fn fixup_value(symtab: &FxHashMap<SymbolId, SymbolDef>, fixup: &SymFixup) -> Result<u32, String> {
@@ -207,6 +215,7 @@ fn symbol_id(sym: &SymbolRef) -> SymbolId {
         SymbolRef::Func(func) => SymbolId::Func(*func),
         SymbolRef::Global(gv) => SymbolId::Global(*gv),
         SymbolRef::Embed(sym) => SymbolId::Embed(sym.clone()),
+        SymbolRef::CurrentSection => SymbolId::CurrentSection,
     }
 }
 

--- a/crates/ir/src/inst/data.rs
+++ b/crates/ir/src/inst/data.rs
@@ -15,6 +15,7 @@ pub enum SymbolRef {
     Func(FuncRef),
     Global(GlobalVariableRef),
     Embed(EmbedSymbol),
+    CurrentSection,
 }
 
 impl<Ctx> IrWrite<Ctx> for SymbolRef
@@ -31,6 +32,7 @@ where
                 .as_ref()
                 .with_gv_store(|s| write!(w, "${}", s.gv_data(*gv).symbol)),
             Self::Embed(sym) => write!(w, "&{}", sym.0.as_str()),
+            Self::CurrentSection => write!(w, "."),
         }
     }
 }
@@ -41,6 +43,7 @@ impl Visitable for SymbolRef {
             Self::Func(f) => f.accept(visitor),
             Self::Global(gv) => gv.accept(visitor),
             Self::Embed(_) => {}
+            Self::CurrentSection => {}
         }
     }
 }
@@ -51,6 +54,7 @@ impl VisitableMut for SymbolRef {
             Self::Func(f) => f.accept_mut(visitor),
             Self::Global(gv) => gv.accept_mut(visitor),
             Self::Embed(_) => {}
+            Self::CurrentSection => {}
         }
     }
 }

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -570,6 +570,8 @@ impl FromSyntax<Error> for InstArg {
             InstArgKind::FuncRef(func)
         } else if let Some(sym) = node.single_opt(Rule::embed_symbol) {
             InstArgKind::EmbedSymbol(sym)
+        } else if node.get_opt(Rule::current_section_symbol).is_some() {
+            InstArgKind::CurrentSection
         } else {
             unreachable!()
         };
@@ -589,6 +591,7 @@ pub enum InstArgKind {
     ValueBlockMap((Value, BlockId)),
     FuncRef(FunctionName),
     EmbedSymbol(EmbedSymbol),
+    CurrentSection,
 }
 
 impl InstArgKind {
@@ -600,6 +603,7 @@ impl InstArgKind {
             Self::ValueBlockMap(_) => "(value, block)",
             Self::FuncRef(_) => "function name",
             Self::EmbedSymbol(_) => "embed symbol",
+            Self::CurrentSection => "current section symbol",
         }
         .into()
     }

--- a/crates/parser/src/inst/data.rs
+++ b/crates/parser/src/inst/data.rs
@@ -46,6 +46,7 @@ fn build_symbol_ref(
         }
 
         ast::InstArgKind::EmbedSymbol(sym) => Ok(SymbolRef::Embed(sym.clone())),
+        ast::InstArgKind::CurrentSection => Ok(SymbolRef::CurrentSection),
 
         ast::InstArgKind::Value(value) => match &value.kind {
             ast::ValueKind::Global(name) => {
@@ -60,14 +61,15 @@ fn build_symbol_ref(
             }
 
             _ => Err(Box::new(Error::InstArgKindMismatch {
-                expected: "function name, embed symbol, or global value".into(),
+                expected: "function name, embed symbol, current section symbol, or global value"
+                    .into(),
                 actual: Some("value".into()),
                 span: arg.span,
             })),
         },
 
         other => Err(Box::new(Error::InstArgKindMismatch {
-            expected: "function name, embed symbol, or global value".into(),
+            expected: "function name, embed symbol, current section symbol, or global value".into(),
             actual: Some(
                 match other {
                     ast::InstArgKind::Value(_) => "value",
@@ -76,6 +78,7 @@ fn build_symbol_ref(
                     ast::InstArgKind::ValueBlockMap(_) => "(value, block)",
                     ast::InstArgKind::FuncRef(_) => "function name",
                     ast::InstArgKind::EmbedSymbol(_) => "embed symbol",
+                    ast::InstArgKind::CurrentSection => "current section symbol",
                 }
                 .into(),
             ),

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -725,6 +725,8 @@ func public %main() {
         v3.i256 = sym_size $foo;
         v4.i256 = sym_addr &runtime;
         v5.i256 = sym_size &runtime;
+        v6.i256 = sym_addr .;
+        v7.i256 = sym_size .;
         return;
 }
 "#;
@@ -738,6 +740,8 @@ func public %main() {
         assert!(printed.contains("sym_size $foo"));
         assert!(printed.contains("sym_addr &runtime"));
         assert!(printed.contains("sym_size &runtime"));
+        assert!(printed.contains("sym_addr ."));
+        assert!(printed.contains("sym_size ."));
     }
 
     #[test]

--- a/crates/parser/src/sonatina.pest
+++ b/crates/parser/src/sonatina.pest
@@ -76,6 +76,7 @@ local_section_ref   =  { "." ~ section_name }
 external_section_ref = { object_identifier ~ "." ~ section_name }
 embed_symbol        = ${ "&" ~ embed_name }
 embed_name          = @{ ident_start_char ~ ident_body_char* }
+current_section_symbol = { "." }
 
 // Stmts
 stmt        = { (assign_stmt | inst_stmt) ~ ";" }
@@ -85,7 +86,7 @@ inst_stmt   = { inst }
 inst            = { inst_name ~ inst_arg* }
 inst_name       = { inst_identifier }
 inst_identifier = @{ ident_start_char ~ ident_body_char* }
-inst_arg        = { value | type_name | block_ident | value_block_map | function_identifier | embed_symbol }
+inst_arg        = { value | type_name | block_ident | value_block_map | function_identifier | embed_symbol | current_section_symbol }
 value_block_map = { "(" ~ value ~ block_ident ~ ")" }
 
 value        =  { value_name | imm_number | undef | global_value }

--- a/crates/verifier/src/verify/function/type_rules/mod.rs
+++ b/crates/verifier/src/verify/function/type_rules/mod.rs
@@ -517,6 +517,7 @@ impl FunctionVerifier<'_> {
                     );
                 }
             }
+            SymbolRef::CurrentSection => {}
         }
     }
 }

--- a/crates/verifier/src/verify/module_invariants.rs
+++ b/crates/verifier/src/verify/module_invariants.rs
@@ -729,6 +729,7 @@ fn record_symbol_membership(
         SymbolRef::Embed(embed) => {
             used_embed_symbols.insert(embed.0.to_string());
         }
+        SymbolRef::CurrentSection => {}
     }
 }
 

--- a/crates/verifier/tests/verifier.rs
+++ b/crates/verifier/tests/verifier.rs
@@ -796,6 +796,32 @@ object @Contract {
 }
 
 #[test]
+fn current_section_symbols_are_accepted_without_embed_declaration() {
+    let src = r#"
+target = "evm-ethereum-london"
+
+func public %entry() -> unit {
+    block0:
+        v0.i256 = sym_addr .;
+        v1.i256 = sym_size .;
+        return;
+}
+
+object @Contract {
+  section runtime {
+    entry %entry;
+  }
+}
+"#;
+
+    let parsed = parse_module(src).expect("module should parse");
+    let cfg = VerifierConfig::for_level(VerificationLevel::Standard);
+    let report = verify_module(&parsed.module, &cfg);
+
+    assert!(report.is_ok(), "expected no verifier errors, got {report}");
+}
+
+#[test]
 fn undeclared_embed_symbols_are_rejected_even_without_objects() {
     let src = r#"
 target = "evm-ethereum-london"


### PR DESCRIPTION
`sym_size .` in the text form of the ir. `CurrentSection` in the api.