### PR TITLE
plank fix, adce improvement

### DIFF
--- a/crates/codegen/src/isa/evm/emit/alloc.rs
+++ b/crates/codegen/src/isa/evm/emit/alloc.rs
@@ -13,7 +13,9 @@ pub(crate) struct FinalAlloc {
 
 impl FinalAlloc {
     pub(crate) fn new(inner: StackifyAlloc, mem_plan: FuncMemPlan) -> Self {
-        Self { inner, mem_plan }
+        let alloc = Self { inner, mem_plan };
+        alloc.validate_object_actions();
+        alloc
     }
 
     fn abs_addr_for_word(&self, word_off: u32) -> u32 {
@@ -26,6 +28,19 @@ impl FinalAlloc {
             .get(&id)
             .copied()
             .unwrap_or_else(|| panic!("missing stack object location for obj {}", id.as_u32()))
+    }
+
+    fn validate_object_actions(&self) {
+        self.inner.for_each_action(|action| match action {
+            Action::MemLoadObj(id) | Action::MemStoreObj(id) => {
+                assert!(
+                    self.mem_plan.obj_loc.contains_key(id),
+                    "stackify emitted object action for unplaced stack object {}",
+                    id.as_u32()
+                );
+            }
+            _ => {}
+        });
     }
 
     fn dynamic_frame_layout(&self) -> DynamicFrameLayout {

--- a/crates/codegen/src/isa/evm/escape_scan.rs
+++ b/crates/codegen/src/isa/evm/escape_scan.rs
@@ -37,6 +37,7 @@ pub(crate) enum PtrTransferEvent<'a> {
     },
     Write {
         kind: PtrWriteKind,
+        dest: ValueId,
         dest_prov: &'a Provenance,
         source: PtrTransferSource<'a>,
     },
@@ -49,6 +50,7 @@ pub(crate) enum PtrTransferEvent<'a> {
         callee: FuncRef,
         arg_index: usize,
         value: ValueId,
+        dest: ValueId,
         dest_prov: &'a Provenance,
     },
 }
@@ -107,6 +109,7 @@ pub(crate) fn for_each_ptr_transfer_at_inst<'a>(
             let dest = *mstore.addr();
             visit(PtrTransferEvent::Write {
                 kind: PtrWriteKind::Store,
+                dest,
                 dest_prov: &ctx.prov[dest],
                 source: PtrTransferSource::Value(*mstore.value()),
             });
@@ -115,6 +118,7 @@ pub(crate) fn for_each_ptr_transfer_at_inst<'a>(
             let dest = *mstore8.addr();
             visit(PtrTransferEvent::Write {
                 kind: PtrWriteKind::Store,
+                dest,
                 dest_prov: &ctx.prov[dest],
                 source: PtrTransferSource::Value(*mstore8.val()),
             });
@@ -127,6 +131,7 @@ pub(crate) fn for_each_ptr_transfer_at_inst<'a>(
                 if let Some(stored) = ctx.local_mem.get(&base) {
                     visit(PtrTransferEvent::Write {
                         kind: PtrWriteKind::Copy,
+                        dest,
                         dest_prov: &ctx.prov[dest],
                         source: PtrTransferSource::LocalMem { addr, stored },
                     });
@@ -136,6 +141,7 @@ pub(crate) fn for_each_ptr_transfer_at_inst<'a>(
                 if let Some(stored) = ctx.arg_mem.get(arg_index as usize) {
                     visit(PtrTransferEvent::Write {
                         kind: PtrWriteKind::Copy,
+                        dest,
                         dest_prov: &ctx.prov[dest],
                         source: PtrTransferSource::ArgMem { stored },
                     });
@@ -144,6 +150,7 @@ pub(crate) fn for_each_ptr_transfer_at_inst<'a>(
             if !src_prov.is_local_addr() {
                 visit(PtrTransferEvent::Write {
                     kind: PtrWriteKind::Copy,
+                    dest,
                     dest_prov: &ctx.prov[dest],
                     source: PtrTransferSource::UnknownCopy,
                 });
@@ -167,6 +174,7 @@ pub(crate) fn for_each_ptr_transfer_at_inst<'a>(
                         callee,
                         arg_index,
                         value,
+                        dest,
                         dest_prov: &ctx.prov[dest],
                     });
                 }
@@ -236,6 +244,7 @@ pub(crate) fn for_each_escape_event_at_inst<'a>(
             arg_index,
             value,
             dest_prov,
+            ..
         } => {
             if (dest_prov.has_any_arg() || dest_prov.may_be_nonlocal_nonarg())
                 && !call_arg_escapes.contains(&(callee, arg_index, value))

--- a/crates/codegen/src/isa/evm/memory_plan.rs
+++ b/crates/codegen/src/isa/evm/memory_plan.rs
@@ -21,9 +21,10 @@ use super::{
     malloc_plan::MallocEscapeKind,
     ptr_escape::PtrEscapeSummary,
     static_arena_alloc::{
-        CallSiteObjects, ExactPackItem, FuncStackObjects, LiveRegion, LocalObjIdx, ObjFacts,
-        PackedObject, StableItemIdx, StackObj, StackObjId, StackObjKind, StaticArenaAllocCtx,
-        pack_exact_peak, pack_exact_with_offsets, pack_objects_presorted,
+        CallSiteObjects, ExactPackItem, ExactPackWorkspace, FuncStackObjects, LiveRegion,
+        LocalObjIdx, ObjFacts, PackedObject, StableItemIdx, StackObj, StackObjId, StackObjKind,
+        StaticArenaAllocCtx, pack_exact_peak_by, pack_exact_with_offsets_by,
+        pack_objects_presorted,
     },
 };
 use sonatina_ir::isa::evm::Evm;
@@ -200,21 +201,27 @@ mod tests {
         let _ = shadow_conflicts[0].insert(LocalObjIdx::new(0));
         let _ = shadow_conflicts[0].insert(LocalObjIdx::new(1));
 
+        let stable_ctx = StablePackCtx {
+            sorted_objects: &sorted_objects,
+            must_stable: &must_stable,
+            real_conflicts_by_local: &real_conflicts,
+            shadow_conflicts_by_call: &shadow_conflicts,
+        };
+        let mut entries = Vec::new();
         let mut items = Vec::new();
-        let mut conflicts = Vec::new();
-        build_stable_pack(
+        build_stable_pack_entries(
+            &mut entries,
             &mut items,
-            &mut conflicts,
             &[shadow],
-            StablePackCtx {
-                sorted_objects: &sorted_objects,
-                must_stable: &must_stable,
-                real_conflicts_by_local: &real_conflicts,
-                shadow_conflicts_by_call: &shadow_conflicts,
-            },
+            stable_ctx,
             &promoted_optional,
         );
-        let packed = pack_exact_with_offsets(&items, &conflicts);
+        let mut pack_workspace = ExactPackWorkspace::default();
+        let packed = pack_exact_with_offsets_by(
+            &items,
+            |lhs, rhs| stable_pack_entries_conflict(stable_ctx, &entries, lhs, rhs),
+            &mut pack_workspace,
+        );
 
         let real0_off = packed.offsets[&real0.id];
         let real1_off = packed.offsets[&real1.id];
@@ -226,15 +233,18 @@ mod tests {
         assert_eq!(shadow_off, 4);
     }
 
-    #[test]
-    fn swap_search_uses_bounded_shortlists_once_pair_count_exceeds_limit() {
-        let candidate_count = 320usize;
+    fn with_half_promoted_placement_problem(
+        candidate_count: usize,
+        size_mod: usize,
+        recursive_cost_mod: usize,
+        f: impl FnOnce(&PlacementProblem<'_>, &PlacementState),
+    ) {
         let objects: Vec<_> = (0..candidate_count)
             .map(|idx| {
                 stack_obj(
                     idx as u32,
                     StackObjKind::Alloca(InstId::from_u32(idx as u32)),
-                    1 + (idx % 3) as u32,
+                    1 + (idx % size_mod) as u32,
                     region(0, 0, 1),
                 )
             })
@@ -257,7 +267,7 @@ mod tests {
                 obj_id: obj.id,
                 local_idx: LocalObjIdx::new(local_idx),
                 size_words: obj.size_words,
-                recursive_access_cost: (local_idx % 11) as u64,
+                recursive_access_cost: (local_idx % recursive_cost_mod) as u64,
                 shadow_copy_words: 0,
                 live_call_indices: SmallVec::new(),
             })
@@ -286,110 +296,230 @@ mod tests {
             state.apply_add(&problem, candidate_idx);
         }
 
-        let feasible_add_count = state.promoted.iter().filter(|&&promoted| !promoted).count();
-        let feasible_remove_count = state.promoted_count;
-        assert!(
-            feasible_add_count.saturating_mul(feasible_remove_count) > SWAP_FULL_PAIR_LIMIT,
-            "test must exercise the bounded swap shortlist path"
-        );
+        f(&problem, &state);
+    }
 
-        let mut lb_state = PlacementLowerBoundState::new(&problem);
-        let mut search_work = SearchWorkBuffers::default();
-        let current_score = FuncPlacementScore {
-            scratch_words: u32::MAX,
-            stable_words: u32::MAX,
-            cost: u64::MAX,
+    fn with_two_call_shadow_delta_problem(
+        f: impl FnOnce(&PlacementProblem<'_>, &mut PlacementState),
+    ) {
+        let objects = vec![
+            stack_obj(
+                0,
+                StackObjKind::Alloca(InstId::from_u32(0)),
+                4,
+                region(0, 0, 1),
+            ),
+            stack_obj(
+                1,
+                StackObjKind::Alloca(InstId::from_u32(1)),
+                4,
+                region(1, 0, 1),
+            ),
+        ];
+        let obj_size_words = objects.iter().map(|obj| (obj.id, obj.size_words)).collect();
+        let call_sites = vec![
+            CallSiteObjects {
+                inst: InstId::from_u32(10),
+                call_rank: 10,
+                callee: FuncRef::from_u32(0),
+                result_count: 0,
+                arg_count: 0,
+                live_across_objs: vec![StackObjId::new(0)],
+                callee_visible_objs: Vec::new(),
+            },
+            CallSiteObjects {
+                inst: InstId::from_u32(11),
+                call_rank: 20,
+                callee: FuncRef::from_u32(0),
+                result_count: 0,
+                arg_count: 0,
+                live_across_objs: vec![StackObjId::new(1)],
+                callee_visible_objs: Vec::new(),
+            },
+        ];
+        let stack = FuncStackObjects {
+            objects,
+            obj_facts: FxHashMap::default(),
+            obj_size_words,
+            alloca_ids: FxHashMap::default(),
+            spill_obj: SecondaryMap::default(),
+            call_sites,
+            next_obj_id: 2,
         };
-        let _ = find_best_exact_swap_move(
-            &problem,
-            &state,
-            &mut lb_state,
-            current_score,
-            &mut FuncPlacementScoreWorkspace::default(),
-            &mut search_work,
-        );
+        let sorted_objects: Vec<_> = stack.objects.iter().collect();
+        let sorted_calls: Vec<_> = stack.call_sites.iter().collect();
+        let candidates = sorted_objects
+            .iter()
+            .enumerate()
+            .map(|(local_idx, obj)| CandidateMeta {
+                obj_id: obj.id,
+                local_idx: LocalObjIdx::new(local_idx),
+                size_words: obj.size_words,
+                recursive_access_cost: 0,
+                shadow_copy_words: u64::from(obj.size_words),
+                live_call_indices: smallvec![local_idx as u32],
+            })
+            .collect();
+        let mut shadow_conflicts_by_call = vec![BitSet::default(); 2];
+        let _ = shadow_conflicts_by_call[0].insert(LocalObjIdx::new(0));
+        let _ = shadow_conflicts_by_call[1].insert(LocalObjIdx::new(1));
+        let cost_model = ArenaCostModel::default();
+        let problem = PlacementProblem {
+            stack: &stack,
+            sorted_objects,
+            sorted_calls,
+            must_stable: BitSet::default(),
+            must_stable_by_local: vec![false; 2],
+            candidates,
+            base_shadow_words_by_call: vec![4, 4],
+            base_shadow_copy_words: 8,
+            base_recursive_access_cost: 0,
+            frame_setup_cost: 0,
+            shadow_cost_per_word: 0,
+            next_shadow_base_id: stack.next_obj_id,
+            is_recursive: false,
+            cost_model: &cost_model,
+            real_conflicts_by_local: vec![BitSet::default(); 2],
+            shadow_conflicts_by_call,
+        };
+        let mut state = PlacementState::new(&problem);
 
-        assert!(!search_work.add_shortlist.is_empty());
-        assert!(!search_work.remove_shortlist.is_empty());
-        assert!(search_work.add_shortlist.len() <= SWAP_SHORTLIST_PER_METRIC * 3);
-        assert!(search_work.remove_shortlist.len() <= SWAP_SHORTLIST_PER_METRIC * 3);
-        assert_eq!(
-            search_work.swap_exact.len(),
-            search_work
-                .add_shortlist
-                .len()
-                .saturating_mul(search_work.remove_shortlist.len()),
-            "bounded swap search should only exact-score the shortlist cross-product",
-        );
+        f(&problem, &mut state);
+    }
+
+    fn stable_peak_with_full_shadow_scan(
+        problem: &PlacementProblem<'_>,
+        state: &PlacementState,
+        mv: PlacementMove,
+    ) -> u32 {
+        let mut entries = Vec::new();
+        let mut items = Vec::new();
+        let (insert_idx, skip_idx) = stable_local_indices_for_move(problem, mv);
+        for local_idx in TrialLocalIter::new(&state.stable_real_locals, insert_idx, skip_idx) {
+            let obj = problem.sorted_objects[local_idx as usize];
+            push_stable_real_entry(&mut entries, local_idx, obj);
+        }
+        for call_idx in 0..problem.sorted_calls.len() {
+            let shadow_words = shadow_words_for_call_after_move(problem, state, mv, call_idx);
+            if shadow_words != 0 {
+                push_score_shadow_entry(&mut entries, problem, call_idx as u32, shadow_words);
+            }
+        }
+        finish_stable_pack_entries(&mut entries, &mut items);
+        let stable_ctx = StablePackCtx {
+            sorted_objects: &problem.sorted_objects,
+            must_stable: &problem.must_stable,
+            real_conflicts_by_local: &problem.real_conflicts_by_local,
+            shadow_conflicts_by_call: &problem.shadow_conflicts_by_call,
+        };
+        let mut pack_workspace = ExactPackWorkspace::default();
+        pack_exact_peak_by(
+            &items,
+            |lhs, rhs| stable_pack_entries_conflict(stable_ctx, &entries, lhs, rhs),
+            &mut pack_workspace,
+        )
+    }
+
+    fn has_stable_entry(entries: &[StablePackEntry], member: StablePackMember) -> bool {
+        entries.iter().any(|entry| entry.member == member)
+    }
+
+    #[test]
+    fn swap_search_uses_bounded_shortlists_once_pair_count_exceeds_limit() {
+        with_half_promoted_placement_problem(320, 3, 11, |problem, state| {
+            let feasible_add_count = state.promoted.iter().filter(|&&promoted| !promoted).count();
+            let feasible_remove_count = state.promoted_count;
+            assert!(
+                feasible_add_count.saturating_mul(feasible_remove_count) > SWAP_FULL_PAIR_LIMIT,
+                "test must exercise the bounded swap shortlist path"
+            );
+
+            let mut lb_state = PlacementLowerBoundState::new(problem);
+            let mut search_work = SearchWorkBuffers::default();
+            let current_score = FuncPlacementScore {
+                scratch_words: u32::MAX,
+                stable_words: u32::MAX,
+                cost: u64::MAX,
+            };
+            let _ = find_best_exact_swap_move(
+                problem,
+                state,
+                &mut lb_state,
+                current_score,
+                &mut FuncPlacementScoreWorkspace::default(),
+                &mut search_work,
+            );
+
+            assert!(!search_work.add_shortlist.is_empty());
+            assert!(!search_work.remove_shortlist.is_empty());
+            assert!(search_work.add_shortlist.len() <= SWAP_SHORTLIST_PER_METRIC * 3);
+            assert!(search_work.remove_shortlist.len() <= SWAP_SHORTLIST_PER_METRIC * 3);
+            assert_eq!(
+                search_work.swap_exact.len(),
+                search_work
+                    .add_shortlist
+                    .len()
+                    .saturating_mul(search_work.remove_shortlist.len()),
+                "bounded swap search should only exact-score the shortlist cross-product",
+            );
+        });
     }
 
     #[test]
     fn one_flip_search_uses_bounded_shortlists_once_candidate_count_exceeds_limit() {
-        let candidate_count = ONE_FLIP_FULL_LIMIT + 64;
-        let objects: Vec<_> = (0..candidate_count)
-            .map(|idx| {
-                stack_obj(
-                    idx as u32,
-                    StackObjKind::Alloca(InstId::from_u32(idx as u32)),
-                    1 + (idx % 5) as u32,
-                    region(0, 0, 1),
-                )
-            })
-            .collect();
-        let obj_size_words = objects.iter().map(|obj| (obj.id, obj.size_words)).collect();
-        let stack = FuncStackObjects {
-            objects,
-            obj_facts: FxHashMap::default(),
-            obj_size_words,
-            alloca_ids: FxHashMap::default(),
-            spill_obj: SecondaryMap::default(),
-            call_sites: Vec::new(),
-            next_obj_id: candidate_count as u32,
-        };
-        let sorted_objects: Vec<_> = stack.objects.iter().collect();
-        let candidates = sorted_objects
-            .iter()
-            .enumerate()
-            .map(|(local_idx, obj)| CandidateMeta {
-                obj_id: obj.id,
-                local_idx: LocalObjIdx::new(local_idx),
-                size_words: obj.size_words,
-                recursive_access_cost: (local_idx % 13) as u64,
-                shadow_copy_words: 0,
-                live_call_indices: SmallVec::new(),
-            })
-            .collect();
-        let cost_model = ArenaCostModel::default();
-        let problem = PlacementProblem {
-            stack: &stack,
-            sorted_objects,
-            sorted_calls: Vec::new(),
-            must_stable: BitSet::default(),
-            must_stable_by_local: vec![false; candidate_count],
-            candidates,
-            base_shadow_words_by_call: Vec::new(),
-            base_shadow_copy_words: 0,
-            base_recursive_access_cost: 0,
-            frame_setup_cost: 0,
-            shadow_cost_per_word: 0,
-            next_shadow_base_id: stack.next_obj_id,
-            is_recursive: false,
-            cost_model: &cost_model,
-            real_conflicts_by_local: vec![BitSet::default(); candidate_count],
-            shadow_conflicts_by_call: Vec::new(),
-        };
-        let mut state = PlacementState::new(&problem);
-        for candidate_idx in 0..candidate_count / 2 {
-            state.apply_add(&problem, candidate_idx);
-        }
+        with_half_promoted_placement_problem(ONE_FLIP_FULL_LIMIT + 64, 5, 13, |problem, state| {
+            let mut work = SearchWorkBuffers::default();
+            collect_one_flip_shortlists(problem, state, &mut work);
 
-        let mut work = SearchWorkBuffers::default();
-        collect_one_flip_shortlists(&problem, &state, &mut work);
+            assert!(!work.add_shortlist.is_empty());
+            assert!(!work.remove_shortlist.is_empty());
+            assert!(work.add_shortlist.len() <= ONE_FLIP_SHORTLIST_PER_METRIC * 3);
+            assert!(work.remove_shortlist.len() <= ONE_FLIP_SHORTLIST_PER_METRIC * 3);
+        });
+    }
 
-        assert!(!work.add_shortlist.is_empty());
-        assert!(!work.remove_shortlist.is_empty());
-        assert!(work.add_shortlist.len() <= ONE_FLIP_SHORTLIST_PER_METRIC * 3);
-        assert!(work.remove_shortlist.len() <= ONE_FLIP_SHORTLIST_PER_METRIC * 3);
+    #[test]
+    fn stable_score_shadow_delta_matches_full_call_scan() {
+        with_two_call_shadow_delta_problem(|problem, state| {
+            let mut workspace = FuncPlacementScoreWorkspace::default();
+
+            let add_move = PlacementMove::Add(0);
+            assert_eq!(
+                stable_peak_with_move(problem, state, add_move, &mut workspace),
+                stable_peak_with_full_shadow_scan(problem, state, add_move),
+            );
+            assert!(has_stable_entry(
+                &workspace.stable_entries,
+                StablePackMember::Real(LocalObjIdx::new(0)),
+            ));
+            assert!(!has_stable_entry(
+                &workspace.stable_entries,
+                StablePackMember::Shadow(0),
+            ));
+            assert!(has_stable_entry(
+                &workspace.stable_entries,
+                StablePackMember::Shadow(1),
+            ));
+
+            state.apply_add(problem, 0);
+            let remove_move = PlacementMove::Remove(0);
+            assert_eq!(
+                stable_peak_with_move(problem, state, remove_move, &mut workspace),
+                stable_peak_with_full_shadow_scan(problem, state, remove_move),
+            );
+            assert!(!has_stable_entry(
+                &workspace.stable_entries,
+                StablePackMember::Real(LocalObjIdx::new(0)),
+            ));
+            assert!(has_stable_entry(
+                &workspace.stable_entries,
+                StablePackMember::Shadow(0),
+            ));
+            assert!(has_stable_entry(
+                &workspace.stable_entries,
+                StablePackMember::Shadow(1),
+            ));
+        });
     }
 }
 
@@ -496,21 +626,41 @@ struct FuncPlacementScore {
 struct FuncPlacementWorkspace {
     scratch_pack: Vec<PackedObject>,
     shadow_objs: Vec<ShadowPackObj>,
+    stable_entries: Vec<StablePackEntry>,
     stable_items: Vec<ExactPackItem<StableItemIdx>>,
-    stable_conflicts: Vec<BitSet<StableItemIdx>>,
+    stable_pack: ExactPackWorkspace<StableItemIdx>,
 }
 
 #[derive(Default)]
 struct FuncPlacementScoreWorkspace {
+    scratch_items: Vec<ExactPackItem<LocalObjIdx>>,
+    stable_entries: Vec<StablePackEntry>,
     stable_items: Vec<ExactPackItem<StableItemIdx>>,
-    stable_conflicts: Vec<BitSet<StableItemIdx>>,
+    changed_shadow_calls: Vec<u32>,
+    scratch_pack: ExactPackWorkspace<LocalObjIdx>,
+    stable_pack: ExactPackWorkspace<StableItemIdx>,
 }
 
+#[derive(Clone, Copy)]
 struct StablePackCtx<'a> {
     sorted_objects: &'a [&'a StackObj],
     must_stable: &'a BitSet<StackObjId>,
     real_conflicts_by_local: &'a [BitSet<LocalObjIdx>],
     shadow_conflicts_by_call: &'a [BitSet<LocalObjIdx>],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StablePackMember {
+    Real(LocalObjIdx),
+    Shadow(u32),
+}
+
+#[derive(Clone, Copy, Debug)]
+struct StablePackEntry {
+    sort_key: (u32, u32, u32),
+    member: StablePackMember,
+    id: StackObjId,
+    size_words: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -1210,23 +1360,25 @@ fn solve_func_placement(
     let problem = PlacementProblem::new(stack, facts, is_recursive, cost_model);
     let mut state = PlacementState::new(&problem);
     let mut lb_state = PlacementLowerBoundState::new(&problem);
+    let stable_item_capacity = problem
+        .sorted_objects
+        .len()
+        .saturating_add(problem.sorted_calls.len());
     let mut workspace = FuncPlacementWorkspace {
         scratch_pack: Vec::with_capacity(problem.sorted_objects.len()),
         shadow_objs: Vec::with_capacity(problem.sorted_calls.len()),
-        stable_items: Vec::with_capacity(
-            problem
-                .sorted_objects
-                .len()
-                .saturating_add(problem.sorted_calls.len()),
-        ),
-        stable_conflicts: Vec::with_capacity(
-            problem
-                .sorted_objects
-                .len()
-                .saturating_add(problem.sorted_calls.len()),
-        ),
+        stable_entries: Vec::with_capacity(stable_item_capacity),
+        stable_items: Vec::with_capacity(stable_item_capacity),
+        stable_pack: ExactPackWorkspace::with_capacity(stable_item_capacity),
     };
-    let mut score_workspace = FuncPlacementScoreWorkspace::default();
+    let mut score_workspace = FuncPlacementScoreWorkspace {
+        scratch_items: Vec::with_capacity(problem.sorted_objects.len()),
+        stable_entries: Vec::with_capacity(stable_item_capacity),
+        stable_items: Vec::with_capacity(stable_item_capacity),
+        changed_shadow_calls: Vec::new(),
+        scratch_pack: ExactPackWorkspace::with_capacity(problem.sorted_objects.len()),
+        stable_pack: ExactPackWorkspace::with_capacity(stable_item_capacity),
+    };
     let mut search_work = SearchWorkBuffers::default();
     let mut best_score =
         evaluate_func_placement_score(&problem, &state, PlacementMove::None, &mut score_workspace);
@@ -1337,19 +1489,24 @@ fn evaluate_func_placement(
         call_preserve.insert(call.inst, plan);
     }
 
-    build_stable_pack(
+    let stable_ctx = StablePackCtx {
+        sorted_objects: &problem.sorted_objects,
+        must_stable: &problem.must_stable,
+        real_conflicts_by_local: &problem.real_conflicts_by_local,
+        shadow_conflicts_by_call: &problem.shadow_conflicts_by_call,
+    };
+    build_stable_pack_entries(
+        &mut workspace.stable_entries,
         &mut workspace.stable_items,
-        &mut workspace.stable_conflicts,
         &workspace.shadow_objs,
-        StablePackCtx {
-            sorted_objects: &problem.sorted_objects,
-            must_stable: &problem.must_stable,
-            real_conflicts_by_local: &problem.real_conflicts_by_local,
-            shadow_conflicts_by_call: &problem.shadow_conflicts_by_call,
-        },
+        stable_ctx,
         promoted_optional,
     );
-    let stable_pack = pack_exact_with_offsets(&workspace.stable_items, &workspace.stable_conflicts);
+    let stable_pack = pack_exact_with_offsets_by(
+        &workspace.stable_items,
+        |lhs, rhs| stable_pack_entries_conflict(stable_ctx, &workspace.stable_entries, lhs, rhs),
+        &mut workspace.stable_pack,
+    );
     let stable_offsets = stable_pack.offsets;
     let stable_words = stable_pack.max_used;
 
@@ -1403,6 +1560,37 @@ fn evaluate_func_placement_score(
     )
 }
 
+fn score_move_if_better(
+    problem: &PlacementProblem<'_>,
+    state: &PlacementState,
+    mv: PlacementMove,
+    current_score: FuncPlacementScore,
+    workspace: &mut FuncPlacementScoreWorkspace,
+) -> Option<FuncPlacementScore> {
+    let (shadow_copy_words, recursive_access_cost) = additive_terms_with_move(problem, state, mv);
+    let scratch_words = scratch_peak_with_move(problem, state, mv, workspace);
+    let lower_bound = score_from_words(
+        problem,
+        recursive_access_cost,
+        shadow_copy_words,
+        scratch_words,
+        0,
+    );
+    if !is_better_score(lower_bound, current_score) {
+        return None;
+    }
+
+    let stable_words = stable_peak_with_move(problem, state, mv, workspace);
+    let exact = score_from_words(
+        problem,
+        recursive_access_cost,
+        shadow_copy_words,
+        scratch_words,
+        stable_words,
+    );
+    is_better_score(exact, current_score).then_some(exact)
+}
+
 fn score_from_words(
     problem: &PlacementProblem<'_>,
     recursive_access_cost: u64,
@@ -1429,10 +1617,10 @@ fn scratch_peak_with_move(
     mv: PlacementMove,
     workspace: &mut FuncPlacementScoreWorkspace,
 ) -> u32 {
-    let _ = workspace;
     let (insert_idx, skip_idx) = scratch_local_indices_for_move(problem, mv);
-    let items: Vec<_> = TrialLocalIter::new(&state.scratch_real_locals, insert_idx, skip_idx)
-        .map(|local_idx| {
+    workspace.scratch_items.clear();
+    workspace.scratch_items.extend(
+        TrialLocalIter::new(&state.scratch_real_locals, insert_idx, skip_idx).map(|local_idx| {
             let obj = problem.sorted_objects[local_idx as usize];
             ExactPackItem {
                 id: obj.id,
@@ -1440,9 +1628,13 @@ fn scratch_peak_with_move(
                 size_words: obj.size_words,
                 min_offset_words: 0,
             }
-        })
-        .collect();
-    pack_exact_peak(&items, &problem.real_conflicts_by_local)
+        }),
+    );
+    pack_exact_peak_by(
+        &workspace.scratch_items,
+        |lhs, rhs| problem.real_conflicts_by_local[lhs.index()].contains(rhs),
+        &mut workspace.scratch_pack,
+    )
 }
 
 fn stable_peak_with_move(
@@ -1451,46 +1643,25 @@ fn stable_peak_with_move(
     mv: PlacementMove,
     workspace: &mut FuncPlacementScoreWorkspace,
 ) -> u32 {
-    let promoted_optional = promoted_optional_with_move(problem, state, mv);
-    let shadow_objs = shadow_pack_objs_for_move(problem, state, mv);
-    build_stable_pack(
+    let stable_ctx = StablePackCtx {
+        sorted_objects: &problem.sorted_objects,
+        must_stable: &problem.must_stable,
+        real_conflicts_by_local: &problem.real_conflicts_by_local,
+        shadow_conflicts_by_call: &problem.shadow_conflicts_by_call,
+    };
+    build_stable_pack_entries_for_move(
+        &mut workspace.stable_entries,
         &mut workspace.stable_items,
-        &mut workspace.stable_conflicts,
-        &shadow_objs,
-        StablePackCtx {
-            sorted_objects: &problem.sorted_objects,
-            must_stable: &problem.must_stable,
-            real_conflicts_by_local: &problem.real_conflicts_by_local,
-            shadow_conflicts_by_call: &problem.shadow_conflicts_by_call,
-        },
-        &promoted_optional,
+        &mut workspace.changed_shadow_calls,
+        problem,
+        state,
+        mv,
     );
-    pack_exact_peak(&workspace.stable_items, &workspace.stable_conflicts)
-}
-
-fn promoted_optional_with_move(
-    problem: &PlacementProblem<'_>,
-    state: &PlacementState,
-    mv: PlacementMove,
-) -> BitSet<StackObjId> {
-    let mut promoted = problem.promoted_optional(state);
-    match mv {
-        PlacementMove::None => {}
-        PlacementMove::Add(candidate_idx) => {
-            let _ = promoted.insert(problem.candidates[candidate_idx].obj_id);
-        }
-        PlacementMove::Remove(candidate_idx) => {
-            promoted.remove(problem.candidates[candidate_idx].obj_id);
-        }
-        PlacementMove::Swap {
-            add_idx,
-            remove_idx,
-        } => {
-            promoted.remove(problem.candidates[remove_idx].obj_id);
-            let _ = promoted.insert(problem.candidates[add_idx].obj_id);
-        }
-    }
-    promoted
+    pack_exact_peak_by(
+        &workspace.stable_items,
+        |lhs, rhs| stable_pack_entries_conflict(stable_ctx, &workspace.stable_entries, lhs, rhs),
+        &mut workspace.stable_pack,
+    )
 }
 
 fn shadow_words_for_call_after_move(
@@ -1530,35 +1701,6 @@ fn shadow_words_for_call_after_move(
     shadow_words
 }
 
-fn shadow_pack_objs_for_move(
-    problem: &PlacementProblem<'_>,
-    state: &PlacementState,
-    mv: PlacementMove,
-) -> Vec<ShadowPackObj> {
-    let mut shadow_objs = Vec::new();
-    for (call_idx, &call) in problem.sorted_calls.iter().enumerate() {
-        let shadow_words = shadow_words_for_call_after_move(problem, state, mv, call_idx);
-        if shadow_words == 0 {
-            continue;
-        }
-        shadow_objs.push(ShadowPackObj {
-            call_idx: call_idx as u32,
-            obj: StackObj {
-                id: StackObjId::new(
-                    problem_shadow_order_id(problem.next_shadow_base_id, call_idx) as usize,
-                ),
-                kind: StackObjKind::Shadow(call.inst),
-                size_words: shadow_words,
-                region: LiveRegion::sort_only(call.call_rank),
-                access_weight: 0,
-                load_count: 0,
-                store_count: 0,
-            },
-        });
-    }
-    shadow_objs
-}
-
 fn find_best_exact_one_flip_move(
     problem: &PlacementProblem<'_>,
     state: &PlacementState,
@@ -1586,8 +1728,7 @@ fn find_best_exact_one_flip_move(
         } else {
             PlacementMove::Add(candidate_idx)
         };
-        let exact = evaluate_func_placement_score(problem, state, mv, exact_ws);
-        if is_better_score(exact, current_score) {
+        if let Some(exact) = score_move_if_better(problem, state, mv, current_score, exact_ws) {
             work.one_flip_exact.push(ExactMoveEval { mv, exact });
         }
     }
@@ -1641,8 +1782,9 @@ fn find_best_exact_swap_move(
                     add_idx,
                     remove_idx,
                 };
-                let exact = evaluate_func_placement_score(problem, state, mv, exact_ws);
-                if is_better_score(exact, current_score) {
+                if let Some(exact) =
+                    score_move_if_better(problem, state, mv, current_score, exact_ws)
+                {
                     work.swap_exact.push(ExactMoveEval { mv, exact });
                 }
             }
@@ -1655,8 +1797,9 @@ fn find_best_exact_swap_move(
                     add_idx,
                     remove_idx,
                 };
-                let exact = evaluate_func_placement_score(problem, state, mv, exact_ws);
-                if is_better_score(exact, current_score) {
+                if let Some(exact) =
+                    score_move_if_better(problem, state, mv, current_score, exact_ws)
+                {
                     work.swap_exact.push(ExactMoveEval { mv, exact });
                 }
             }
@@ -1846,77 +1989,171 @@ fn build_scratch_pack(
     }
 }
 
-fn build_stable_pack(
+fn build_stable_pack_entries(
+    stable_entries: &mut Vec<StablePackEntry>,
     stable_items: &mut Vec<ExactPackItem<StableItemIdx>>,
-    stable_conflicts: &mut Vec<BitSet<StableItemIdx>>,
     shadow_objs: &[ShadowPackObj],
     ctx: StablePackCtx<'_>,
     promoted_optional: &BitSet<StackObjId>,
 ) {
-    #[derive(Clone, Copy)]
-    enum StablePackMember {
-        Real(LocalObjIdx),
-        Shadow(u32),
-    }
-
+    stable_entries.clear();
     stable_items.clear();
-    stable_conflicts.clear();
-    let mut members = Vec::new();
     for (local_idx, &obj) in ctx.sorted_objects.iter().enumerate() {
         if !is_stable_real(ctx.must_stable, promoted_optional, obj.id) || obj.size_words == 0 {
             continue;
         }
-        members.push((
-            obj.region.sort_key(obj.id),
-            StablePackMember::Real(LocalObjIdx::new(local_idx)),
-            obj.id,
-            obj.size_words,
-        ));
+        push_stable_real_entry(stable_entries, local_idx as u32, obj);
     }
     for shadow in shadow_objs {
         if shadow.obj.size_words == 0 {
             continue;
         }
-        members.push((
-            shadow.obj.region.sort_key(shadow.obj.id),
-            StablePackMember::Shadow(shadow.call_idx),
-            shadow.obj.id,
-            shadow.obj.size_words,
-        ));
+        stable_entries.push(StablePackEntry {
+            sort_key: shadow.obj.region.sort_key(shadow.obj.id),
+            member: StablePackMember::Shadow(shadow.call_idx),
+            id: shadow.obj.id,
+            size_words: shadow.obj.size_words,
+        });
     }
-    members.sort_unstable_by_key(|(sort_key, _, _, _)| *sort_key);
+    finish_stable_pack_entries(stable_entries, stable_items);
+}
 
-    for (item_idx, (_sort_key, member, id, size_words)) in members.iter().enumerate() {
+fn build_stable_pack_entries_for_move(
+    stable_entries: &mut Vec<StablePackEntry>,
+    stable_items: &mut Vec<ExactPackItem<StableItemIdx>>,
+    changed_shadow_calls: &mut Vec<u32>,
+    problem: &PlacementProblem<'_>,
+    state: &PlacementState,
+    mv: PlacementMove,
+) {
+    stable_entries.clear();
+    stable_items.clear();
+    let (insert_idx, skip_idx) = stable_local_indices_for_move(problem, mv);
+    for local_idx in TrialLocalIter::new(&state.stable_real_locals, insert_idx, skip_idx) {
+        let obj = problem.sorted_objects[local_idx as usize];
+        push_stable_real_entry(stable_entries, local_idx, obj);
+    }
+    push_stable_shadow_entries_for_move(stable_entries, changed_shadow_calls, problem, state, mv);
+    finish_stable_pack_entries(stable_entries, stable_items);
+}
+
+fn push_stable_real_entry(
+    stable_entries: &mut Vec<StablePackEntry>,
+    local_idx: u32,
+    obj: &StackObj,
+) {
+    if obj.size_words == 0 {
+        return;
+    }
+    stable_entries.push(StablePackEntry {
+        sort_key: obj.region.sort_key(obj.id),
+        member: StablePackMember::Real(LocalObjIdx::new(local_idx as usize)),
+        id: obj.id,
+        size_words: obj.size_words,
+    });
+}
+
+fn push_stable_shadow_entries_for_move(
+    stable_entries: &mut Vec<StablePackEntry>,
+    changed_shadow_calls: &mut Vec<u32>,
+    problem: &PlacementProblem<'_>,
+    state: &PlacementState,
+    mv: PlacementMove,
+) {
+    collect_changed_shadow_calls(problem, mv, changed_shadow_calls);
+    for &call_idx in &state.nonzero_shadow_calls {
+        if changed_shadow_calls.binary_search(&call_idx).is_ok() {
+            continue;
+        }
+        push_score_shadow_entry(
+            stable_entries,
+            problem,
+            call_idx,
+            state.shadow_words_by_call[call_idx as usize],
+        );
+    }
+    for &call_idx in changed_shadow_calls.iter() {
+        let shadow_words = shadow_words_for_call_after_move(problem, state, mv, call_idx as usize);
+        if shadow_words != 0 {
+            push_score_shadow_entry(stable_entries, problem, call_idx, shadow_words);
+        }
+    }
+}
+
+fn collect_changed_shadow_calls(
+    problem: &PlacementProblem<'_>,
+    mv: PlacementMove,
+    changed_shadow_calls: &mut Vec<u32>,
+) {
+    changed_shadow_calls.clear();
+    match mv {
+        PlacementMove::None => {}
+        PlacementMove::Add(candidate_idx) | PlacementMove::Remove(candidate_idx) => {
+            changed_shadow_calls.extend(problem.candidates[candidate_idx].live_call_indices.iter());
+        }
+        PlacementMove::Swap {
+            add_idx,
+            remove_idx,
+        } => {
+            changed_shadow_calls.extend(problem.candidates[add_idx].live_call_indices.iter());
+            changed_shadow_calls.extend(problem.candidates[remove_idx].live_call_indices.iter());
+        }
+    }
+    changed_shadow_calls.sort_unstable();
+    changed_shadow_calls.dedup();
+}
+
+fn push_score_shadow_entry(
+    stable_entries: &mut Vec<StablePackEntry>,
+    problem: &PlacementProblem<'_>,
+    call_idx: u32,
+    size_words: u32,
+) {
+    let id = StackObjId::new(
+        problem_shadow_order_id(problem.next_shadow_base_id, call_idx as usize) as usize,
+    );
+    let call = problem.sorted_calls[call_idx as usize];
+    stable_entries.push(StablePackEntry {
+        sort_key: (call.call_rank, call.call_rank, id.as_u32()),
+        member: StablePackMember::Shadow(call_idx),
+        id,
+        size_words,
+    });
+}
+
+fn finish_stable_pack_entries(
+    stable_entries: &mut [StablePackEntry],
+    stable_items: &mut Vec<ExactPackItem<StableItemIdx>>,
+) {
+    stable_entries.sort_unstable_by_key(|entry| entry.sort_key);
+    for (item_idx, entry) in stable_entries.iter().enumerate() {
         stable_items.push(ExactPackItem {
-            id: *id,
+            id: entry.id,
             idx: StableItemIdx::new(item_idx),
-            size_words: *size_words,
+            size_words: entry.size_words,
             min_offset_words: 0,
         });
-        stable_conflicts.push(BitSet::default());
-        let _ = member;
     }
+}
 
-    for lhs_idx in 0..members.len() {
-        for rhs_idx in lhs_idx + 1..members.len() {
-            let conflicts = match (members[lhs_idx].1, members[rhs_idx].1) {
-                (StablePackMember::Real(lhs), StablePackMember::Real(rhs)) => {
-                    ctx.real_conflicts_by_local[lhs.index()].contains(rhs)
-                }
-                (StablePackMember::Real(local), StablePackMember::Shadow(call_idx))
-                | (StablePackMember::Shadow(call_idx), StablePackMember::Real(local)) => {
-                    ctx.shadow_conflicts_by_call[call_idx as usize].contains(local)
-                }
-                (StablePackMember::Shadow(_), StablePackMember::Shadow(_)) => false,
-            };
-            if !conflicts {
-                continue;
-            }
-            let lhs = StableItemIdx::new(lhs_idx);
-            let rhs = StableItemIdx::new(rhs_idx);
-            let _ = stable_conflicts[lhs.index()].insert(rhs);
-            let _ = stable_conflicts[rhs.index()].insert(lhs);
+fn stable_pack_entries_conflict(
+    ctx: StablePackCtx<'_>,
+    stable_entries: &[StablePackEntry],
+    lhs: StableItemIdx,
+    rhs: StableItemIdx,
+) -> bool {
+    match (
+        stable_entries[lhs.index()].member,
+        stable_entries[rhs.index()].member,
+    ) {
+        (StablePackMember::Real(lhs), StablePackMember::Real(rhs)) => {
+            ctx.real_conflicts_by_local[lhs.index()].contains(rhs)
         }
+        (StablePackMember::Real(local), StablePackMember::Shadow(call_idx))
+        | (StablePackMember::Shadow(call_idx), StablePackMember::Real(local)) => {
+            ctx.shadow_conflicts_by_call[call_idx as usize].contains(local)
+        }
+        (StablePackMember::Shadow(_), StablePackMember::Shadow(_)) => false,
     }
 }
 
@@ -2067,6 +2304,30 @@ fn scratch_local_indices_for_move(
         } => (
             Some(problem.candidates[remove_idx].local_idx.as_u32()),
             Some(problem.candidates[add_idx].local_idx.as_u32()),
+        ),
+    }
+}
+
+fn stable_local_indices_for_move(
+    problem: &PlacementProblem<'_>,
+    mv: PlacementMove,
+) -> (Option<u32>, Option<u32>) {
+    match mv {
+        PlacementMove::None => (None, None),
+        PlacementMove::Add(candidate_idx) => (
+            Some(problem.candidates[candidate_idx].local_idx.as_u32()),
+            None,
+        ),
+        PlacementMove::Remove(candidate_idx) => (
+            None,
+            Some(problem.candidates[candidate_idx].local_idx.as_u32()),
+        ),
+        PlacementMove::Swap {
+            add_idx,
+            remove_idx,
+        } => (
+            Some(problem.candidates[add_idx].local_idx.as_u32()),
+            Some(problem.candidates[remove_idx].local_idx.as_u32()),
         ),
     }
 }

--- a/crates/codegen/src/isa/evm/memory_plan.rs
+++ b/crates/codegen/src/isa/evm/memory_plan.rs
@@ -322,6 +322,75 @@ mod tests {
             "bounded swap search should only exact-score the shortlist cross-product",
         );
     }
+
+    #[test]
+    fn one_flip_search_uses_bounded_shortlists_once_candidate_count_exceeds_limit() {
+        let candidate_count = ONE_FLIP_FULL_LIMIT + 64;
+        let objects: Vec<_> = (0..candidate_count)
+            .map(|idx| {
+                stack_obj(
+                    idx as u32,
+                    StackObjKind::Alloca(InstId::from_u32(idx as u32)),
+                    1 + (idx % 5) as u32,
+                    region(0, 0, 1),
+                )
+            })
+            .collect();
+        let obj_size_words = objects.iter().map(|obj| (obj.id, obj.size_words)).collect();
+        let stack = FuncStackObjects {
+            objects,
+            obj_facts: FxHashMap::default(),
+            obj_size_words,
+            alloca_ids: FxHashMap::default(),
+            spill_obj: SecondaryMap::default(),
+            call_sites: Vec::new(),
+            next_obj_id: candidate_count as u32,
+        };
+        let sorted_objects: Vec<_> = stack.objects.iter().collect();
+        let candidates = sorted_objects
+            .iter()
+            .enumerate()
+            .map(|(local_idx, obj)| CandidateMeta {
+                obj_id: obj.id,
+                local_idx: LocalObjIdx::new(local_idx),
+                size_words: obj.size_words,
+                recursive_access_cost: (local_idx % 13) as u64,
+                shadow_copy_words: 0,
+                live_call_indices: SmallVec::new(),
+            })
+            .collect();
+        let cost_model = ArenaCostModel::default();
+        let problem = PlacementProblem {
+            stack: &stack,
+            sorted_objects,
+            sorted_calls: Vec::new(),
+            must_stable: BitSet::default(),
+            must_stable_by_local: vec![false; candidate_count],
+            candidates,
+            base_shadow_words_by_call: Vec::new(),
+            base_shadow_copy_words: 0,
+            base_recursive_access_cost: 0,
+            frame_setup_cost: 0,
+            shadow_cost_per_word: 0,
+            next_shadow_base_id: stack.next_obj_id,
+            is_recursive: false,
+            cost_model: &cost_model,
+            real_conflicts_by_local: vec![BitSet::default(); candidate_count],
+            shadow_conflicts_by_call: Vec::new(),
+        };
+        let mut state = PlacementState::new(&problem);
+        for candidate_idx in 0..candidate_count / 2 {
+            state.apply_add(&problem, candidate_idx);
+        }
+
+        let mut work = SearchWorkBuffers::default();
+        collect_one_flip_shortlists(&problem, &state, &mut work);
+
+        assert!(!work.add_shortlist.is_empty());
+        assert!(!work.remove_shortlist.is_empty());
+        assert!(work.add_shortlist.len() <= ONE_FLIP_SHORTLIST_PER_METRIC * 3);
+        assert!(work.remove_shortlist.len() <= ONE_FLIP_SHORTLIST_PER_METRIC * 3);
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -518,6 +587,8 @@ struct ShadowPackObj {
 
 const SWAP_FULL_PAIR_LIMIT: usize = 25_000;
 const SWAP_SHORTLIST_PER_METRIC: usize = 8;
+const ONE_FLIP_FULL_LIMIT: usize = 128;
+const ONE_FLIP_SHORTLIST_PER_METRIC: usize = 8;
 
 impl<'a> PlacementProblem<'a> {
     fn new(
@@ -1498,7 +1569,18 @@ fn find_best_exact_one_flip_move(
 ) -> Option<ExactMoveEval> {
     let _ = lb_state;
     work.one_flip_exact.clear();
-    for candidate_idx in 0..problem.candidates.len() {
+    let mut candidates = Vec::new();
+    if problem.candidates.len() <= ONE_FLIP_FULL_LIMIT {
+        candidates.extend(0..problem.candidates.len());
+    } else {
+        collect_one_flip_shortlists(problem, state, work);
+        candidates.extend(work.add_shortlist.iter().copied());
+        candidates.extend(work.remove_shortlist.iter().copied());
+        candidates.sort_unstable();
+        candidates.dedup();
+    }
+
+    for candidate_idx in candidates {
         let mv = if state.promoted[candidate_idx] {
             PlacementMove::Remove(candidate_idx)
         } else {
@@ -1517,6 +1599,17 @@ fn find_best_exact_one_flip_move(
             .then_with(|| cmp_move_tie_key(problem, a.mv, b.mv))
     });
     work.one_flip_exact.first().copied()
+}
+
+fn collect_one_flip_shortlists(
+    problem: &PlacementProblem<'_>,
+    state: &PlacementState,
+    work: &mut SearchWorkBuffers,
+) {
+    work.add_shortlist.clear();
+    work.remove_shortlist.clear();
+    collect_metric_shortlist(problem, state, false, ONE_FLIP_SHORTLIST_PER_METRIC, work);
+    collect_metric_shortlist(problem, state, true, ONE_FLIP_SHORTLIST_PER_METRIC, work);
 }
 
 fn find_best_exact_swap_move(
@@ -1587,8 +1680,8 @@ fn collect_swap_shortlists(
 ) {
     work.add_shortlist.clear();
     work.remove_shortlist.clear();
-    collect_metric_shortlist(problem, state, false, work);
-    collect_metric_shortlist(problem, state, true, work);
+    collect_metric_shortlist(problem, state, false, SWAP_SHORTLIST_PER_METRIC, work);
+    collect_metric_shortlist(problem, state, true, SWAP_SHORTLIST_PER_METRIC, work);
 
     work.add_shortlist
         .sort_unstable_by_key(|&candidate_idx| problem.candidates[candidate_idx].obj_id.as_u32());
@@ -1600,6 +1693,7 @@ fn collect_metric_shortlist(
     problem: &PlacementProblem<'_>,
     state: &PlacementState,
     promoted: bool,
+    per_metric: usize,
     work: &mut SearchWorkBuffers,
 ) {
     for metric in 0..3 {
@@ -1621,7 +1715,7 @@ fn collect_metric_shortlist(
                         .cmp(&problem.candidates[rhs].obj_id.as_u32())
                 })
         });
-        for &candidate_idx in candidates.iter().take(SWAP_SHORTLIST_PER_METRIC) {
+        for &candidate_idx in candidates.iter().take(per_metric) {
             if promoted {
                 push_unique_candidate(&mut work.remove_shortlist, candidate_idx);
             } else {

--- a/crates/codegen/src/isa/evm/pipeline.rs
+++ b/crates/codegen/src/isa/evm/pipeline.rs
@@ -231,6 +231,9 @@ impl EvmPipelineContext<'_> {
         AggregateExpandAbi::default().run(module);
         legalize_evm_section(module, &self.funcs);
         self.func_behavior_dirty = true;
+        if self.backend.late_cleanup_profile == LateCleanupProfile::Off {
+            self.run_pass_round("post_evm_legalize", &[Pass::CfgCleanup], false, false);
+        }
         Ok(())
     }
 

--- a/crates/codegen/src/isa/evm/provenance.rs
+++ b/crates/codegen/src/isa/evm/provenance.rs
@@ -51,14 +51,18 @@ impl Provenance {
         self.unknown_non_arg || !self.unknown_arg_indices.is_empty()
     }
 
-    fn add_unknown_arg_index(&mut self, idx: u32) -> bool {
-        if self.unknown_arg_indices.contains(&idx) {
+    fn insert_arg_index(indices: &mut SmallVec<[u32; 4]>, idx: u32) -> bool {
+        if indices.contains(&idx) {
             return false;
         }
-        self.unknown_arg_indices.push(idx);
-        self.unknown_arg_indices.sort_unstable();
-        self.unknown_arg_indices.dedup();
+        indices.push(idx);
+        indices.sort_unstable();
+        indices.dedup();
         true
+    }
+
+    fn add_unknown_arg_index(&mut self, idx: u32) -> bool {
+        Self::insert_arg_index(&mut self.unknown_arg_indices, idx)
     }
 
     fn collapse_arg_bases_to_unknown_arg_indices(&mut self) -> bool {
@@ -347,7 +351,7 @@ pub(crate) fn compute_provenance(
     }
 
     for (idx, &arg) in function.arg_values.iter().enumerate() {
-        if type_can_carry_pointer_provenance(module, function.dfg.value_ty(arg)) {
+        if function.dfg.value_ty(arg).is_pointer(module) {
             prov[arg].bases.push(PtrBase::Arg(idx as u32));
         }
     }
@@ -763,6 +767,34 @@ block0:
         );
 
         assert!(!ret_prov.is_unknown_ptr(), "{ret_prov:?}");
+        assert_eq!(ret_prov.malloc_insts().count(), 0, "{ret_prov:?}");
+    }
+
+    #[test]
+    fn scalar_i256_arg_forwarding_does_not_create_pointer_provenance() {
+        let ret_prov = ret_provenance(
+            r#"
+target = "evm-ethereum-osaka"
+
+func public %id(v0.i256) -> i256 {
+block0:
+    return v0;
+}
+
+func public %caller(v0.i256) -> i256 {
+block0:
+    v1.i256 = call %id v0;
+    return v1;
+}
+"#,
+            "caller",
+        );
+
+        assert!(!ret_prov.is_unknown_ptr(), "{ret_prov:?}");
+        assert_eq!(
+            ret_prov.arg_indices().collect::<Vec<_>>(),
+            Vec::<u32>::new()
+        );
         assert_eq!(ret_prov.malloc_insts().count(), 0, "{ret_prov:?}");
     }
 

--- a/crates/codegen/src/isa/evm/ptr_escape.rs
+++ b/crates/codegen/src/isa/evm/ptr_escape.rs
@@ -1,10 +1,10 @@
-#[cfg(test)]
 use cranelift_entity::SecondaryMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use sonatina_ir::{
-    Function, InstId, Module, ValueId,
-    isa::evm::Evm,
+    Function, InstId, InstSetExt, Module, ValueId,
+    inst::evm::inst_set::EvmInstKind,
+    isa::{Isa, evm::Evm},
     module::{FuncRef, ModuleCtx},
 };
 use std::collections::{BTreeMap, BTreeSet};
@@ -126,20 +126,27 @@ impl PtrEscapeSummary {
         let mut out = Self::new(arg_count, ret_count);
         module.func_sig(func, |sig| {
             for (ret_idx, &ret_ty) in sig.ret_tys().iter().enumerate() {
-                if type_can_carry_pointer_provenance(module, ret_ty) {
+                if ret_ty.is_pointer(module) {
                     out.returns[ret_idx].non_arg_pointer = true;
                     for arg_idx in 0..arg_count {
                         let _ = out.returns[ret_idx].record_arg(arg_idx as u32);
                     }
                 }
             }
+
+            for (src_idx, &src_ty) in sig.args().iter().enumerate() {
+                if !src_ty.is_pointer(module) {
+                    continue;
+                }
+
+                let _ = out.args[src_idx].stores.record_nonlocal();
+                for (dst_idx, &dst_ty) in sig.args().iter().enumerate() {
+                    if dst_ty.is_pointer(module) {
+                        let _ = out.args[src_idx].record_store_to_arg(dst_idx as u32);
+                    }
+                }
+            }
         });
-        for arg in &mut out.args {
-            arg.stores.record_arg();
-            arg.stores.record_nonlocal();
-            arg.arg_store_targets
-                .extend((0..arg_count).map(|idx| idx as u32));
-        }
         out
     }
 
@@ -385,6 +392,286 @@ fn topo_sort_sccs(
     topo
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct ArgOrigins(SmallVec<[u32; 4]>);
+
+impl ArgOrigins {
+    fn new() -> Self {
+        Self(SmallVec::new())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn insert(&mut self, idx: u32) -> bool {
+        if self.0.contains(&idx) {
+            return false;
+        }
+        self.0.push(idx);
+        self.0.sort_unstable();
+        true
+    }
+
+    fn union_with(&mut self, other: &Self) -> bool {
+        let mut changed = false;
+        for idx in other.iter() {
+            changed |= self.insert(idx);
+        }
+        changed
+    }
+
+    fn iter(&self) -> impl Iterator<Item = u32> + '_ {
+        self.0.iter().copied()
+    }
+
+    fn source_indices_with(&self, src_prov: &Provenance) -> SmallVec<[usize; 4]> {
+        let mut out = SmallVec::new();
+        out.extend(src_prov.arg_indices().map(|idx| idx as usize));
+        out.extend(self.iter().map(|idx| idx as usize));
+        out
+    }
+
+    fn from_addr(addr_prov: &Provenance, addr_origins: &Self) -> Self {
+        let mut out = Self::new();
+        for idx in addr_prov.arg_indices() {
+            let _ = out.insert(idx);
+        }
+        let _ = out.union_with(addr_origins);
+        out
+    }
+
+    fn is_only_forwarded_addr_for(&self, addr_prov: &Provenance) -> bool {
+        !self.is_empty() && addr_prov.has_no_known_bases() && !addr_prov.is_unknown_ptr()
+    }
+}
+
+struct ArgForwardingState<'a> {
+    function: &'a Function,
+    module: &'a ModuleCtx,
+    isa: &'a Evm,
+    summaries: &'a FxHashMap<FuncRef, PtrEscapeSummary>,
+    prov: &'a SecondaryMap<ValueId, Provenance>,
+    origins: SecondaryMap<ValueId, ArgOrigins>,
+    local_mem: FxHashMap<InstId, ArgOrigins>,
+    arg_mem: Vec<ArgOrigins>,
+}
+
+impl<'a> ArgForwardingState<'a> {
+    fn new(
+        function: &'a Function,
+        module: &'a ModuleCtx,
+        isa: &'a Evm,
+        summaries: &'a FxHashMap<FuncRef, PtrEscapeSummary>,
+        prov: &'a SecondaryMap<ValueId, Provenance>,
+    ) -> Self {
+        let mut origins: SecondaryMap<ValueId, ArgOrigins> = SecondaryMap::new();
+        for value in function.dfg.value_ids() {
+            let _ = &mut origins[value];
+        }
+        for (idx, &arg) in function.arg_values.iter().enumerate() {
+            if type_can_carry_pointer_provenance(module, function.dfg.value_ty(arg)) {
+                let _ = origins[arg].insert(idx as u32);
+            }
+        }
+
+        Self {
+            function,
+            module,
+            isa,
+            summaries,
+            prov,
+            origins,
+            local_mem: FxHashMap::default(),
+            arg_mem: vec![ArgOrigins::new(); function.arg_values.len()],
+        }
+    }
+
+    fn compute(mut self) -> SecondaryMap<ValueId, ArgOrigins> {
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for block in self.function.layout.iter_block() {
+                for inst in self.function.layout.iter_inst(block) {
+                    changed |= self.visit_inst(inst);
+                }
+            }
+        }
+        self.origins
+    }
+
+    fn visit_inst(&mut self, inst: InstId) -> bool {
+        let data = self
+            .isa
+            .inst_set()
+            .resolve_inst(self.function.dfg.inst(inst));
+
+        if let EvmInstKind::Mstore(mstore) = &data {
+            return self.store_value_to_addr(*mstore.addr(), *mstore.value());
+        }
+
+        if let EvmInstKind::Call(call) = &data {
+            let mut changed = false;
+            let summary =
+                PtrEscapeSummary::get_or_conservative(self.summaries, self.module, *call.callee());
+            let args = call.args();
+            summary.for_each_store_effect(args, |src_idx, dst_actual| {
+                if let Some(&src_actual) = args.get(src_idx) {
+                    changed |= self.store_value_to_addr(dst_actual, src_actual);
+                }
+            });
+
+            for (ret_idx, &def) in self.function.dfg.inst_results(inst).iter().enumerate() {
+                if type_can_carry_pointer_provenance(self.module, self.function.dfg.value_ty(def)) {
+                    let mut next = ArgOrigins::new();
+                    for &idx in summary.returned_arg_indices(ret_idx) {
+                        if let Some(&arg) = args.get(idx as usize) {
+                            let _ = next.union_with(&self.origins[arg]);
+                        }
+                    }
+                    changed |= self.set_origins(def, next);
+                }
+            }
+            return changed;
+        }
+
+        let [def] = self.function.dfg.inst_results(inst) else {
+            return false;
+        };
+        if !type_can_carry_pointer_provenance(self.module, self.function.dfg.value_ty(*def)) {
+            return false;
+        }
+
+        self.set_origins(*def, self.compute_inst_origins(inst, data))
+    }
+
+    fn compute_inst_origins(&self, inst: InstId, data: EvmInstKind<'_>) -> ArgOrigins {
+        let mut next = ArgOrigins::new();
+        match data {
+            EvmInstKind::Mload(mload) => {
+                let _ = next.union_with(&self.load_from_addr(*mload.addr()));
+            }
+            EvmInstKind::Phi(phi) => {
+                for (value, _) in phi.args().iter() {
+                    let _ = next.union_with(&self.origins[*value]);
+                }
+            }
+            EvmInstKind::Gep(gep) => {
+                if let Some(&base) = gep.values().first() {
+                    let _ = next.union_with(&self.origins[base]);
+                }
+            }
+            EvmInstKind::Bitcast(bc) => {
+                let _ = next.union_with(&self.origins[*bc.from()]);
+            }
+            EvmInstKind::IntToPtr(i2p) => {
+                let _ = next.union_with(&self.origins[*i2p.from()]);
+            }
+            EvmInstKind::PtrToInt(p2i) => {
+                let _ = next.union_with(&self.origins[*p2i.from()]);
+            }
+            EvmInstKind::InsertValue(iv) => {
+                let _ = next.union_with(&self.origins[*iv.dest()]);
+                let _ = next.union_with(&self.origins[*iv.value()]);
+            }
+            EvmInstKind::ExtractValue(ev) => {
+                let _ = next.union_with(&self.origins[*ev.dest()]);
+            }
+            EvmInstKind::Add(_)
+            | EvmInstKind::Sub(_)
+            | EvmInstKind::Mul(_)
+            | EvmInstKind::And(_)
+            | EvmInstKind::Or(_)
+            | EvmInstKind::Xor(_)
+            | EvmInstKind::Shl(_)
+            | EvmInstKind::Shr(_)
+            | EvmInstKind::Sar(_)
+            | EvmInstKind::Not(_)
+            | EvmInstKind::Sext(_)
+            | EvmInstKind::Zext(_)
+            | EvmInstKind::Trunc(_)
+            | EvmInstKind::EvmSdiv(_)
+            | EvmInstKind::EvmUdiv(_)
+            | EvmInstKind::EvmUmod(_)
+            | EvmInstKind::EvmSmod(_)
+            | EvmInstKind::EvmAddMod(_)
+            | EvmInstKind::EvmMulMod(_)
+            | EvmInstKind::EvmExp(_)
+            | EvmInstKind::EvmSignExtend(_)
+            | EvmInstKind::EvmByte(_)
+            | EvmInstKind::EvmClz(_) => {
+                self.function.dfg.inst(inst).for_each_value(&mut |value| {
+                    let _ = next.union_with(&self.origins[value]);
+                });
+            }
+            _ => {}
+        }
+        next
+    }
+
+    fn store_value_to_addr(&mut self, addr: ValueId, value: ValueId) -> bool {
+        self.store_origins_to_addr(addr, self.origins[value].clone())
+    }
+
+    fn store_origins_to_addr(&mut self, addr: ValueId, val_origins: ArgOrigins) -> bool {
+        let mut changed = false;
+        let addr_prov = &self.prov[addr];
+        if addr_prov.is_local_addr() {
+            for base in addr_prov.alloca_insts() {
+                changed |= self
+                    .local_mem
+                    .entry(base)
+                    .or_default()
+                    .union_with(&val_origins);
+            }
+        }
+
+        for idx in ArgOrigins::from_addr(addr_prov, &self.origins[addr]).iter() {
+            if let Some(slot) = self.arg_mem.get_mut(idx as usize) {
+                changed |= slot.union_with(&val_origins);
+            }
+        }
+        changed
+    }
+
+    fn load_from_addr(&self, addr: ValueId) -> ArgOrigins {
+        let mut out = ArgOrigins::new();
+        let addr_prov = &self.prov[addr];
+        if addr_prov.is_local_addr() {
+            for base in addr_prov.alloca_insts() {
+                if let Some(stored) = self.local_mem.get(&base) {
+                    let _ = out.union_with(stored);
+                }
+            }
+        }
+
+        for idx in ArgOrigins::from_addr(addr_prov, &self.origins[addr]).iter() {
+            if let Some(stored) = self.arg_mem.get(idx as usize) {
+                let _ = out.union_with(stored);
+            }
+        }
+        out
+    }
+
+    fn set_origins(&mut self, value: ValueId, next: ArgOrigins) -> bool {
+        if self.origins[value] == next {
+            return false;
+        }
+        self.origins[value] = next;
+        true
+    }
+}
+
+fn compute_arg_forwarding(
+    function: &Function,
+    module: &ModuleCtx,
+    isa: &Evm,
+    summaries: &FxHashMap<FuncRef, PtrEscapeSummary>,
+    prov: &SecondaryMap<ValueId, Provenance>,
+) -> SecondaryMap<ValueId, ArgOrigins> {
+    ArgForwardingState::new(function, module, isa, summaries, prov).compute()
+}
+
 fn compute_summary_for_func(
     module: &Module,
     func: FuncRef,
@@ -394,7 +681,7 @@ fn compute_summary_for_func(
     module.func_store.view(func, |function| {
         let sig_arg_count = module.ctx.func_sig(func, |sig| sig.args().len());
         debug_assert_eq!(function.arg_values.len(), sig_arg_count);
-        let mut summary = PtrEscapeSummary::empty_for_func(&module.ctx, func);
+        let summary = PtrEscapeSummary::empty_for_func(&module.ctx, func);
 
         let prov_info = compute_provenance(function, &module.ctx, isa, |callee| {
             PtrEscapeSummary::get_or_conservative(summaries, &module.ctx, callee)
@@ -402,6 +689,7 @@ fn compute_summary_for_func(
         let prov = &prov_info.value;
         let local_mem = &prov_info.local_mem;
         let arg_mem = &prov_info.arg_mem;
+        let arg_origins = compute_arg_forwarding(function, &module.ctx, isa, summaries, prov);
         let scan_ctx = EscapeScanCtx {
             module: &module.ctx,
             isa,
@@ -411,69 +699,134 @@ fn compute_summary_for_func(
             arg_mem,
         };
 
-        let malloc_escape = compute_local_malloc_escape(scan_ctx, function);
-        for block in function.layout.iter_block() {
-            for inst in function.layout.iter_inst(block) {
-                for_each_ptr_transfer_at_inst(function, inst, scan_ctx, |event| match event {
-                    PtrTransferEvent::Return { ret_idx, value } => {
-                        let ret_prov = &prov[value];
-                        if ret_prov.is_unknown_ptr()
-                            || ret_prov.malloc_insts().next().is_some()
-                            || (function.dfg.value_ty(value).is_pointer(&module.ctx)
-                                && ret_prov.has_no_known_bases())
-                        {
-                            summary.record_returned_non_arg_pointer(ret_idx);
-                        }
+        let malloc_escape = compute_local_malloc_escape(scan_ctx, function, &arg_origins);
+        SummaryComputer {
+            function,
+            scan_ctx,
+            arg_origins: &arg_origins,
+            malloc_escape: &malloc_escape,
+            summary,
+        }
+        .compute()
+    })
+}
 
-                        for idx in prov[value].arg_indices() {
-                            summary.record_returned_arg(ret_idx, idx as usize);
-                        }
-                    }
-                    PtrTransferEvent::Write {
-                        dest_prov, source, ..
-                    } => match source {
-                        PtrTransferSource::Value(value) => {
-                            record_escape_into_provenance(
-                                &mut summary,
-                                &prov[value],
-                                dest_prov,
-                                &malloc_escape.escaping,
-                            );
-                        }
-                        PtrTransferSource::LocalMem { stored, .. }
-                        | PtrTransferSource::ArgMem { stored } => {
-                            record_escape_into_provenance(
-                                &mut summary,
-                                stored,
-                                dest_prov,
-                                &malloc_escape.escaping,
-                            );
-                        }
-                        PtrTransferSource::UnknownCopy => {}
-                    },
-                    PtrTransferEvent::CallArgEscape { value, .. } => {
-                        for arg_idx in prov[value].arg_indices() {
-                            summary.record_store_nonlocal(arg_idx as usize);
-                        }
-                    }
-                    PtrTransferEvent::CallArgStore {
-                        value, dest_prov, ..
-                    } => {
-                        for arg_idx in prov[value].arg_indices() {
-                            record_escape_from_arg_index(
-                                &mut summary,
-                                arg_idx as usize,
-                                dest_prov,
-                                &malloc_escape.escaping,
-                            );
-                        }
-                    }
+struct SummaryComputer<'a> {
+    function: &'a Function,
+    scan_ctx: EscapeScanCtx<'a>,
+    arg_origins: &'a SecondaryMap<ValueId, ArgOrigins>,
+    malloc_escape: &'a LocalMallocEscape,
+    summary: PtrEscapeSummary,
+}
+
+impl<'a> SummaryComputer<'a> {
+    fn compute(mut self) -> PtrEscapeSummary {
+        for block in self.function.layout.iter_block() {
+            for inst in self.function.layout.iter_inst(block) {
+                for_each_ptr_transfer_at_inst(self.function, inst, self.scan_ctx, |event| {
+                    self.record_event(event);
                 });
             }
         }
+        self.summary
+    }
 
-        summary
-    })
+    fn record_event(&mut self, event: PtrTransferEvent<'a>) {
+        match event {
+            PtrTransferEvent::Return { ret_idx, value } => self.record_return(ret_idx, value),
+            PtrTransferEvent::Write {
+                dest,
+                dest_prov,
+                source,
+                ..
+            } => match source {
+                PtrTransferSource::Value(value) => self.record_value_write(value, dest_prov, dest),
+                PtrTransferSource::LocalMem { stored, .. }
+                | PtrTransferSource::ArgMem { stored } => {
+                    self.record_provenance_write(stored, dest_prov, dest);
+                }
+                PtrTransferSource::UnknownCopy => {}
+            },
+            PtrTransferEvent::CallArgEscape { value, .. } => {
+                for arg_idx in self.arg_sources(value) {
+                    self.summary.record_store_nonlocal(arg_idx);
+                }
+            }
+            PtrTransferEvent::CallArgStore {
+                value,
+                dest,
+                dest_prov,
+                ..
+            } => self.record_value_write(value, dest_prov, dest),
+        }
+    }
+
+    fn record_return(&mut self, ret_idx: usize, value: ValueId) {
+        let ret_prov = &self.scan_ctx.prov[value];
+        if ret_prov.is_unknown_ptr()
+            || ret_prov.malloc_insts().next().is_some()
+            || (self
+                .function
+                .dfg
+                .value_ty(value)
+                .is_pointer(self.scan_ctx.module)
+                && ret_prov.has_no_known_bases())
+        {
+            self.summary.record_returned_non_arg_pointer(ret_idx);
+        }
+
+        for arg_idx in self.arg_sources(value) {
+            self.summary.record_returned_arg(ret_idx, arg_idx);
+        }
+    }
+
+    fn record_value_write(&mut self, value: ValueId, dst_prov: &Provenance, dst: ValueId) {
+        let dst_origins = self.arg_origins[dst].clone();
+        for arg_idx in self.arg_sources(value) {
+            self.record_arg_write(arg_idx, dst_prov, &dst_origins);
+        }
+    }
+
+    fn record_provenance_write(
+        &mut self,
+        src_prov: &Provenance,
+        dst_prov: &Provenance,
+        dst: ValueId,
+    ) {
+        let dst_origins = self.arg_origins[dst].clone();
+        for arg_idx in src_prov.arg_indices() {
+            self.record_arg_write(arg_idx as usize, dst_prov, &dst_origins);
+        }
+    }
+
+    fn record_arg_write(
+        &mut self,
+        src_idx: usize,
+        dst_prov: &Provenance,
+        dst_origins: &ArgOrigins,
+    ) {
+        if dst_prov.is_local_addr() || dst_prov.malloc_insts().next().is_some() {
+            self.summary.record_store_local(src_idx);
+        }
+        for dst_idx in dst_prov.arg_indices() {
+            self.summary.record_store_to_arg(src_idx, dst_idx);
+        }
+        for dst_idx in dst_origins.iter() {
+            self.summary.record_store_to_arg(src_idx, dst_idx);
+        }
+        if (dst_prov.may_be_nonlocal_nonarg_without_malloc()
+            && !dst_origins.is_only_forwarded_addr_for(dst_prov))
+            || dst_prov
+                .malloc_insts()
+                .any(|malloc| self.malloc_escape.escaping.contains(&malloc))
+        {
+            self.summary.record_store_nonlocal(src_idx);
+        }
+    }
+
+    fn arg_sources(&self, value: ValueId) -> SmallVec<[usize; 4]> {
+        self.arg_origins[value].source_indices_with(&self.scan_ctx.prov[value])
+    }
 }
 
 #[derive(Default)]
@@ -483,7 +836,12 @@ struct LocalMallocEscape {
 }
 
 impl LocalMallocEscape {
-    fn record_write(&mut self, src_prov: &Provenance, dst_prov: &Provenance) {
+    fn record_write(
+        &mut self,
+        src_prov: &Provenance,
+        dst_prov: &Provenance,
+        dst_origins: &ArgOrigins,
+    ) {
         for malloc in dst_prov.malloc_insts() {
             let _ = self
                 .contents
@@ -492,7 +850,14 @@ impl LocalMallocEscape {
                 .union_with(src_prov);
         }
 
-        if dst_prov.has_any_arg() || dst_prov.may_be_nonlocal_nonarg_without_malloc() {
+        if dst_prov.has_any_arg() {
+            self.record_escape(src_prov);
+            return;
+        }
+
+        if dst_prov.may_be_nonlocal_nonarg_without_malloc()
+            && !dst_origins.is_only_forwarded_addr_for(dst_prov)
+        {
             self.record_escape(src_prov);
         }
     }
@@ -520,6 +885,7 @@ impl LocalMallocEscape {
 fn compute_local_malloc_escape(
     scan_ctx: EscapeScanCtx<'_>,
     function: &Function,
+    arg_origins: &SecondaryMap<ValueId, ArgOrigins>,
 ) -> LocalMallocEscape {
     let mut out = LocalMallocEscape::default();
     let prov = scan_ctx.prov;
@@ -530,19 +896,27 @@ fn compute_local_malloc_escape(
                 PtrTransferEvent::Return { value, .. }
                 | PtrTransferEvent::CallArgEscape { value, .. } => out.record_escape(&prov[value]),
                 PtrTransferEvent::Write {
-                    dest_prov, source, ..
+                    dest,
+                    dest_prov,
+                    source,
+                    ..
                 } => match source {
-                    PtrTransferSource::Value(value) => out.record_write(&prov[value], dest_prov),
+                    PtrTransferSource::Value(value) => {
+                        out.record_write(&prov[value], dest_prov, &arg_origins[dest]);
+                    }
                     PtrTransferSource::LocalMem { stored, .. }
                     | PtrTransferSource::ArgMem { stored } => {
-                        out.record_write(stored, dest_prov);
+                        out.record_write(stored, dest_prov, &arg_origins[dest]);
                     }
                     PtrTransferSource::UnknownCopy => {}
                 },
                 PtrTransferEvent::CallArgStore {
-                    value, dest_prov, ..
+                    value,
+                    dest,
+                    dest_prov,
+                    ..
                 } => {
-                    out.record_write(&prov[value], dest_prov);
+                    out.record_write(&prov[value], dest_prov, &arg_origins[dest]);
                 }
             });
         }
@@ -550,38 +924,6 @@ fn compute_local_malloc_escape(
 
     out.close();
     out
-}
-
-fn record_escape_into_provenance(
-    summary: &mut PtrEscapeSummary,
-    src_prov: &Provenance,
-    dst_prov: &Provenance,
-    escaping_mallocs: &FxHashSet<InstId>,
-) {
-    for arg_idx in src_prov.arg_indices() {
-        record_escape_from_arg_index(summary, arg_idx as usize, dst_prov, escaping_mallocs);
-    }
-}
-
-fn record_escape_from_arg_index(
-    summary: &mut PtrEscapeSummary,
-    src_idx: usize,
-    dst_prov: &Provenance,
-    escaping_mallocs: &FxHashSet<InstId>,
-) {
-    if dst_prov.is_local_addr() || dst_prov.malloc_insts().next().is_some() {
-        summary.record_store_local(src_idx);
-    }
-    for dst_idx in dst_prov.arg_indices() {
-        summary.record_store_to_arg(src_idx, dst_idx);
-    }
-    if dst_prov.may_be_nonlocal_nonarg_without_malloc()
-        || dst_prov
-            .malloc_insts()
-            .any(|malloc| escaping_mallocs.contains(&malloc))
-    {
-        summary.record_store_nonlocal(src_idx);
-    }
 }
 
 #[cfg(test)]
@@ -830,6 +1172,27 @@ block0:
     }
 
     #[test]
+    fn ptr_escape_tracks_i256_store_into_i256_out_param_conditionally() {
+        let (summaries, _) = compute(
+            r#"
+target = "evm-ethereum-osaka"
+
+func public %capture(v0.i256, v1.i256) {
+block0:
+    mstore v1 v0 i256;
+    return;
+}
+"#,
+        );
+
+        let capture = &summaries["capture"];
+        assert_eq!(arg_may_escape(capture), vec![false, false]);
+        assert_eq!(arg_store_targets(capture, 0), vec![1]);
+        assert!(capture.arg_store_lattice(0).may_store_to_arg());
+        assert!(!capture.arg_store_lattice(0).may_store_nonlocal());
+    }
+
+    #[test]
     fn ptr_escape_tracks_i256_malloc_return_as_non_arg_pointer() {
         let (summaries, _) = compute(
             r#"
@@ -920,7 +1283,7 @@ block0:
     }
 
     #[test]
-    fn conservative_unknown_treats_i256_returns_as_pointer_carriers() {
+    fn conservative_unknown_i256_return_is_not_pointer_provenance() {
         let parsed = parse_module(
             r#"
 target = "evm-ethereum-osaka"
@@ -940,8 +1303,75 @@ block0:
             .expect("function exists");
 
         let summary = PtrEscapeSummary::conservative_unknown_ctx(&parsed.module.ctx, f);
-        assert!(summary.return_may_be_non_arg_pointer(0));
-        assert_eq!(ret_args(&summary, 0), vec![0]);
+        assert!(!summary.return_may_be_non_arg_pointer(0));
+        assert_eq!(ret_args(&summary, 0), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn conservative_unknown_i256_args_do_not_create_pointer_store_effects() {
+        let parsed = parse_module(
+            r#"
+target = "evm-ethereum-osaka"
+
+func public %scalar(v0.i256, v1.i256) {
+block0:
+    return;
+}
+
+func public %ptr(v0.*i8, v1.*i8) {
+block0:
+    return;
+}
+"#,
+        )
+        .expect("module parses");
+        let scalar = parsed
+            .module
+            .funcs()
+            .into_iter()
+            .find(|&func| {
+                parsed
+                    .module
+                    .ctx
+                    .func_sig(func, |sig| sig.name() == "scalar")
+            })
+            .expect("function exists");
+        let ptr = parsed
+            .module
+            .funcs()
+            .into_iter()
+            .find(|&func| parsed.module.ctx.func_sig(func, |sig| sig.name() == "ptr"))
+            .expect("function exists");
+
+        let scalar = PtrEscapeSummary::conservative_unknown_ctx(&parsed.module.ctx, scalar);
+        assert_eq!(arg_may_escape(&scalar), vec![false, false]);
+        assert_eq!(arg_store_targets(&scalar, 0), Vec::<u32>::new());
+        assert_eq!(arg_store_targets(&scalar, 1), Vec::<u32>::new());
+
+        let ptr = PtrEscapeSummary::conservative_unknown_ctx(&parsed.module.ctx, ptr);
+        assert_eq!(arg_may_escape(&ptr), vec![true, true]);
+        assert_eq!(arg_store_targets(&ptr, 0), vec![0, 1]);
+        assert_eq!(arg_store_targets(&ptr, 1), vec![0, 1]);
+    }
+
+    #[test]
+    fn ptr_escape_does_not_forward_i256_arg_after_narrowing_to_noncarrier() {
+        let (summaries, _) = compute(
+            r#"
+target = "evm-ethereum-osaka"
+
+func public %capture(v0.i256, v1.i256) {
+block0:
+    v2.i8 = trunc v0 i8;
+    mstore v1 v2 i8;
+    return;
+}
+"#,
+        );
+
+        let capture = &summaries["capture"];
+        assert_eq!(arg_may_escape(capture), vec![false, false]);
+        assert_eq!(arg_store_targets(capture, 0), Vec::<u32>::new());
     }
 
     #[test]

--- a/crates/codegen/src/isa/evm/scratch_plan.rs
+++ b/crates/codegen/src/isa/evm/scratch_plan.rs
@@ -47,8 +47,7 @@ fn addr_may_overlap_scratch(
         return imm_lt_u32(imm, SCRATCH_END_BYTES);
     }
 
-    let prov = &prov[addr];
-    prov.is_unknown_ptr() || prov.has_no_known_bases() || prov.has_any_arg()
+    prov[addr].is_unknown_ptr() || prov[addr].has_no_known_bases() || prov[addr].has_any_arg()
 }
 
 pub(crate) fn inst_is_scratch_clobber(
@@ -122,4 +121,94 @@ pub(crate) fn compute_scratch_live_values(
     }
 
     scratch_live_values
+}
+
+#[cfg(test)]
+mod tests {
+    use sonatina_ir::{InstSetExt, isa::Isa};
+    use sonatina_parser::parse_module;
+    use sonatina_triple::{Architecture, EvmVersion, OperatingSystem, TargetTriple, Vendor};
+
+    use super::{super::ptr_escape::compute_ptr_escape_summaries, *};
+
+    fn first_mstore_clobbers_scratch(src: &str, func_name: &str) -> bool {
+        let parsed = parse_module(src).expect("module parses");
+        let funcs = parsed.module.funcs();
+        let func_ref = parsed
+            .module
+            .funcs()
+            .into_iter()
+            .find(|&func| {
+                parsed
+                    .module
+                    .ctx
+                    .func_sig(func, |sig| sig.name() == func_name)
+            })
+            .expect("function exists");
+
+        let isa = Evm::new(TargetTriple {
+            architecture: Architecture::Evm,
+            vendor: Vendor::Ethereum,
+            operating_system: OperatingSystem::Evm(EvmVersion::Osaka),
+        });
+        let summaries = compute_ptr_escape_summaries(&parsed.module, &funcs, &isa);
+
+        parsed.module.func_store.view(func_ref, |function| {
+            let prov = compute_value_provenance(function, &parsed.module.ctx, &isa, |callee| {
+                PtrEscapeSummary::get_or_conservative(&summaries, &parsed.module.ctx, callee)
+            });
+            let mstore = function
+                .layout
+                .iter_block()
+                .flat_map(|block| function.layout.iter_inst(block))
+                .find(|&inst| {
+                    matches!(
+                        isa.inst_set().resolve_inst(function.dfg.inst(inst)),
+                        EvmInstKind::Mstore(_)
+                    )
+                })
+                .expect("mstore exists");
+
+            inst_is_scratch_clobber(function, &isa, mstore, &prov)
+        })
+    }
+
+    #[test]
+    fn allocator_managed_address_with_i256_offset_is_not_scratch_clobber() {
+        let clobbers = first_mstore_clobbers_scratch(
+            r#"
+target = "evm-ethereum-osaka"
+
+func public %f(v0.i256) {
+block0:
+    v1.*i8 = evm_malloc 96.i256;
+    v2.i256 = ptr_to_int v1 i256;
+    v3.i256 = add v2 v0;
+    mstore v3 1.i256 i256;
+    return;
+}
+"#,
+            "f",
+        );
+
+        assert!(!clobbers);
+    }
+
+    #[test]
+    fn plain_i256_address_remains_scratch_clobber() {
+        let clobbers = first_mstore_clobbers_scratch(
+            r#"
+target = "evm-ethereum-osaka"
+
+func public %f(v0.i256) {
+block0:
+    mstore v0 1.i256 i256;
+    return;
+}
+"#,
+            "f",
+        );
+
+        assert!(clobbers);
+    }
 }

--- a/crates/codegen/src/isa/evm/static_arena_alloc.rs
+++ b/crates/codegen/src/isa/evm/static_arena_alloc.rs
@@ -249,9 +249,6 @@ pub(crate) fn compute_func_stack_objects(
 
     let mut spilled_values: BitSet<ValueId> = BitSet::default();
     for (v, obj) in analysis.alloc.spill_obj.iter() {
-        if analysis.alloc.scratch_slot_of_value[v].is_some() {
-            continue;
-        }
         if obj.is_some() {
             spilled_values.insert(v);
             spill_obj[v] = *obj;

--- a/crates/codegen/src/isa/evm/static_arena_alloc.rs
+++ b/crates/codegen/src/isa/evm/static_arena_alloc.rs
@@ -31,7 +31,8 @@ mod exact_pack;
 mod object_liveness;
 
 pub(crate) use exact_pack::{
-    ExactPackItem, PackedObject, pack_exact_peak, pack_exact_with_offsets, pack_objects_presorted,
+    ExactPackItem, ExactPackWorkspace, PackedObject, pack_exact_peak_by,
+    pack_exact_with_offsets_by, pack_objects_presorted,
 };
 #[cfg(test)]
 pub(crate) use object_liveness::BlockLiveSegment;
@@ -1227,7 +1228,12 @@ block0:
         let _ = conflicts[0].insert(LocalObjIdx::new(1));
         let _ = conflicts[1].insert(LocalObjIdx::new(0));
 
-        let packed = pack_exact_with_offsets(&items, &conflicts);
+        let mut workspace = ExactPackWorkspace::default();
+        let packed = pack_exact_with_offsets_by(
+            &items,
+            |lhs, rhs| conflicts[lhs.index()].contains(rhs),
+            &mut workspace,
+        );
         assert_eq!(packed.offsets[&StackObjId::new(1)], 0);
         assert_eq!(packed.offsets[&StackObjId::new(2)], 3);
         assert_eq!(packed.offsets[&StackObjId::new(3)], 5);

--- a/crates/codegen/src/isa/evm/static_arena_alloc/exact_pack.rs
+++ b/crates/codegen/src/isa/evm/static_arena_alloc/exact_pack.rs
@@ -1,8 +1,4 @@
-use cranelift_entity::EntityRef;
 use rustc_hash::FxHashMap;
-use std::hash::Hash;
-
-use crate::bitset::BitSet;
 
 use super::{LiveRegion, StackObjId};
 
@@ -28,6 +24,30 @@ pub(crate) struct ExactPackResult {
     pub(crate) max_used: u32,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct ExactPackWorkspace<Idx> {
+    placed: Vec<(u32, u32, Idx)>,
+    occupied: Vec<(u32, u32)>,
+}
+
+impl<Idx> Default for ExactPackWorkspace<Idx> {
+    fn default() -> Self {
+        Self {
+            placed: Vec::new(),
+            occupied: Vec::new(),
+        }
+    }
+}
+
+impl<Idx> ExactPackWorkspace<Idx> {
+    pub(crate) fn with_capacity(item_count: usize) -> Self {
+        Self {
+            placed: Vec::with_capacity(item_count),
+            occupied: Vec::with_capacity(item_count),
+        }
+    }
+}
+
 pub(crate) fn pack_objects_presorted(
     objects: &[PackedObject],
 ) -> (FxHashMap<StackObjId, u32>, u32) {
@@ -44,7 +64,7 @@ pub(crate) fn pack_objects_presorted(
         let off = first_fit_above(
             object.min_offset_words,
             object.size_words,
-            occupied_ranges(
+            &occupied_ranges(
                 placed
                     .iter()
                     .filter(|(_, _, placed_object)| placed_object.region.overlaps(&object.region))
@@ -67,15 +87,16 @@ pub(crate) fn pack_objects_presorted(
     (offsets, max_used)
 }
 
-pub(crate) fn pack_exact_with_offsets<Idx>(
+pub(crate) fn pack_exact_with_offsets_by<Idx>(
     items: &[ExactPackItem<Idx>],
-    conflicts: &[BitSet<Idx>],
+    mut conflicts: impl FnMut(Idx, Idx) -> bool,
+    workspace: &mut ExactPackWorkspace<Idx>,
 ) -> ExactPackResult
 where
-    Idx: EntityRef + Copy + Eq + Hash,
+    Idx: Copy,
 {
+    workspace.placed.clear();
     let mut offsets = FxHashMap::with_capacity_and_hasher(items.len(), Default::default());
-    let mut placed: Vec<(u32, u32, Idx, u32)> = Vec::with_capacity(items.len());
     let mut max_used = 0u32;
 
     for item in items {
@@ -87,55 +108,104 @@ where
         let off = first_fit_above(
             item.min_offset_words,
             item.size_words,
-            occupied_ranges(placed.iter().filter_map(|(off, end, placed_idx, _)| {
-                conflicts[item.idx.index()]
-                    .contains(*placed_idx)
-                    .then_some((*off, *end))
-            })),
+            occupied_ranges_for_item(
+                item.idx,
+                &workspace.placed,
+                &mut conflicts,
+                &mut workspace.occupied,
+            ),
         );
         offsets.insert(item.id, off);
-        max_used = max_used.max(
-            off.checked_add(item.size_words)
-                .expect("locals size overflow"),
-        );
-        placed.push((
-            off,
-            off.checked_add(item.size_words)
-                .expect("locals size overflow"),
-            item.idx,
-            item.size_words,
-        ));
+        let end = off
+            .checked_add(item.size_words)
+            .expect("locals size overflow");
+        max_used = max_used.max(end);
+        workspace.placed.push((off, end, item.idx));
     }
 
     ExactPackResult { offsets, max_used }
 }
 
-pub(crate) fn pack_exact_peak<Idx>(items: &[ExactPackItem<Idx>], conflicts: &[BitSet<Idx>]) -> u32
+pub(crate) fn pack_exact_peak_by<Idx>(
+    items: &[ExactPackItem<Idx>],
+    mut conflicts: impl FnMut(Idx, Idx) -> bool,
+    workspace: &mut ExactPackWorkspace<Idx>,
+) -> u32
 where
-    Idx: EntityRef + Copy + Eq + Hash,
+    Idx: Copy,
 {
-    pack_exact_with_offsets(items, conflicts).max_used
+    workspace.placed.clear();
+    let mut max_used = 0u32;
+
+    for item in items {
+        if item.size_words == 0 {
+            continue;
+        }
+
+        let off = first_fit_above(
+            item.min_offset_words,
+            item.size_words,
+            occupied_ranges_for_item(
+                item.idx,
+                &workspace.placed,
+                &mut conflicts,
+                &mut workspace.occupied,
+            ),
+        );
+        let end = off
+            .checked_add(item.size_words)
+            .expect("locals size overflow");
+        max_used = max_used.max(end);
+        workspace.placed.push((off, end, item.idx));
+    }
+
+    max_used
+}
+
+fn occupied_ranges_for_item<'a, Idx>(
+    item_idx: Idx,
+    placed: &[(u32, u32, Idx)],
+    conflicts: &mut impl FnMut(Idx, Idx) -> bool,
+    occupied: &'a mut Vec<(u32, u32)>,
+) -> &'a [(u32, u32)]
+where
+    Idx: Copy,
+{
+    occupied.clear();
+    occupied.extend(placed.iter().filter_map(|(off, end, placed_idx)| {
+        conflicts(item_idx, *placed_idx).then_some((*off, *end))
+    }));
+    merge_occupied_ranges(occupied);
+    occupied
 }
 
 fn occupied_ranges(occupied: impl Iterator<Item = (u32, u32)>) -> Vec<(u32, u32)> {
     let mut occupied: Vec<_> = occupied.collect();
-    occupied.sort_unstable();
-    let mut merged = Vec::with_capacity(occupied.len());
-    for (start, end) in occupied {
-        if let Some((_, merged_end)) = merged.last_mut()
-            && start <= *merged_end
-        {
-            *merged_end = (*merged_end).max(end);
-        } else {
-            merged.push((start, end));
-        }
-    }
-    merged
+    merge_occupied_ranges(&mut occupied);
+    occupied
 }
 
-fn first_fit_above(min_offset_words: u32, size_words: u32, occupied: Vec<(u32, u32)>) -> u32 {
+fn merge_occupied_ranges(occupied: &mut Vec<(u32, u32)>) {
+    if occupied.is_empty() {
+        return;
+    }
+    occupied.sort_unstable();
+    let mut write_idx = 0usize;
+    for read_idx in 1..occupied.len() {
+        let (start, end) = occupied[read_idx];
+        if start <= occupied[write_idx].1 {
+            occupied[write_idx].1 = occupied[write_idx].1.max(end);
+        } else {
+            write_idx += 1;
+            occupied[write_idx] = (start, end);
+        }
+    }
+    occupied.truncate(write_idx + 1);
+}
+
+fn first_fit_above(min_offset_words: u32, size_words: u32, occupied: &[(u32, u32)]) -> u32 {
     let mut cursor = min_offset_words;
-    for (start, end) in occupied {
+    for &(start, end) in occupied {
         if end <= cursor {
             continue;
         }
@@ -148,4 +218,47 @@ fn first_fit_above(min_offset_words: u32, size_words: u32, occupied: Vec<(u32, u
         cursor = cursor.max(end);
     }
     cursor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitset::BitSet;
+    use cranelift_entity::EntityRef;
+
+    #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+    struct TestIdx(u32);
+    cranelift_entity::entity_impl!(TestIdx);
+
+    fn item(idx: u32, size_words: u32, min_offset_words: u32) -> ExactPackItem<TestIdx> {
+        ExactPackItem {
+            id: StackObjId::new(idx as usize + 1),
+            idx: TestIdx::new(idx as usize),
+            size_words,
+            min_offset_words,
+        }
+    }
+
+    #[test]
+    fn exact_peak_by_matches_bitset_peak_without_offsets() {
+        let items = vec![item(0, 3, 0), item(1, 2, 1), item(2, 1, 5)];
+        let mut conflicts = vec![BitSet::default(); 3];
+        let _ = conflicts[0].insert(TestIdx::new(1));
+        let _ = conflicts[1].insert(TestIdx::new(0));
+
+        let mut workspace = ExactPackWorkspace::default();
+        let peak = pack_exact_peak_by(
+            &items,
+            |lhs, rhs| conflicts[lhs.index()].contains(rhs),
+            &mut workspace,
+        );
+
+        let mut offset_workspace = ExactPackWorkspace::default();
+        let packed = pack_exact_with_offsets_by(
+            &items,
+            |lhs, rhs| conflicts[lhs.index()].contains(rhs),
+            &mut offset_workspace,
+        );
+        assert_eq!(peak, packed.max_used);
+    }
 }

--- a/crates/codegen/src/optim/adce.rs
+++ b/crates/codegen/src/optim/adce.rs
@@ -1,13 +1,12 @@
 //! This module contains a solver for `Aggressive Dead code elimination (ADCE)`.
 
-use std::collections::BTreeSet;
-
 use cranelift_entity::SecondaryMap;
 use rustc_hash::FxHashSet;
-use sonatina_ir::{BlockId, Function, InstId};
+use sonatina_ir::{BlockId, ControlFlowGraph, Function, InstId};
 
 use crate::{
     cfg_edit::{CfgEditor, CleanupMode},
+    cfg_scc::{CfgSccAnalysis, SccId},
     optim::{call_purity::is_nonmutating_returning_call, cfg_cleanup::CfgCleanup},
     post_domtree::{PDFSet, PDTIdom, PostDomTree},
 };
@@ -15,26 +14,35 @@ use crate::{
 pub struct AdceSolver {
     live_insts: SecondaryMap<InstId, bool>,
     live_blocks: SecondaryMap<BlockId, bool>,
-    empty_blocks: BTreeSet<BlockId>,
     post_domtree: PostDomTree,
     worklist: Vec<InstId>,
+    call_policy: AdceCallPolicy,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdceCallPolicy {
+    ConservativeCalls,
+    UseCurrentFuncEffects,
 }
 
 impl AdceSolver {
     pub fn new() -> Self {
+        Self::with_call_policy(AdceCallPolicy::ConservativeCalls)
+    }
+
+    pub fn with_call_policy(call_policy: AdceCallPolicy) -> Self {
         Self {
             live_insts: SecondaryMap::default(),
             live_blocks: SecondaryMap::default(),
-            empty_blocks: BTreeSet::default(),
             post_domtree: PostDomTree::default(),
             worklist: Vec::default(),
+            call_policy,
         }
     }
 
     pub fn clear(&mut self) {
         self.live_insts.clear();
         self.live_blocks.clear();
-        self.empty_blocks.clear();
         self.post_domtree.clear();
         self.worklist.clear();
     }
@@ -52,14 +60,10 @@ impl AdceSolver {
     fn run_dce(&mut self, func: &mut Function) -> bool {
         self.clear();
 
-        self.post_domtree.compute(func);
+        let divergent_blocks = divergent_blocks(func);
+        self.post_domtree
+            .compute_with_extra_exits(func, &divergent_blocks);
         let pdf_set = self.post_domtree.compute_df();
-
-        // TODO: We should remove this restriction.
-        // ref: <https://reviews.llvm.org/D35851>
-        if self.has_infinite_loop(func) {
-            return false;
-        }
 
         // The entry block must always be live — removing it would shift
         // the layout so a different block becomes the entry, breaking
@@ -73,9 +77,15 @@ impl AdceSolver {
 
         for block in func.layout.iter_block() {
             for inst in func.layout.iter_inst(block) {
-                if is_live_root_inst(func, inst) {
+                if is_live_root_inst(func, inst, self.call_policy) {
                     self.mark_inst(func, inst);
                 }
+            }
+        }
+        for block in divergent_blocks {
+            self.mark_block(block);
+            if let Some(term) = func.layout.last_inst_of(block) {
+                self.mark_inst(func, term);
             }
         }
 
@@ -84,16 +94,6 @@ impl AdceSolver {
         }
 
         self.eliminate_dead_code(func)
-    }
-
-    fn has_infinite_loop(&self, func: &Function) -> bool {
-        for block in func.layout.iter_block() {
-            if !self.post_domtree.is_reachable(block) {
-                return true;
-            }
-        }
-
-        false
     }
 
     fn mark_inst(&mut self, func: &Function, inst: InstId) {
@@ -245,6 +245,32 @@ impl AdceSolver {
     }
 }
 
+fn divergent_blocks(func: &Function) -> Vec<BlockId> {
+    let mut cfg = ControlFlowGraph::new();
+    cfg.compute(func);
+
+    let mut sccs = CfgSccAnalysis::new();
+    sccs.compute(&cfg);
+
+    let mut reaches_real_exit = SecondaryMap::<SccId, bool>::with_capacity(sccs.scc_count());
+    for &scc in sccs.topo_order().iter().rev() {
+        let data = sccs.scc_data(scc);
+        reaches_real_exit[scc] = data
+            .blocks_rpo
+            .iter()
+            .any(|block| cfg.exits.contains(block))
+            || data.succ_sccs.iter().any(|&succ| reaches_real_exit[succ]);
+    }
+
+    let mut blocks = Vec::new();
+    for &scc in sccs.topo_order() {
+        if !reaches_real_exit[scc] {
+            blocks.extend(sccs.scc_data(scc).blocks_rpo.iter().copied());
+        }
+    }
+    blocks
+}
+
 fn erase_closed_dead_insts(func: &mut Function, insts: impl IntoIterator<Item = InstId>) -> bool {
     let mut dead_insts = Vec::new();
     let mut dead_set = FxHashSet::default();
@@ -285,11 +311,17 @@ impl Default for AdceSolver {
     }
 }
 
-fn is_live_root_inst(func: &Function, inst_id: InstId) -> bool {
+fn is_live_root_inst(func: &Function, inst_id: InstId, call_policy: AdceCallPolicy) -> bool {
     if func.dfg.call_info(inst_id).is_some() {
-        // ADCE may erase whole unused read-only calls, so only calls that can
-        // mutate state or escape local control remain liveness roots.
-        return !is_nonmutating_returning_call(func, inst_id);
+        return match call_policy {
+            AdceCallPolicy::ConservativeCalls => true,
+            AdceCallPolicy::UseCurrentFuncEffects => {
+                // ADCE may erase whole unused read-only calls only when the
+                // caller guarantees function-effect summaries match the current
+                // call ABI and function bodies.
+                !is_nonmutating_returning_call(func, inst_id)
+            }
+        };
     }
 
     func.dfg.may_mutate_state(inst_id) || func.dfg.may_transfer_control(inst_id)
@@ -297,11 +329,11 @@ fn is_live_root_inst(func: &Function, inst_id: InstId) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use sonatina_ir::{Module, ir_writer::FuncWriter};
+    use sonatina_ir::{FuncEffectSummary, Module, ir_writer::FuncWriter};
 
     use crate::analysis::func_behavior;
 
-    use super::AdceSolver;
+    use super::{AdceCallPolicy, AdceSolver};
 
     fn parse_module(input: &str) -> sonatina_parser::ParsedModule {
         sonatina_parser::parse_module(input).unwrap_or_else(|errs| panic!("parse failed: {errs:?}"))
@@ -319,6 +351,19 @@ mod tests {
             .into_iter()
             .find(|&func_ref| module.ctx.func_sig(func_ref, |sig| sig.name() == name))
             .unwrap_or_else(|| panic!("missing function {name}"))
+    }
+
+    fn run_default_adce(input: &str) -> (bool, String) {
+        let parsed = parse_module(input);
+        let func_ref = only_func_ref(&parsed.module);
+        let changed = parsed
+            .module
+            .func_store
+            .modify(func_ref, |func| AdceSolver::new().run(func));
+        let dumped = parsed.module.func_store.view(func_ref, |func| {
+            FuncWriter::new(func_ref, func).dump_string()
+        });
+        (changed, dumped)
     }
 
     #[test]
@@ -344,25 +389,131 @@ func private %f(v0.i256) -> i256 {
 }
 "#;
 
+        let (_, dumped) = run_default_adce(source);
+        assert!(
+            dumped.contains("phi (v0 block0)") && dumped.contains("block0:\n        jump block1;"),
+            "ADCE must keep the entry predecessor for live phi values:\n{dumped}"
+        );
+    }
+
+    #[test]
+    fn preserves_branch_to_infinite_loop() {
+        let source = r#"
+target = "evm-ethereum-osaka"
+
+func private %f(v0.i1) -> i256 {
+    block0:
+        br v0 block1 block2;
+
+    block1:
+        jump block1;
+
+    block2:
+        return 7.i256;
+}
+"#;
+
+        let (_, dumped) = run_default_adce(source);
+        assert!(
+            dumped.contains("br v0 block1 block2;")
+                && dumped.contains("block1:\n        jump block1;")
+                && dumped.contains("return 7.i256;"),
+            "ADCE must preserve divergence as control behavior:\n{dumped}"
+        );
+    }
+
+    #[test]
+    fn removes_dead_ssa_cycle_in_infinite_loop() {
+        let source = r#"
+target = "evm-ethereum-osaka"
+
+func private %f(v0.i1) {
+    block0:
+        br v0 block1 block2;
+
+    block1:
+        v1.i256 = phi (1.i256 block0) (v2 block1);
+        v2.i256 = add v1 1.i256;
+        jump block1;
+
+    block2:
+        return;
+}
+"#;
+
+        let (changed, dumped) = run_default_adce(source);
+        assert!(changed);
+        assert!(
+            !dumped.contains(" = phi ") && !dumped.contains(" = add "),
+            "ADCE should remove unused pure cycles inside divergent regions:\n{dumped}"
+        );
+        assert!(
+            dumped.contains("block1:\n        jump block1;"),
+            "ADCE should keep the divergent control sink:\n{dumped}"
+        );
+    }
+
+    #[test]
+    fn runs_on_function_with_no_real_exit() {
+        let source = r#"
+target = "evm-ethereum-osaka"
+
+func private %f() {
+    block0:
+        v0.i256 = add 1.i256 2.i256;
+        jump block0;
+}
+"#;
+
+        let (changed, dumped) = run_default_adce(source);
+        assert!(changed);
+        assert!(
+            !dumped.contains(" = add ") && dumped.contains("jump block0;"),
+            "ADCE should remove dead pure code even when the function never returns:\n{dumped}"
+        );
+    }
+
+    #[test]
+    fn removes_unused_read_only_call() {
+        let source = r#"
+target = "evm-ethereum-osaka"
+
+func private %reader(v0.i256) -> i256 {
+    block0:
+        v1.i256 = evm_sload v0;
+        return v1;
+}
+
+func public %caller(v0.i256) -> i256 {
+    block0:
+        v1.i256 = call %reader v0;
+        return 7.i256;
+}
+"#;
+
         let parsed = parse_module(source);
-        let func_ref = only_func_ref(&parsed.module);
+        func_behavior::analyze_module(&parsed.module);
+        let func_ref = find_func(&parsed.module, "caller");
 
         parsed.module.func_store.modify(func_ref, |func| {
-            AdceSolver::new().run(func);
+            AdceSolver::with_call_policy(AdceCallPolicy::UseCurrentFuncEffects).run(func);
         });
 
         parsed.module.func_store.view(func_ref, |func| {
             let dumped = FuncWriter::new(func_ref, func).dump_string();
             assert!(
-                dumped.contains("phi (v0 block0)")
-                    && dumped.contains("block0:\n        jump block1;"),
-                "ADCE must keep the entry predecessor for live phi values:\n{dumped}"
+                !dumped.contains("call %reader"),
+                "ADCE should remove unused read-only calls:\n{dumped}"
+            );
+            assert!(
+                dumped.contains("return 7.i256;"),
+                "caller should still return the live constant:\n{dumped}"
             );
         });
     }
 
     #[test]
-    fn removes_unused_read_only_call() {
+    fn conservative_call_policy_keeps_unused_read_only_call() {
         let source = r#"
 target = "evm-ethereum-osaka"
 
@@ -390,12 +541,52 @@ func public %caller(v0.i256) -> i256 {
         parsed.module.func_store.view(func_ref, |func| {
             let dumped = FuncWriter::new(func_ref, func).dump_string();
             assert!(
-                !dumped.contains("call %reader"),
-                "ADCE should remove unused read-only calls:\n{dumped}"
+                dumped.contains("call %reader"),
+                "conservative ADCE must keep calls even when stale summaries would classify them as elidable:\n{dumped}"
             );
+        });
+    }
+
+    #[test]
+    fn conservative_call_policy_keeps_out_pointer_call_with_stale_pure_summary() {
+        let source = r#"
+target = "evm-ethereum-osaka"
+
+func private %fill(v0.*i256) {
+    block0:
+        mstore v0 42.i256 i256;
+        return;
+}
+
+func public %caller() -> i256 {
+    block0:
+        v0.*i256 = alloca i256;
+        call %fill v0;
+        v1.i256 = mload v0 i256;
+        return v1;
+}
+"#;
+
+        let parsed = parse_module(source);
+        let fill = find_func(&parsed.module, "fill");
+        parsed.module.ctx.set_func_effects(
+            fill,
+            FuncEffectSummary {
+                will_return: true,
+                ..FuncEffectSummary::default()
+            },
+        );
+        let caller = find_func(&parsed.module, "caller");
+
+        parsed.module.func_store.modify(caller, |func| {
+            AdceSolver::new().run(func);
+        });
+
+        parsed.module.func_store.view(caller, |func| {
+            let dumped = FuncWriter::new(caller, func).dump_string();
             assert!(
-                dumped.contains("return 7.i256;"),
-                "caller should still return the live constant:\n{dumped}"
+                dumped.contains("call %fill"),
+                "conservative ADCE must not trust stale pure summaries for out-pointer calls:\n{dumped}"
             );
         });
     }
@@ -427,23 +618,15 @@ func private %f(v0.i1) {
 }
 "#;
 
-        let parsed = parse_module(source);
-        let func_ref = only_func_ref(&parsed.module);
-
-        parsed.module.func_store.modify(func_ref, |func| {
-            assert!(AdceSolver::new().run(func));
-        });
-
-        parsed.module.func_store.view(func_ref, |func| {
-            let dumped = FuncWriter::new(func_ref, func).dump_string();
-            assert!(
-                !dumped.contains("insert_value") && !dumped.contains("@pair = phi"),
-                "ADCE should remove the unused aggregate cycle:\n{dumped}"
-            );
-            assert!(
-                dumped.contains("return;"),
-                "ADCE should preserve live control flow:\n{dumped}"
-            );
-        });
+        let (changed, dumped) = run_default_adce(source);
+        assert!(changed);
+        assert!(
+            !dumped.contains("insert_value") && !dumped.contains("@pair = phi"),
+            "ADCE should remove the unused aggregate cycle:\n{dumped}"
+        );
+        assert!(
+            dumped.contains("return;"),
+            "ADCE should preserve live control flow:\n{dumped}"
+        );
     }
 }

--- a/crates/codegen/src/optim/pipeline.rs
+++ b/crates/codegen/src/optim/pipeline.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use super::{
-    adce::AdceSolver,
+    adce::{AdceCallPolicy, AdceSolver},
     aggregate::{
         AggregateCombine, AggregateScalarize, LocalObjectArgMap, ObjectEffectSummaryMap,
         ObjectLoadStore, ObjectMemoryAnalysis, collect_local_object_arg_info,
@@ -794,7 +794,7 @@ fn run_pass(
         }
         Pass::Adce => {
             let _span = trace_span!("sonatina.optim.pipeline.pass.adce").entered();
-            AdceSolver::new().run(func)
+            AdceSolver::with_call_policy(AdceCallPolicy::UseCurrentFuncEffects).run(func)
         }
         Pass::Licm => {
             let _span = trace_span!("sonatina.optim.pipeline.pass.licm").entered();

--- a/crates/codegen/src/optim/sccp.rs
+++ b/crates/codegen/src/optim/sccp.rs
@@ -22,7 +22,7 @@ use sonatina_ir::{
 };
 
 use super::{
-    adce::AdceSolver,
+    adce::{AdceCallPolicy, AdceSolver},
     cfg_cleanup::CfgCleanup,
     const_eval::{BlockEdge, ConstPathAnalysis, analyze_const_paths, collect_constref_value_tys},
     sccp_simplify::{AuxDeps, SimplifyAction, SimplifyCtx, simplify_inst},
@@ -135,7 +135,7 @@ impl SccpSolver {
         changed |= CfgCleanup::new(cleanup_mode).run(func);
         cfg.compute(func);
 
-        changed |= AdceSolver::new().run(func);
+        changed |= AdceSolver::with_call_policy(AdceCallPolicy::UseCurrentFuncEffects).run(func);
         cfg.compute(func);
         changed
     }

--- a/crates/codegen/src/post_domtree.rs
+++ b/crates/codegen/src/post_domtree.rs
@@ -36,6 +36,10 @@ impl PostDomTree {
     }
 
     pub fn compute(&mut self, func: &Function) {
+        self.compute_with_extra_exits(func, &[]);
+    }
+
+    pub fn compute_with_extra_exits(&mut self, func: &Function, extra_exits: &[BlockId]) {
         self.clear();
 
         self.rcfg.compute(func);
@@ -51,10 +55,15 @@ impl PostDomTree {
         self.rcfg.add_succ_block(self.entry, real_entry);
         self.rcfg.add_succ_block(self.entry, self.exit);
 
-        // Add edges from real exit blocks to dummy exit block.
-        let real_exits = std::mem::take(&mut self.rcfg.exits);
-        for exit in &real_exits {
-            self.rcfg.add_succ_block(*exit, self.exit);
+        // Add edges from real and virtual exit blocks to dummy exit block.
+        let mut exits = std::mem::take(&mut self.rcfg.exits);
+        for &exit in extra_exits {
+            if !exits.contains(&exit) {
+                exits.push(exit);
+            }
+        }
+        for exit in exits {
+            self.rcfg.add_succ_block(exit, self.exit);
         }
 
         self.rcfg.reverse_edges(self.exit, &[self.entry]);

--- a/crates/codegen/src/stackalloc/stackify/alloc.rs
+++ b/crates/codegen/src/stackalloc/stackify/alloc.rs
@@ -3,8 +3,16 @@ use sonatina_ir::{BlockId, Function, InstId, ValueId};
 
 use crate::{
     analysis::memory_access::ExactLocalAddr,
+    isa::evm::static_arena_alloc::StackObjId,
     stackalloc::{Action, Actions, Allocator},
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SpillStorage {
+    Scratch(u32),
+    Object(StackObjId),
+    ExactLocal(ExactLocalAddr),
+}
 
 #[derive(Clone, Default)]
 pub struct StackifyAlloc {
@@ -14,8 +22,8 @@ pub struct StackifyAlloc {
     /// `br_table` lowering uses per-case action sequences stored in IR case order.
     pub(super) brtable_actions: SecondaryMap<InstId, Vec<Actions>>,
 
-    pub(crate) spill_obj:
-        SecondaryMap<ValueId, Option<crate::isa::evm::static_arena_alloc::StackObjId>>,
+    pub(crate) spill_storage: SecondaryMap<ValueId, Option<SpillStorage>>,
+    pub(crate) spill_obj: SecondaryMap<ValueId, Option<StackObjId>>,
     pub(crate) scratch_slot_of_value: SecondaryMap<ValueId, Option<u32>>,
     pub(crate) exact_local_addr: SecondaryMap<ValueId, Option<ExactLocalAddr>>,
 }
@@ -25,6 +33,99 @@ impl StackifyAlloc {
         self.scratch_slot_of_value
             .values()
             .any(|slot| slot.is_some())
+    }
+
+    pub(crate) fn storage_for_value(&self, value: ValueId) -> Option<SpillStorage> {
+        self.spill_storage[value]
+    }
+
+    pub(crate) fn for_each_action(&self, mut f: impl FnMut(&Action)) {
+        for actions in self.pre_actions.values() {
+            for action in actions {
+                f(action);
+            }
+        }
+        for actions in self.post_actions.values() {
+            for action in actions {
+                f(action);
+            }
+        }
+        for cases in self.brtable_actions.values() {
+            for actions in cases {
+                for action in actions {
+                    f(action);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn validate_spill_storage(&self) {
+        for (value, storage) in self.spill_storage.iter() {
+            match storage {
+                Some(SpillStorage::Scratch(slot)) => {
+                    assert_eq!(
+                        self.scratch_slot_of_value[value],
+                        Some(*slot),
+                        "scratch storage map drift for value {}",
+                        value.as_u32()
+                    );
+                    assert_eq!(
+                        self.spill_obj[value],
+                        None,
+                        "scratch-spilled value {} must not have object storage",
+                        value.as_u32()
+                    );
+                }
+                Some(SpillStorage::Object(obj)) => {
+                    assert_eq!(
+                        self.spill_obj[value],
+                        Some(*obj),
+                        "object storage map drift for value {}",
+                        value.as_u32()
+                    );
+                    assert_eq!(
+                        self.scratch_slot_of_value[value],
+                        None,
+                        "object-spilled value {} must not have scratch storage",
+                        value.as_u32()
+                    );
+                }
+                Some(SpillStorage::ExactLocal(exact)) => {
+                    assert_eq!(
+                        self.exact_local_addr[value],
+                        Some(*exact),
+                        "exact local storage map drift for value {}",
+                        value.as_u32()
+                    );
+                }
+                None => {
+                    assert_eq!(
+                        self.scratch_slot_of_value[value],
+                        None,
+                        "unspilled value {} must not have scratch storage",
+                        value.as_u32()
+                    );
+                    assert_eq!(
+                        self.spill_obj[value],
+                        None,
+                        "unspilled value {} must not have object storage",
+                        value.as_u32()
+                    );
+                }
+            }
+        }
+
+        self.for_each_action(|action| {
+            if let Action::MemLoadObj(id) | Action::MemStoreObj(id) = action {
+                assert!(
+                    self.spill_storage.values().any(
+                        |storage| matches!(storage, Some(SpillStorage::Object(obj)) if obj == id)
+                    ),
+                    "stackify emitted object action for non-object spill {}",
+                    id.as_u32()
+                );
+            }
+        });
     }
 }
 
@@ -36,14 +137,16 @@ impl Allocator for StackifyAlloc {
                 idx < super::DUP_MAX,
                 "function arg depth exceeds DUP16 reach"
             );
-            if self.exact_local_addr[arg].is_some() {
-                continue;
-            } else if let Some(slot) = self.scratch_slot_of_value[arg] {
-                act.push(Action::StackDup(idx as u8));
-                act.push(Action::MemStoreAbs(slot * 32));
-            } else if let Some(obj) = self.spill_obj[arg] {
-                act.push(Action::StackDup(idx as u8));
-                act.push(Action::MemStoreObj(obj));
+            match self.storage_for_value(arg) {
+                Some(SpillStorage::Scratch(slot)) => {
+                    act.push(Action::StackDup(idx as u8));
+                    act.push(Action::MemStoreAbs(slot * 32));
+                }
+                Some(SpillStorage::Object(obj)) => {
+                    act.push(Action::StackDup(idx as u8));
+                    act.push(Action::MemStoreObj(obj));
+                }
+                Some(SpillStorage::ExactLocal(_)) | None => {}
             }
         }
         act

--- a/crates/codegen/src/stackalloc/stackify/builder.rs
+++ b/crates/codegen/src/stackalloc/stackify/builder.rs
@@ -13,7 +13,7 @@ use sonatina_ir::{BlockId, Function, ValueId, cfg::ControlFlowGraph};
 use super::{
     alloc::StackifyAlloc,
     iteration::IterationPlanner,
-    slots::{FreeSlotPools, SpillSlotPools},
+    slots::{FreeSlotPools, SpillSlotInterference, SpillSlotPools},
     spill::SpillSet,
     sym_stack::SymStack,
     templates::{
@@ -70,6 +70,7 @@ pub(super) struct StackifyContext<'a> {
     pub(super) def_info: SecondaryMap<ValueId, Option<DefInfo>>,
     pub(super) phi_results: SecondaryMap<BlockId, SmallVec<[ValueId; 4]>>,
     pub(super) phi_out_sources: SecondaryMap<BlockId, BitSet<ValueId>>,
+    pub(super) spill_slot_interference: SpillSlotInterference,
     pub(super) has_internal_return: bool,
     pub(super) reach: StackifyReachability,
     pub(super) value_aliases: SecondaryMap<ValueId, Option<ValueId>>,
@@ -169,6 +170,15 @@ impl<'a> StackifyBuilder<'a> {
         normalize_alias_map(self.func, &mut value_aliases);
 
         let exact_local_addr = compute_exact_local_addrs(self.func, &value_aliases);
+        let phi_results = compute_phi_results(self.func, &value_aliases);
+        let phi_out_sources = compute_phi_out_sources(self.func, self.cfg, &value_aliases);
+        let spill_slot_interference = SpillSlotInterference::compute(
+            self.func,
+            self.cfg,
+            self.liveness,
+            &phi_results,
+            &value_aliases,
+        );
 
         let ctx = StackifyContext {
             func: self.func,
@@ -181,8 +191,9 @@ impl<'a> StackifyBuilder<'a> {
             scc,
             dom_depth: compute_dom_depth(self.dom, entry),
             def_info: compute_def_info(self.func, entry, &value_aliases),
-            phi_results: compute_phi_results(self.func, &value_aliases),
-            phi_out_sources: compute_phi_out_sources(self.func, self.cfg, &value_aliases),
+            phi_results,
+            phi_out_sources,
+            spill_slot_interference,
             // Internal-return functions expect a caller-provided return address below their args.
             has_internal_return: function_has_internal_return(self.func),
             reach: self.reach,
@@ -233,7 +244,7 @@ impl<'a> StackifyBuilder<'a> {
                     .scratch
                     .try_ensure_slot(
                         spilled,
-                        ctx.liveness,
+                        &ctx.spill_slot_interference,
                         &mut arg_free_slots.scratch,
                         Some(ctx.scratch_spill_slots),
                     )

--- a/crates/codegen/src/stackalloc/stackify/builder.rs
+++ b/crates/codegen/src/stackalloc/stackify/builder.rs
@@ -11,7 +11,7 @@ use smallvec::SmallVec;
 use sonatina_ir::{BlockId, Function, ValueId, cfg::ControlFlowGraph};
 
 use super::{
-    alloc::StackifyAlloc,
+    alloc::{SpillStorage, StackifyAlloc},
     iteration::IterationPlanner,
     slots::{FreeSlotPools, SpillSlotInterference, SpillSlotPools},
     spill::SpillSet,
@@ -210,20 +210,36 @@ impl<'a> StackifyBuilder<'a> {
         // remove it from transfer regions (`T(B)` excludes `spill_set`), so future iterations
         // can rely on loads being correct.
         let mut spill_set: BitSet<ValueId> = BitSet::default();
+        let mut forced_object_spills: BitSet<ValueId> = BitSet::default();
         loop {
             let checkpoint = observer.checkpoint();
             let mut slots: SpillSlotPools = SpillSlotPools::default();
 
-            let (mut alloc, spill_requests) =
-                Self::plan_iteration(&ctx, observer, SpillSet::new(&spill_set), &mut slots);
+            let (mut alloc, spill_requests, object_spill_requests) = Self::plan_iteration(
+                &ctx,
+                observer,
+                SpillSet::new(&spill_set),
+                &forced_object_spills,
+                &mut slots,
+            );
 
-            if spill_requests.is_subset(&spill_set) {
-                alloc.scratch_slot_of_value = slots.scratch.take_slot_map();
+            let spill_stable = spill_requests.is_subset(&spill_set);
+            let object_spills_stable = object_spill_requests.is_subset(&forced_object_spills);
+            if spill_stable && object_spills_stable {
+                Self::finalize_spill_storage(
+                    &ctx,
+                    SpillSet::new(&spill_set),
+                    &forced_object_spills,
+                    &mut slots,
+                    &mut alloc,
+                );
+                alloc.validate_spill_storage();
                 return alloc;
             }
 
             observer.rollback(checkpoint);
             spill_set.union_with(&spill_requests);
+            forced_object_spills.union_with(&object_spill_requests);
         }
     }
 
@@ -231,15 +247,18 @@ impl<'a> StackifyBuilder<'a> {
         ctx: &StackifyContext<'_>,
         observer: &mut O,
         spill: SpillSet<'_>,
+        forced_object_spills: &BitSet<ValueId>,
         slots: &mut SpillSlotPools,
-    ) -> (StackifyAlloc, BitSet<ValueId>) {
+    ) -> (StackifyAlloc, BitSet<ValueId>, BitSet<ValueId>) {
+        let mut object_spill_requests: BitSet<ValueId> = BitSet::default();
         let mut arg_free_slots: FreeSlotPools = FreeSlotPools::default();
         for &arg in ctx.func.arg_values.iter() {
             let arg = ctx.canonicalize_value(arg);
             if let Some(spilled) = spill.spilled(arg)
-                && ctx.scratch_spill_slots != 0
                 && ctx.exact_local_addr[arg].is_none()
+                && ctx.scratch_spill_slots != 0
                 && !ctx.scratch_live_values.contains(arg)
+                && !forced_object_spills.contains(arg)
                 && slots
                     .scratch
                     .try_ensure_slot(
@@ -248,9 +267,9 @@ impl<'a> StackifyBuilder<'a> {
                         &mut arg_free_slots.scratch,
                         Some(ctx.scratch_spill_slots),
                     )
-                    .is_some()
+                    .is_none()
             {
-                continue;
+                object_spill_requests.insert(arg);
             }
         }
 
@@ -263,6 +282,7 @@ impl<'a> StackifyBuilder<'a> {
             pre_actions: SecondaryMap::new(),
             post_actions: SecondaryMap::new(),
             brtable_actions: SecondaryMap::new(),
+            spill_storage: SecondaryMap::new(),
             spill_obj,
             scratch_slot_of_value: SecondaryMap::new(),
             exact_local_addr: ctx.exact_local_addr.clone(),
@@ -289,12 +309,61 @@ impl<'a> StackifyBuilder<'a> {
             &interfaces.carry_in,
             &mut alloc,
             &mut spill_requests,
+            &mut object_spill_requests,
+            forced_object_spills,
             inherited_stack,
             observer,
         );
         planner.plan_blocks();
 
-        (alloc, spill_requests)
+        (alloc, spill_requests, object_spill_requests)
+    }
+
+    fn finalize_spill_storage(
+        ctx: &StackifyContext<'_>,
+        spill: SpillSet<'_>,
+        forced_object_spills: &BitSet<ValueId>,
+        slots: &mut SpillSlotPools,
+        alloc: &mut StackifyAlloc,
+    ) {
+        let scratch_slots = slots.scratch.take_slot_map();
+        let raw_spill_obj = alloc.spill_obj.clone();
+        let mut spill_storage: SecondaryMap<ValueId, Option<SpillStorage>> = SecondaryMap::new();
+        let mut spill_obj: SecondaryMap<
+            ValueId,
+            Option<crate::isa::evm::static_arena_alloc::StackObjId>,
+        > = SecondaryMap::new();
+        let mut scratch_slot_of_value: SecondaryMap<ValueId, Option<u32>> = SecondaryMap::new();
+        for value in ctx.func.dfg.value_ids() {
+            let _ = &mut spill_storage[value];
+            let _ = &mut spill_obj[value];
+            let _ = &mut scratch_slot_of_value[value];
+        }
+
+        for value in spill.bitset().iter() {
+            if let Some(exact) = ctx.exact_local_addr[value] {
+                spill_storage[value] = Some(SpillStorage::ExactLocal(exact));
+            } else if ctx.scratch_spill_slots == 0
+                || ctx.scratch_live_values.contains(value)
+                || forced_object_spills.contains(value)
+            {
+                let obj = raw_spill_obj[value].expect("object spill missing stack object id");
+                spill_storage[value] = Some(SpillStorage::Object(obj));
+                spill_obj[value] = Some(obj);
+            } else if let Some(slot) = scratch_slots[value] {
+                spill_storage[value] = Some(SpillStorage::Scratch(slot));
+                scratch_slot_of_value[value] = Some(slot);
+            } else {
+                panic!(
+                    "spilled value {} has no stable scratch slot or object storage",
+                    value.as_u32()
+                );
+            }
+        }
+
+        alloc.spill_storage = spill_storage;
+        alloc.spill_obj = spill_obj;
+        alloc.scratch_slot_of_value = scratch_slot_of_value;
     }
 }
 

--- a/crates/codegen/src/stackalloc/stackify/iteration.rs
+++ b/crates/codegen/src/stackalloc/stackify/iteration.rs
@@ -33,6 +33,8 @@ pub(super) struct IterationPlanner<'a, 'ctx, O: StackifyObserver> {
     carry_in: &'a SecondaryMap<BlockId, BitSet<ValueId>>,
     alloc: &'a mut StackifyAlloc,
     spill_requests: &'a mut BitSet<ValueId>,
+    object_spill_requests: &'a mut BitSet<ValueId>,
+    forced_object_spills: &'a BitSet<ValueId>,
     inherited_stack: BTreeMap<BlockId, (BlockId, SymStack)>,
     pending_edges: BTreeMap<BlockId, Vec<PendingEdge<O::DeferredExit>>>,
     planned_blocks: BitSet<BlockId>,
@@ -60,6 +62,8 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
         carry_in: &'a SecondaryMap<BlockId, BitSet<ValueId>>,
         alloc: &'a mut StackifyAlloc,
         spill_requests: &'a mut BitSet<ValueId>,
+        object_spill_requests: &'a mut BitSet<ValueId>,
+        forced_object_spills: &'a BitSet<ValueId>,
         inherited_stack: BTreeMap<BlockId, (BlockId, SymStack)>,
         observer: &'a mut O,
     ) -> Self {
@@ -72,6 +76,8 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
             carry_in,
             alloc,
             spill_requests,
+            object_spill_requests,
+            forced_object_spills,
             inherited_stack,
             pending_edges: BTreeMap::new(),
             planned_blocks: BitSet::default(),
@@ -93,6 +99,8 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
             self.ctx,
             &self.alloc.spill_obj,
             &self.alloc.exact_local_addr,
+            self.object_spill_requests,
+            self.forced_object_spills,
             free_slots,
             &mut *self.slots,
         );
@@ -309,6 +317,8 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
                     self.ctx,
                     &self.alloc.spill_obj,
                     &self.alloc.exact_local_addr,
+                    self.object_spill_requests,
+                    self.forced_object_spills,
                     free_slots,
                     &mut *self.slots,
                 );
@@ -328,6 +338,8 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
                     self.ctx,
                     &self.alloc.spill_obj,
                     &self.alloc.exact_local_addr,
+                    self.object_spill_requests,
+                    self.forced_object_spills,
                     free_slots,
                     &mut *self.slots,
                 );
@@ -355,6 +367,8 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
                     self.ctx,
                     &self.alloc.spill_obj,
                     &self.alloc.exact_local_addr,
+                    self.object_spill_requests,
+                    self.forced_object_spills,
                     free_slots,
                     &mut *self.slots,
                 );

--- a/crates/codegen/src/stackalloc/stackify/mod.rs
+++ b/crates/codegen/src/stackalloc/stackify/mod.rs
@@ -13,6 +13,9 @@
 //! - When a value cannot be duplicated from within `DUP16` reach, it is added to `spill_set`,
 //!   assigned a stack object, and reloaded from memory; `spill_set` is discovered via a
 //!   monotone fixed point.
+//! - Scratch spill slots use block liveness plus phi-edge interference, because phi sources and
+//!   results are simultaneous edge assignments even though normal liveness treats phi operands as
+//!   predecessor-tail uses.
 //!
 //! Notes specific to this codebase:
 //! - Critical edges must be split before running this allocator.

--- a/crates/codegen/src/stackalloc/stackify/planner/control_flow.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/control_flow.rs
@@ -200,6 +200,8 @@ block1:
             spill_set.insert(second_phi);
 
             let mut spill_requests = crate::bitset::BitSet::default();
+            let mut object_spill_requests = crate::bitset::BitSet::default();
+            let forced_object_spills = crate::bitset::BitSet::default();
             let spill_obj: SecondaryMap<ValueId, Option<_>> = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -223,6 +225,8 @@ block1:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );
@@ -316,6 +320,8 @@ block1:
             spill_set.insert(spilled_phi);
 
             let mut spill_requests = crate::bitset::BitSet::default();
+            let mut object_spill_requests = crate::bitset::BitSet::default();
+            let forced_object_spills = crate::bitset::BitSet::default();
             let spill_obj: SecondaryMap<ValueId, Option<_>> = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -339,6 +345,8 @@ block1:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );

--- a/crates/codegen/src/stackalloc/stackify/planner/control_flow.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/control_flow.rs
@@ -38,8 +38,9 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
             }
         }
 
-        // Memory-only phi results do not participate in the successor's stack template: store
-        // them directly from the incoming source, then normalize only the stack-resident prefix.
+        // Memory-only phi results do not participate in the successor's stack template. Their
+        // spill slots are assigned with phi-edge interference, so stores can be emitted directly
+        // without clobbering later source loads on this edge.
         for &(phi_res, src) in &spilled_phi_pairs {
             self.emit_store_spilled_value_from_source(phi_res, src);
         }
@@ -104,5 +105,263 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
             "stackify supports at most 16 return values for {inst:?}"
         );
         self.normalize_to_exact(ret_vals.as_slice());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        cfg_scc::CfgSccAnalysis,
+        domtree::DomTree,
+        liveness::Liveness,
+        stackalloc::{
+            Action, Actions,
+            stackify::{
+                builder::StackifyReachability,
+                planner::{
+                    MemPlan, NormalizeSearchScratch, Planner,
+                    test_utils::build_stackify_test_context,
+                },
+                slots::{FreeSlotPools, SpillSlotPools},
+                spill::SpillSet,
+                sym_stack::SymStack,
+                templates::BlockTemplate,
+            },
+        },
+    };
+    use cranelift_entity::SecondaryMap;
+    use smallvec::smallvec;
+    use sonatina_ir::{BlockId, ValueId, cfg::ControlFlowGraph};
+    use sonatina_parser::parse_module;
+
+    #[test]
+    fn spilled_phi_edge_slots_keep_parallel_sources_distinct() {
+        let parsed = parse_module(
+            r#"
+target = "evm-ethereum-osaka"
+
+func public %entry(v0.i256) -> i256 {
+block0:
+    v1.i256 = add v0 1.i256;
+    jump block1;
+
+block1:
+    v2.i256 = phi (0.i256 block0);
+    v3.i256 = phi (v1 block0);
+    return v3;
+}
+"#,
+        )
+        .expect("module parses");
+        let func_ref = parsed
+            .module
+            .funcs()
+            .into_iter()
+            .find(|&func| {
+                parsed
+                    .module
+                    .ctx
+                    .func_sig(func, |sig| sig.name() == "entry")
+            })
+            .expect("entry exists");
+
+        parsed.module.func_store.view(func_ref, |func| {
+            let mut cfg = ControlFlowGraph::default();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let mut ctx = build_stackify_test_context(
+                func,
+                &cfg,
+                &dom,
+                &liveness,
+                entry,
+                scc,
+                StackifyReachability::new(16),
+            );
+            ctx.scratch_spill_slots = 3;
+
+            let source = parsed.debug.value(func_ref, "v1").expect("v1");
+            let first_phi = parsed.debug.value(func_ref, "v2").expect("v2");
+            let second_phi = parsed.debug.value(func_ref, "v3").expect("v3");
+
+            let mut spill_set = crate::bitset::BitSet::default();
+            spill_set.insert(source);
+            spill_set.insert(first_phi);
+            spill_set.insert(second_phi);
+
+            let mut spill_requests = crate::bitset::BitSet::default();
+            let spill_obj: SecondaryMap<ValueId, Option<_>> = SecondaryMap::new();
+            let mut free_slots = FreeSlotPools::default();
+            let mut slots = SpillSlotPools::default();
+
+            let spilled_source = SpillSet::new(&spill_set)
+                .spilled(source)
+                .expect("source is spilled");
+            slots
+                .scratch
+                .try_ensure_slot(
+                    spilled_source,
+                    &ctx.spill_slot_interference,
+                    &mut free_slots.scratch,
+                    Some(3),
+                )
+                .expect("source scratch slot");
+
+            let mem = MemPlan::new(
+                SpillSet::new(&spill_set),
+                &mut spill_requests,
+                &ctx,
+                &spill_obj,
+                &ctx.exact_local_addr,
+                &mut free_slots,
+                &mut slots,
+            );
+            let mut stack = SymStack::opaque_prefix_empty(false);
+            let mut actions = Actions::new();
+            let mut search_scratch = NormalizeSearchScratch::default();
+            let mut planner =
+                Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+
+            let mut template = BlockTemplate::new(smallvec![]);
+            template.freeze_transfer(smallvec![]);
+            planner.plan_edge_fixup_to_template(&template, BlockId(0), BlockId(1));
+
+            assert_eq!(
+                actions.as_slice(),
+                &[
+                    Action::Push(sonatina_ir::Immediate::I256(0.into())),
+                    Action::MemStoreAbs(32),
+                    Action::MemLoadAbs(0),
+                    Action::MemStoreAbs(64),
+                ],
+            );
+            assert_eq!(slots.scratch.slot_for(source), Some(0));
+            assert_eq!(slots.scratch.slot_for(first_phi), Some(1));
+            assert_eq!(slots.scratch.slot_for(second_phi), Some(2));
+        });
+    }
+
+    #[test]
+    fn spilled_phi_store_does_not_clobber_later_stack_phi_source() {
+        let parsed = parse_module(
+            r#"
+target = "evm-ethereum-osaka"
+
+func public %entry(v0.i256) -> i256 {
+block0:
+    v1.i256 = add v0 1.i256;
+    jump block1;
+
+block1:
+    v2.i256 = phi (0.i256 block0);
+    v3.i256 = phi (v1 block0);
+    return v3;
+}
+"#,
+        )
+        .expect("module parses");
+        let func_ref = parsed
+            .module
+            .funcs()
+            .into_iter()
+            .find(|&func| {
+                parsed
+                    .module
+                    .ctx
+                    .func_sig(func, |sig| sig.name() == "entry")
+            })
+            .expect("entry exists");
+
+        parsed.module.func_store.view(func_ref, |func| {
+            let mut cfg = ControlFlowGraph::default();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let mut ctx = build_stackify_test_context(
+                func,
+                &cfg,
+                &dom,
+                &liveness,
+                entry,
+                scc,
+                StackifyReachability::new(16),
+            );
+            ctx.scratch_spill_slots = 2;
+
+            let source = parsed.debug.value(func_ref, "v1").expect("v1");
+            let spilled_phi = parsed.debug.value(func_ref, "v2").expect("v2");
+            let stack_phi = parsed.debug.value(func_ref, "v3").expect("v3");
+
+            let mut spill_set = crate::bitset::BitSet::default();
+            spill_set.insert(source);
+            spill_set.insert(spilled_phi);
+
+            let mut spill_requests = crate::bitset::BitSet::default();
+            let spill_obj: SecondaryMap<ValueId, Option<_>> = SecondaryMap::new();
+            let mut free_slots = FreeSlotPools::default();
+            let mut slots = SpillSlotPools::default();
+
+            let spilled_source = SpillSet::new(&spill_set)
+                .spilled(source)
+                .expect("source is spilled");
+            slots
+                .scratch
+                .try_ensure_slot(
+                    spilled_source,
+                    &ctx.spill_slot_interference,
+                    &mut free_slots.scratch,
+                    Some(2),
+                )
+                .expect("source scratch slot");
+
+            let mem = MemPlan::new(
+                SpillSet::new(&spill_set),
+                &mut spill_requests,
+                &ctx,
+                &spill_obj,
+                &ctx.exact_local_addr,
+                &mut free_slots,
+                &mut slots,
+            );
+            let mut stack = SymStack::opaque_prefix_empty(false);
+            let mut actions = Actions::new();
+            let mut search_scratch = NormalizeSearchScratch::default();
+            let mut planner =
+                Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+
+            let mut template = BlockTemplate::new(smallvec![stack_phi]);
+            template.freeze_transfer(smallvec![]);
+            planner.plan_edge_fixup_to_template(&template, BlockId(0), BlockId(1));
+
+            assert_eq!(
+                actions.as_slice(),
+                &[
+                    Action::Push(sonatina_ir::Immediate::I256(0.into())),
+                    Action::MemStoreAbs(32),
+                    Action::MemLoadAbs(0),
+                ],
+            );
+            assert_eq!(slots.scratch.slot_for(source), Some(0));
+            assert_eq!(slots.scratch.slot_for(spilled_phi), Some(1));
+        });
     }
 }

--- a/crates/codegen/src/stackalloc/stackify/planner/mod.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/mod.rs
@@ -27,6 +27,7 @@ pub(super) struct MemPlanSnapshot {
     free_slots: FreeSlotPools,
     slots: SpillSlotPools,
     spill_requests: BitSet<ValueId>,
+    object_spill_requests: BitSet<ValueId>,
 }
 
 pub(super) struct MemPlan<'a> {
@@ -34,6 +35,8 @@ pub(super) struct MemPlan<'a> {
     scratch_spill_slots: u32,
     spill_obj: &'a SecondaryMap<ValueId, Option<crate::isa::evm::static_arena_alloc::StackObjId>>,
     exact_local_addr: &'a SecondaryMap<ValueId, Option<ExactLocalAddr>>,
+    object_spill_requests: &'a mut BitSet<ValueId>,
+    forced_object_spills: &'a BitSet<ValueId>,
     free_slots: &'a mut FreeSlotPools,
     slots: &'a mut SpillSlotPools,
     spill_slot_interference: &'a SpillSlotInterference,
@@ -41,6 +44,7 @@ pub(super) struct MemPlan<'a> {
 }
 
 impl<'a> MemPlan<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         spill: SpillSet<'a>,
         spill_requests: &'a mut BitSet<ValueId>,
@@ -50,6 +54,8 @@ impl<'a> MemPlan<'a> {
             Option<crate::isa::evm::static_arena_alloc::StackObjId>,
         >,
         exact_local_addr: &'a SecondaryMap<ValueId, Option<ExactLocalAddr>>,
+        object_spill_requests: &'a mut BitSet<ValueId>,
+        forced_object_spills: &'a BitSet<ValueId>,
         free_slots: &'a mut FreeSlotPools,
         slots: &'a mut SpillSlotPools,
     ) -> Self {
@@ -58,6 +64,8 @@ impl<'a> MemPlan<'a> {
             scratch_spill_slots: ctx.scratch_spill_slots,
             spill_obj,
             exact_local_addr,
+            object_spill_requests,
+            forced_object_spills,
             free_slots,
             slots,
             spill_slot_interference: &ctx.spill_slot_interference,
@@ -74,6 +82,7 @@ impl<'a> MemPlan<'a> {
             free_slots: self.free_slots.clone(),
             slots: self.slots.clone(),
             spill_requests: self.spill.spill_requests().clone(),
+            object_spill_requests: (*self.object_spill_requests).clone(),
         }
     }
 
@@ -81,6 +90,17 @@ impl<'a> MemPlan<'a> {
         *self.free_slots = snapshot.free_slots;
         *self.slots = snapshot.slots;
         self.spill.restore_spill_requests(snapshot.spill_requests);
+        *self.object_spill_requests = snapshot.object_spill_requests;
+    }
+
+    fn must_use_object_storage(&self, v: ValueId) -> bool {
+        self.scratch_spill_slots == 0
+            || self.scratch_live_values.contains(v)
+            || self.forced_object_spills.contains(v)
+    }
+
+    fn request_object_storage(&mut self, v: ValueId) {
+        self.object_spill_requests.insert(v);
     }
 
     fn emit_store_for_spilled_value(&mut self, v: ValueId, actions: &mut Actions) {
@@ -96,17 +116,17 @@ impl<'a> MemPlan<'a> {
             return;
         }
 
-        if self.scratch_spill_slots != 0
-            && !self.scratch_live_values.contains(v)
-            && let Some(slot) = self.slots.scratch.try_ensure_slot(
+        if !self.must_use_object_storage(v) {
+            if let Some(slot) = self.slots.scratch.try_ensure_slot(
                 spilled,
                 self.spill_slot_interference,
                 &mut self.free_slots.scratch,
                 Some(self.scratch_spill_slots),
-            )
-        {
-            actions.push(Action::MemStoreAbs(slot * 32));
-            return;
+            ) {
+                actions.push(Action::MemStoreAbs(slot * 32));
+                return;
+            }
+            self.request_object_storage(v);
         }
 
         actions.push(Action::MemStoreObj(
@@ -133,11 +153,11 @@ impl<'a> MemPlan<'a> {
             };
         }
 
-        if self.scratch_spill_slots != 0
-            && !self.scratch_live_values.contains(v)
-            && let Some(slot) = self.slots.scratch.slot_for(v)
-        {
-            return Action::MemLoadAbs(slot * 32);
+        if !self.must_use_object_storage(v) {
+            if let Some(slot) = self.slots.scratch.slot_for(v) {
+                return Action::MemLoadAbs(slot * 32);
+            }
+            self.request_object_storage(v);
         }
 
         // Invariant: every spilled value has a `StackObjId` assigned by stackify's builder

--- a/crates/codegen/src/stackalloc/stackify/planner/mod.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/mod.rs
@@ -10,7 +10,6 @@ pub(super) use normalize_search::NormalizeSearchScratch;
 use crate::{
     analysis::memory_access::ExactLocalAddr,
     bitset::BitSet,
-    liveness::Liveness,
     stackalloc::{Action, Actions},
 };
 use cranelift_entity::{EntityRef, SecondaryMap};
@@ -18,7 +17,7 @@ use sonatina_ir::ValueId;
 
 use super::{
     StackifyContext,
-    slots::{FreeSlotPools, SpillSlotPools},
+    slots::{FreeSlotPools, SpillSlotInterference, SpillSlotPools},
     spill::{SpillDiscovery, SpillSet},
     sym_stack::SymStack,
 };
@@ -37,7 +36,7 @@ pub(super) struct MemPlan<'a> {
     exact_local_addr: &'a SecondaryMap<ValueId, Option<ExactLocalAddr>>,
     free_slots: &'a mut FreeSlotPools,
     slots: &'a mut SpillSlotPools,
-    liveness: &'a Liveness,
+    spill_slot_interference: &'a SpillSlotInterference,
     spill: SpillDiscovery<'a>,
 }
 
@@ -61,7 +60,7 @@ impl<'a> MemPlan<'a> {
             exact_local_addr,
             free_slots,
             slots,
-            liveness: ctx.liveness,
+            spill_slot_interference: &ctx.spill_slot_interference,
             spill: SpillDiscovery::new(spill, spill_requests),
         }
     }
@@ -101,7 +100,7 @@ impl<'a> MemPlan<'a> {
             && !self.scratch_live_values.contains(v)
             && let Some(slot) = self.slots.scratch.try_ensure_slot(
                 spilled,
-                self.liveness,
+                self.spill_slot_interference,
                 &mut self.free_slots.scratch,
                 Some(self.scratch_spill_slots),
             )

--- a/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
@@ -5652,6 +5652,8 @@ block0:
 
             let spill_set = BitSet::default();
             let mut spill_requests = BitSet::default();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let spill_obj = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -5661,6 +5663,8 @@ block0:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );
@@ -5728,6 +5732,8 @@ block0:
 
             let spill_set = BitSet::default();
             let mut spill_requests = BitSet::default();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let spill_obj = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -5737,6 +5743,8 @@ block0:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );

--- a/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
@@ -605,6 +605,8 @@ block0:
 
                 let spill_set = BitSet::default();
                 let mut spill_requests = BitSet::default();
+                let mut object_spill_requests = BitSet::default();
+                let forced_object_spills = BitSet::default();
                 let spill_obj = SecondaryMap::new();
                 let mut free_slots = FreeSlotPools::default();
                 let mut slots = SpillSlotPools::default();
@@ -614,6 +616,8 @@ block0:
                     &ctx,
                     &spill_obj,
                     &ctx.exact_local_addr,
+                    &mut object_spill_requests,
+                    &forced_object_spills,
                     &mut free_slots,
                     &mut slots,
                 );
@@ -652,6 +656,8 @@ block0:
 
             let spill_set = BitSet::default();
             let mut spill_requests = BitSet::default();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let spill_obj = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -661,6 +667,8 @@ block0:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );
@@ -717,6 +725,8 @@ block0:
 
             let spill_set = BitSet::default();
             let mut spill_requests = BitSet::default();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let spill_obj = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -726,6 +736,8 @@ block0:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );
@@ -807,6 +819,8 @@ block0:
 
             let spill_set = BitSet::default();
             let mut spill_requests = BitSet::default();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let spill_obj = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -816,6 +830,8 @@ block0:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );
@@ -872,6 +888,8 @@ block0:
 
             let spill_set = BitSet::default();
             let mut spill_requests = BitSet::default();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let spill_obj = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -881,6 +899,8 @@ block0:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );
@@ -948,6 +968,8 @@ block0:
 
             let spill_set = BitSet::default();
             let mut spill_requests = BitSet::default();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let spill_obj = SecondaryMap::new();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
@@ -957,6 +979,8 @@ block0:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );
@@ -986,12 +1010,16 @@ block0:
             last_use.insert(func.arg_values[2]);
             let mut stack = SymStack::entry_stack(func, false);
             let mut actions = crate::stackalloc::Actions::new();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let mem = MemPlan::new(
                 SpillSet::new(&spill_set),
                 &mut spill_requests,
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );

--- a/crates/codegen/src/stackalloc/stackify/planner/test_utils.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/test_utils.rs
@@ -34,6 +34,14 @@ pub(super) fn build_stackify_test_context<'a>(
     let def_info = compute_def_info(func, entry, &value_aliases);
     let phi_results = compute_phi_results(func, &value_aliases);
     let phi_out_sources = compute_phi_out_sources(func, cfg, &value_aliases);
+    let spill_slot_interference =
+        crate::stackalloc::stackify::slots::SpillSlotInterference::compute(
+            func,
+            cfg,
+            liveness,
+            &phi_results,
+            &value_aliases,
+        );
     let mut analysis = MemoryAccessAnalysis::new();
     let mut exact_local_addr: SecondaryMap<ValueId, Option<_>> = SecondaryMap::new();
     for value in func.dfg.values.keys() {
@@ -54,6 +62,7 @@ pub(super) fn build_stackify_test_context<'a>(
         def_info,
         phi_results,
         phi_out_sources,
+        spill_slot_interference,
         has_internal_return: function_has_internal_return(func),
         reach,
         value_aliases,

--- a/crates/codegen/src/stackalloc/stackify/slots.rs
+++ b/crates/codegen/src/stackalloc/stackify/slots.rs
@@ -1,16 +1,95 @@
-use cranelift_entity::SecondaryMap;
-use sonatina_ir::{BlockId, ValueId};
+use cranelift_entity::{SecondaryMap, entity_impl};
+use smallvec::SmallVec;
+use sonatina_ir::{BlockId, Function, ValueId, cfg::ControlFlowGraph};
 use std::collections::BTreeSet;
 
 use crate::{bitset::BitSet, liveness::Liveness};
 
-use super::spill::SpilledValueId;
+use super::{spill::SpilledValueId, templates::phi_args_for_edge};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct PhiEdgePoint(u32);
+entity_impl!(PhiEdgePoint);
+
+#[derive(Default, Clone)]
+struct SpillSlotLiveRange {
+    blocks: BitSet<BlockId>,
+    phi_edges: BitSet<PhiEdgePoint>,
+}
+
+impl SpillSlotLiveRange {
+    fn union_with(&mut self, other: &Self) {
+        self.blocks.union_with(&other.blocks);
+        self.phi_edges.union_with(&other.phi_edges);
+    }
+
+    fn is_disjoint(&self, other: &Self) -> bool {
+        self.blocks.is_disjoint(&other.blocks) && self.phi_edges.is_disjoint(&other.phi_edges)
+    }
+}
+
+#[derive(Default, Clone)]
+pub(super) struct SpillSlotInterference {
+    ranges: SecondaryMap<ValueId, SpillSlotLiveRange>,
+}
+
+impl SpillSlotInterference {
+    pub(super) fn compute(
+        func: &Function,
+        cfg: &ControlFlowGraph,
+        liveness: &Liveness,
+        phi_results: &SecondaryMap<BlockId, SmallVec<[ValueId; 4]>>,
+        value_aliases: &SecondaryMap<ValueId, Option<ValueId>>,
+    ) -> Self {
+        let mut interference = Self::default();
+        for value in func.dfg.value_ids() {
+            let value = value_aliases[value].unwrap_or(value);
+            interference.ranges[value]
+                .blocks
+                .union_with(&liveness.val_live_blocks[value]);
+        }
+
+        let mut edge_idx = 0u32;
+        for pred in func.layout.iter_block() {
+            for &succ in cfg.succs_of(pred) {
+                if phi_results[succ].is_empty() {
+                    continue;
+                }
+
+                let edge = PhiEdgePoint(edge_idx);
+                edge_idx = edge_idx
+                    .checked_add(1)
+                    .expect("phi edge interference index overflow");
+
+                for source in phi_args_for_edge(func, pred, succ) {
+                    let source = value_aliases[source].unwrap_or(source);
+                    if !func.dfg.value_is_imm(source) {
+                        interference.ranges[source].phi_edges.insert(edge);
+                    }
+                }
+
+                for &result in &phi_results[succ] {
+                    let result = value_aliases[result].unwrap_or(result);
+                    if !func.dfg.value_is_imm(result) {
+                        interference.ranges[result].phi_edges.insert(edge);
+                    }
+                }
+            }
+        }
+
+        interference
+    }
+
+    fn range(&self, value: ValueId) -> &SpillSlotLiveRange {
+        &self.ranges[value]
+    }
+}
 
 #[derive(Default, Clone)]
 pub(super) struct SlotPool {
     slot_of: SecondaryMap<ValueId, Option<u32>>,
     next_slot: u32,
-    slot_live_blocks: Vec<BitSet<BlockId>>,
+    slot_live_ranges: Vec<SpillSlotLiveRange>,
 }
 
 impl SlotPool {
@@ -25,7 +104,7 @@ impl SlotPool {
     pub(super) fn try_ensure_slot(
         &mut self,
         v: SpilledValueId,
-        liveness: &Liveness,
+        interference: &SpillSlotInterference,
         free_slots: &mut FreeSlots,
         max_slots: Option<u32>,
     ) -> Option<u32> {
@@ -38,16 +117,16 @@ impl SlotPool {
         let slot = if let Some(slot) = free_slots.take_released() {
             slot
         } else {
-            let live_blocks = &liveness.val_live_blocks[v];
+            let range = interference.range(v);
             let mut found: Option<u32> = None;
             for candidate in 0..self.next_slot {
                 let idx = candidate as usize;
                 debug_assert!(
-                    idx < self.slot_live_blocks.len(),
-                    "slot_live_blocks out of sync: candidate={candidate} len={}",
-                    self.slot_live_blocks.len()
+                    idx < self.slot_live_ranges.len(),
+                    "slot_live_ranges out of sync: candidate={candidate} len={}",
+                    self.slot_live_ranges.len()
                 );
-                if self.slot_live_blocks[idx].is_disjoint(live_blocks) {
+                if self.slot_live_ranges[idx].is_disjoint(range) {
                     found = Some(candidate);
                     break;
                 }
@@ -65,20 +144,20 @@ impl SlotPool {
                     .next_slot
                     .checked_add(1)
                     .expect("frame slot index overflow");
-                self.slot_live_blocks.push(BitSet::default());
+                self.slot_live_ranges.push(SpillSlotLiveRange::default());
                 slot
             }
         };
 
         self.slot_of[v] = Some(slot);
 
-        // Track the live-block union for this slot to support cross-block reuse checks.
+        // Track the live range union for this slot to support cross-path reuse checks.
         let idx = slot as usize;
         debug_assert!(
-            idx < self.slot_live_blocks.len(),
-            "slot_live_blocks missing slot"
+            idx < self.slot_live_ranges.len(),
+            "slot_live_ranges missing slot"
         );
-        self.slot_live_blocks[idx].union_with(&liveness.val_live_blocks[v]);
+        self.slot_live_ranges[idx].union_with(interference.range(v));
         Some(slot)
     }
 

--- a/crates/codegen/src/stackalloc/stackify/trace.rs
+++ b/crates/codegen/src/stackalloc/stackify/trace.rs
@@ -12,6 +12,7 @@ use crate::{bitset::BitSet, isa::evm::immediate_u32};
 use super::{
     super::Action,
     StackifyAlloc,
+    alloc::SpillStorage,
     sym_stack::{StackItem, SymStack},
     templates::BlockTemplate,
 };
@@ -136,20 +137,18 @@ impl StackifyTrace {
         let _ = writeln!(&mut out, "STACKIFY");
 
         let mut spill_set_by_slot: BTreeMap<(u8, u32), Vec<ValueId>> = BTreeMap::new();
-        for (v, slot) in alloc.scratch_slot_of_value.iter() {
-            if let Some(slot) = *slot {
-                spill_set_by_slot.entry((0, slot)).or_default().push(v);
-            }
-        }
-        for (v, obj) in alloc.spill_obj.iter() {
-            if alloc.scratch_slot_of_value[v].is_some() {
-                continue;
-            }
-            if let Some(obj) = *obj {
-                spill_set_by_slot
-                    .entry((1, obj.as_u32()))
-                    .or_default()
-                    .push(v);
+        for (v, storage) in alloc.spill_storage.iter() {
+            match storage {
+                Some(SpillStorage::Scratch(slot)) => {
+                    spill_set_by_slot.entry((0, *slot)).or_default().push(v);
+                }
+                Some(SpillStorage::Object(obj)) => {
+                    spill_set_by_slot
+                        .entry((1, obj.as_u32()))
+                        .or_default()
+                        .push(v);
+                }
+                Some(SpillStorage::ExactLocal(_)) | None => {}
             }
         }
         if !spill_set_by_slot.is_empty() {

--- a/crates/codegen/src/transform/aggregate/cleanup.rs
+++ b/crates/codegen/src/transform/aggregate/cleanup.rs
@@ -1,67 +1,71 @@
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
-use sonatina_ir::{
-    Function, InstId, ValueId,
-    func_cursor::{CursorLocation, FuncCursor, InstInserter},
-};
+use sonatina_ir::{Function, InstId, ValueId};
 
 #[derive(Default)]
 pub(crate) struct DeadPureInstCleanup {
     worklist: Vec<InstId>,
-    queued: FxHashSet<InstId>,
+    candidates: FxHashSet<InstId>,
+    live: FxHashSet<InstId>,
 }
 
 impl DeadPureInstCleanup {
     pub(crate) fn run_with_current_users(&mut self, func: &mut Function) -> bool {
         self.worklist.clear();
-        self.queued.clear();
+        self.candidates.clear();
+        self.live.clear();
+
+        let mut insts = Vec::new();
         for block in func.layout.iter_block() {
-            let mut next_inst = func.layout.first_inst_of(block);
-            while let Some(inst) = next_inst {
-                next_inst = func.layout.next_inst_of(inst);
-                if is_dead_pure_inst(func, inst) && self.queued.insert(inst) {
-                    self.worklist.push(inst);
+            for inst in func.layout.iter_inst(block) {
+                insts.push(inst);
+                if is_drop_candidate(func, inst) {
+                    self.candidates.insert(inst);
                 }
             }
         }
 
-        let mut changed = false;
+        for inst in insts.iter().copied() {
+            if !self.candidates.contains(&inst) {
+                self.mark_operands_live(func, inst);
+            }
+        }
+
         while let Some(inst) = self.worklist.pop() {
-            self.queued.remove(&inst);
-            if !is_dead_pure_inst(func, inst) {
-                continue;
-            }
-
-            let operands = inst_operands(func, inst);
-            InstInserter::at_location(CursorLocation::At(inst)).remove_inst(func);
-            changed = true;
-
-            for operand in operands {
-                let Some(def_inst) = func.dfg.value_inst(operand) else {
-                    continue;
-                };
-                if self.queued.insert(def_inst) {
-                    self.worklist.push(def_inst);
-                }
-            }
+            self.mark_operands_live(func, inst);
         }
 
-        changed
+        let dead_insts: Vec<_> = insts
+            .into_iter()
+            .filter(|inst| self.candidates.contains(inst) && !self.live.contains(inst))
+            .collect();
+        if dead_insts.is_empty() {
+            return false;
+        }
+
+        for &inst in &dead_insts {
+            func.layout.remove_inst(inst);
+        }
+        func.erase_insts(&dead_insts);
+        true
+    }
+
+    fn mark_operands_live(&mut self, func: &Function, inst: InstId) {
+        for operand in inst_operands(func, inst) {
+            let Some(def_inst) = func.dfg.value_inst(operand) else {
+                continue;
+            };
+            if self.candidates.contains(&def_inst) && self.live.insert(def_inst) {
+                self.worklist.push(def_inst);
+            }
+        }
     }
 }
 
-fn is_dead_pure_inst(func: &Function, inst: InstId) -> bool {
-    if !func.layout.is_inst_inserted(inst) || !func.dfg.can_drop_if_unused(inst) {
-        return false;
-    }
-
-    func.dfg.inst_results(inst).iter().copied().all(|result| {
-        !func
-            .dfg
-            .users(result)
-            .copied()
-            .any(|user| func.layout.is_inst_inserted(user))
-    })
+fn is_drop_candidate(func: &Function, inst: InstId) -> bool {
+    func.layout.is_inst_inserted(inst)
+        && func.dfg.call_info(inst).is_none()
+        && func.dfg.can_drop_if_unused(inst)
 }
 
 fn inst_operands(func: &Function, inst: InstId) -> SmallVec<[ValueId; 8]> {
@@ -129,6 +133,56 @@ block0:
                         )
                         .is_none(),
                         "dead sub should be removed"
+                    );
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn dead_pure_cleanup_removes_closed_dead_cycles() {
+        let module = parse_test_module(
+            r#"
+target = "evm-ethereum-london"
+
+func private %f(v0.i1) {
+block0:
+    br v0 block1 block2;
+
+block1:
+    v1.i256 = phi (v2 block1) (1.i256 block0);
+    v2.i256 = add v1 1.i256;
+    jump block1;
+
+block2:
+    return;
+}
+"#,
+        );
+        let func_ref = lookup_func(&module, "f");
+        module.func_store.modify(func_ref, |func| {
+            func.rebuild_users();
+            assert!(DeadPureInstCleanup::default().run_with_current_users(func));
+        });
+
+        module.func_store.view(func_ref, |func| {
+            for block in func.layout.iter_block() {
+                for inst in func.layout.iter_inst(block) {
+                    assert!(
+                        <&sonatina_ir::inst::arith::Add as InstDowncast>::downcast(
+                            func.inst_set(),
+                            func.dfg.inst(inst),
+                        )
+                        .is_none(),
+                        "dead add cycle member should be removed"
+                    );
+                    assert!(
+                        <&sonatina_ir::inst::control_flow::Phi as InstDowncast>::downcast(
+                            func.inst_set(),
+                            func.dfg.inst(inst),
+                        )
+                        .is_none(),
+                        "dead phi cycle member should be removed"
                     );
                 }
             }

--- a/crates/codegen/src/transform/aggregate/legalize.rs
+++ b/crates/codegen/src/transform/aggregate/legalize.rs
@@ -12,13 +12,9 @@ use sonatina_ir::{
     types::CompoundType,
 };
 
-use crate::{
-    cfg_edit::CleanupMode,
-    critical_edge::CriticalEdgeSplitter,
-    optim::{adce::AdceSolver, cfg_cleanup::CfgCleanup},
-};
+use crate::{critical_edge::CriticalEdgeSplitter, optim::adce::AdceSolver};
 
-use super::{cleanup::DeadPureInstCleanup, shape};
+use super::shape;
 
 #[derive(Clone, Copy)]
 struct AggregateProjectionView {
@@ -216,7 +212,6 @@ pub struct AggregateLowerToMemoryLegalize {
     slot_tree_queue: Vec<ValueId>,
     slot_tree_seen_insts: FxHashSet<InstId>,
     slot_tree_seen_values: FxHashSet<ValueId>,
-    dead_pure_cleanup: DeadPureInstCleanup,
 }
 
 #[derive(Default)]
@@ -250,7 +245,7 @@ impl AggregateLowerToMemoryLegalize {
         // Legalization uses `dfg.change_to_alias`, which requires up-to-date user sets.
         func.rebuild_users();
 
-        let (blocks, split_edges) = self.prepare_legalize_block_order(func, scan.has_agg_phi);
+        let blocks = self.prepare_legalize_block_order(func, scan.has_agg_phi);
         for block in blocks {
             for &inst in &scan.candidates[block] {
                 if !func.layout.is_inst_inserted(inst) {
@@ -261,7 +256,7 @@ impl AggregateLowerToMemoryLegalize {
         }
 
         if self.changed {
-            self.changed |= self.cleanup_legalized_artifacts(func, split_edges);
+            self.changed |= self.cleanup_legalized_artifacts(func);
         }
         assert_aggregate_legalized(func, module);
         self.changed
@@ -271,81 +266,43 @@ impl AggregateLowerToMemoryLegalize {
         &mut self,
         func: &mut Function,
         has_agg_phi: bool,
-    ) -> (SmallVec<[BlockId; 16]>, bool) {
+    ) -> SmallVec<[BlockId; 16]> {
         let entry = func
             .layout
             .entry_block()
             .expect("function must have entry block");
         if func.layout.next_block_of(entry).is_none() {
-            return (smallvec![entry], false);
+            return smallvec![entry];
         }
 
         let mut cfg = ControlFlowGraph::new();
         cfg.compute(func);
         if !has_agg_phi {
-            return (aggregate_legalize_block_order(func, &cfg), false);
+            return aggregate_legalize_block_order(func, &cfg);
         }
 
         let block_count = func.layout.iter_block().count();
         CriticalEdgeSplitter::new().run(func, &mut cfg);
         let changed = func.layout.iter_block().count() != block_count;
         self.changed |= changed;
-        (aggregate_legalize_block_order(func, &cfg), changed)
+        aggregate_legalize_block_order(func, &cfg)
     }
 
-    fn cleanup_legalized_artifacts(&mut self, func: &mut Function, split_edges: bool) -> bool {
-        // User sets stay current through legalization and CFG cleanup, so the cleanup
+    fn cleanup_legalized_artifacts(&mut self, func: &mut Function) -> bool {
+        // User sets stay current through legalization and cleanup, so the cleanup
         // phases can share the single rebuild done before rewriting starts.
         let mut changed = false;
-        let mut pending_cfg_cleanup = split_edges;
 
         loop {
-            let removed_mloads = self.remove_dead_aggregate_mloads(func);
             let removed_slots = self.remove_dead_materialized_slots(func);
-            let removed_pure = self.dead_pure_cleanup.run_with_current_users(func);
             let removed_dead = AdceSolver::new().run(func);
-            let cleaned_cfg = pending_cfg_cleanup && CfgCleanup::new(CleanupMode::Strict).run(func);
-            pending_cfg_cleanup = false;
 
-            let progress =
-                removed_mloads || removed_slots || removed_pure || removed_dead || cleaned_cfg;
+            let progress = removed_slots || removed_dead;
             changed |= progress;
             if !progress {
                 return changed;
             }
         }
-    }
-
-    fn remove_dead_aggregate_mloads(&self, func: &mut Function) -> bool {
-        let mut changed = false;
-        let blocks: Vec<_> = func.layout.iter_block().collect();
-        for block in blocks {
-            let insts: Vec<_> = func.layout.iter_inst(block).collect();
-            for inst in insts {
-                let Some(mload) = downcast::<&data::Mload>(func.inst_set(), func.dfg.inst(inst))
-                else {
-                    continue;
-                };
-                if !shape::is_supported_aggregate_ty(func.ctx(), *mload.ty()) {
-                    continue;
-                }
-                let Some(result) = func.dfg.inst_result(inst) else {
-                    continue;
-                };
-                if func
-                    .dfg
-                    .users(result)
-                    .copied()
-                    .any(|user| func.layout.is_inst_inserted(user))
-                {
-                    continue;
-                }
-
-                InstInserter::at_location(CursorLocation::At(inst)).remove_inst(func);
-                changed = true;
-            }
-        }
-        changed
     }
 
     fn create_temp_alloca(&mut self, func: &mut Function, ty: Type) -> ValueId {
@@ -2032,8 +1989,8 @@ pub fn cleanup_dead_aggregate_alloca_trees(function: &mut Function, module: &Mod
     let mut changed = false;
     loop {
         let removed_slots = cleanup.remove_dead_materialized_slots(function);
-        let removed_pure = cleanup.dead_pure_cleanup.run_with_current_users(function);
-        let progress = removed_slots || removed_pure;
+        let removed_dead = AdceSolver::new().run(function);
+        let progress = removed_slots || removed_dead;
         changed |= progress;
         if !progress {
             return changed;

--- a/crates/codegen/test_files/evm/fe_commutative_branch_array5_loop_regression.snap
+++ b/crates/codegen/test_files/evm/fe_commutative_branch_array5_loop_regression.snap
@@ -6,8 +6,8 @@ input_file: test_files/evm/fe_commutative_branch_array5_loop_regression.sntn
 evm.config: stack_reach=16 vcode=false bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false opt=2
 
 object: Contract
-  section runtime: 521 bytes
-  total: 521 bytes
+  section runtime: 526 bytes
+  total: 526 bytes
 
 functions:
   verify_checked: ir_blocks=17 ir_insts=95 vcode_ops=311 fixups=6 imm_bytes=90

--- a/crates/codegen/test_files/evm/plank_slot0_unpack_aggregate_return_speed_bug.opt_ir.snap
+++ b/crates/codegen/test_files/evm/plank_slot0_unpack_aggregate_return_speed_bug.opt_ir.snap
@@ -1,0 +1,127 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: opt_ir_snapshot
+input_file: test_files/evm/plank_slot0_unpack_aggregate_return_speed_bug.sntn
+---
+target = "evm-ethereum-osaka"
+
+type @Slot0 = {i256, i256, i256, i256, i256, i256, i1};
+
+func public %init() {
+    block0:
+        v0.i256 = sym_size &runtime;
+        v1.*i8 = evm_malloc v0;
+        v2.i256 = ptr_to_int v1 i256;
+        v3.i256 = sym_addr &runtime;
+        evm_code_copy v2 v3 v0;
+        evm_return v2 v0;
+}
+
+func private %unpack(v0.i256) -> @Slot0 {
+    block0:
+        v2.i256 = shr 160.i256 v0;
+        v4.i256 = and v2 16777215.i256;
+        v48.i1 = lt v4 8388608.i256;
+        br v48 block3 block2;
+
+    block2:
+        v9.i256 = or v4 -16777216.i256;
+        jump block3;
+
+    block3:
+        v11.i256 = phi (v9 block2) (v4 block0);
+        v14.i256 = shr 184.i256 v0;
+        v16.i256 = and v14 65535.i256;
+        v18.i256 = shr 200.i256 v0;
+        v19.i256 = and v18 65535.i256;
+        v21.i256 = shr 216.i256 v0;
+        v22.i256 = and v21 65535.i256;
+        v24.i256 = shr 232.i256 v0;
+        v26.i256 = and v24 255.i256;
+        v28.i256 = shr 240.i256 v0;
+        v30.i256 = and v28 1.i256;
+        v32.i1 = gt v30 0.i256;
+        v34.i256 = and v0 1461501637330902918203684832716283019655932542975.i256;
+        v36.@Slot0 = insert_value undef.@Slot0 0.i256 v34;
+        v37.@Slot0 = insert_value v36 1.i256 v11;
+        v39.@Slot0 = insert_value v37 2.i256 v16;
+        v41.@Slot0 = insert_value v39 3.i256 v19;
+        v43.@Slot0 = insert_value v41 4.i256 v22;
+        v45.@Slot0 = insert_value v43 5.i256 v26;
+        v47.@Slot0 = insert_value v45 6.i256 v32;
+        return v47;
+}
+
+func public %run() {
+    block0:
+        v1.i256 = evm_calldata_load 0.i256;
+        v3.i256 = shr 224.i256 v1;
+        v5.i1 = eq v3 4130829085.i256;
+        br v5 block2 block1;
+
+    block1:
+        v19.i1 = eq v3 944818109.i256;
+        br v19 block4 block9;
+
+    block2:
+        v7.i256 = evm_calldata_load 4.i256;
+        v9.i256 = and v7 1461501637330902918203684832716283019655932542975.i256;
+        v55.i256 = or v9 179764701391701058939053234424102811417679702786048.i256;
+        v64.i256 = or v55 1606938044258990275541962092341162602522202993782792835301376.i256;
+        v68.i256 = or v64 105312291668557186697918027683670432318895095400549111254310977536.i256;
+        v77.i256 = or v68 1766847064778384329583297500742918515827483896875618958121606201292619776.i256;
+        evm_sstore 6.i256 v77;
+        v15.*i8 = evm_malloc 0.i256;
+        v16.i256 = ptr_to_int v15 i256;
+        evm_return v16 0.i256;
+
+    block4:
+        v20.i256 = evm_sload 6.i256;
+        v21.@Slot0 = call %unpack v20;
+        v22.*i8 = evm_malloc 224.i256;
+        v23.i256 = ptr_to_int v22 i256;
+        v24.i256 = extract_value v21 0.i256;
+        mstore v23 v24 i256;
+        v26.i256 = add v23 32.i256;
+        v27.i256 = extract_value v21 1.i256;
+        mstore v26 v27 i256;
+        v29.i256 = add v23 64.i256;
+        v31.i256 = extract_value v21 2.i256;
+        mstore v29 v31 i256;
+        v33.i256 = add v23 96.i256;
+        v35.i256 = extract_value v21 3.i256;
+        mstore v33 v35 i256;
+        v37.i256 = add v23 128.i256;
+        v38.i256 = extract_value v21 4.i256;
+        mstore v37 v38 i256;
+        v40.i256 = add v23 160.i256;
+        v42.i256 = extract_value v21 5.i256;
+        mstore v40 v42 i256;
+        v44.i256 = add v23 192.i256;
+        v45.i1 = extract_value v21 6.i256;
+        br v45 block6 block7;
+
+    block6:
+        jump block7;
+
+    block7:
+        v46.i256 = phi (1.i256 block6) (0.i256 block4);
+        mstore v44 v46 i256;
+        evm_return v23 224.i256;
+
+    block9:
+        v49.*i8 = evm_malloc 0.i256;
+        v50.i256 = ptr_to_int v49 i256;
+        evm_revert v50 0.i256;
+}
+
+
+object @Contract {
+    section runtime {
+        entry %run;
+    }
+    section init {
+        entry %init;
+        embed .runtime as &runtime;
+    }
+}

--- a/crates/codegen/test_files/evm/plank_slot0_unpack_aggregate_return_speed_bug.snap
+++ b/crates/codegen/test_files/evm/plank_slot0_unpack_aggregate_return_speed_bug.snap
@@ -1,0 +1,24 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: "String::from_utf8(out).unwrap()"
+input_file: test_files/evm/plank_slot0_unpack_aggregate_return_speed_bug.sntn
+---
+evm.config: stack_reach=16 vcode=false bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false opt=2
+
+object: Contract
+  section runtime: 453 bytes
+  section init: 464 bytes
+  total: 917 bytes
+
+functions:
+  init: ir_blocks=1 ir_insts=6 vcode_ops=19 fixups=3 imm_bytes=5
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  unpack: ir_blocks=4 ir_insts=35 vcode_ops=79 fixups=1 imm_bytes=22
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=7 abs_words_end=0
+  run: ir_blocks=8 ir_insts=56 vcode_ops=152 fixups=9 imm_bytes=35
+    mem: scratch_words=0 stable_words=7 stable_mode=StaticAbs(base=0xa0) entry_abs_words=0 abs_words_end=7
+
+evm:
+  deploy: success reason=Return gas_used=149868 gas_refunded=0 logs=0 output=create len=453 addr=0xbd770416a3345f91e4b34576cb804a576fa48eb1
+  case initialize: calldata_len=36 success reason=Return gas_used=43557 gas_refunded=0 logs=0 output=call len=0 tx_gas=21336 runtime_gas=22221
+  case slot0: calldata_len=4 success reason=Return gas_used=23760 gas_refunded=0 logs=0 output=call len=224 tx_gas=21064 runtime_gas=2696

--- a/crates/codegen/test_files/evm/plank_slot0_unpack_aggregate_return_speed_bug.sntn
+++ b/crates/codegen/test_files/evm/plank_slot0_unpack_aggregate_return_speed_bug.sntn
@@ -1,0 +1,129 @@
+#! evm.config: { opt: 2 }
+#! evm.case: initialize
+#!   calldata: 0xf637731d u256(56022770974786139918731938227)
+#!   expect: return
+#! evm.case: slot0
+#!   calldata: 0x3850c7bd
+#!   expect: return u256(56022770974786139918731938227) u256(123) u256(0) u256(1) u256(1) u256(0) u256(1)
+
+target = "evm-ethereum-osaka"
+
+type @Slot0 = {i256, i256, i256, i256, i256, i256, i1};
+
+func public %init() {
+    block0:
+        v0.i256 = sym_size &runtime;
+        v1.*i8 = evm_malloc v0;
+        v2.i256 = ptr_to_int v1 i256;
+        v3.i256 = sym_addr &runtime;
+        evm_code_copy v2 v3 v0;
+        evm_return v2 v0;
+}
+
+func private %unpack(v0.i256) -> @Slot0 {
+    block0:
+        v2.i256 = shr 160.i256 v0;
+        v4.i256 = and v2 16777215.i256;
+        v48.i1 = lt v4 8388608.i256;
+        br v48 block3 block2;
+
+    block2:
+        v9.i256 = or v4 -16777216.i256;
+        jump block3;
+
+    block3:
+        v11.i256 = phi (v9 block2) (v4 block0);
+        v14.i256 = shr 184.i256 v0;
+        v16.i256 = and v14 65535.i256;
+        v18.i256 = shr 200.i256 v0;
+        v19.i256 = and v18 65535.i256;
+        v21.i256 = shr 216.i256 v0;
+        v22.i256 = and v21 65535.i256;
+        v24.i256 = shr 232.i256 v0;
+        v26.i256 = and v24 255.i256;
+        v28.i256 = shr 240.i256 v0;
+        v30.i256 = and v28 1.i256;
+        v32.i1 = gt v30 0.i256;
+        v34.i256 = and v0 1461501637330902918203684832716283019655932542975.i256;
+        v36.@Slot0 = insert_value undef.@Slot0 0.i256 v34;
+        v37.@Slot0 = insert_value v36 1.i256 v11;
+        v39.@Slot0 = insert_value v37 2.i256 v16;
+        v41.@Slot0 = insert_value v39 3.i256 v19;
+        v43.@Slot0 = insert_value v41 4.i256 v22;
+        v45.@Slot0 = insert_value v43 5.i256 v26;
+        v47.@Slot0 = insert_value v45 6.i256 v32;
+        return v47;
+}
+
+func public %run() {
+    block0:
+        v1.i256 = evm_calldata_load 0.i256;
+        v3.i256 = shr 224.i256 v1;
+        v5.i1 = eq v3 4130829085.i256;
+        br v5 block2 block1;
+
+    block1:
+        v19.i1 = eq v3 944818109.i256;
+        br v19 block4 block9;
+
+    block2:
+        v7.i256 = evm_calldata_load 4.i256;
+        v9.i256 = and v7 1461501637330902918203684832716283019655932542975.i256;
+        v55.i256 = or v9 179764701391701058939053234424102811417679702786048.i256;
+        v64.i256 = or v55 1606938044258990275541962092341162602522202993782792835301376.i256;
+        v68.i256 = or v64 105312291668557186697918027683670432318895095400549111254310977536.i256;
+        v77.i256 = or v68 1766847064778384329583297500742918515827483896875618958121606201292619776.i256;
+        evm_sstore 6.i256 v77;
+        v15.*i8 = evm_malloc 0.i256;
+        v16.i256 = ptr_to_int v15 i256;
+        evm_return v16 0.i256;
+
+    block4:
+        v20.i256 = evm_sload 6.i256;
+        v21.@Slot0 = call %unpack v20;
+        v22.*i8 = evm_malloc 224.i256;
+        v23.i256 = ptr_to_int v22 i256;
+        v24.i256 = extract_value v21 0.i256;
+        mstore v23 v24 i256;
+        v26.i256 = add v23 32.i256;
+        v27.i256 = extract_value v21 1.i256;
+        mstore v26 v27 i256;
+        v29.i256 = add v23 64.i256;
+        v31.i256 = extract_value v21 2.i256;
+        mstore v29 v31 i256;
+        v33.i256 = add v23 96.i256;
+        v35.i256 = extract_value v21 3.i256;
+        mstore v33 v35 i256;
+        v37.i256 = add v23 128.i256;
+        v38.i256 = extract_value v21 4.i256;
+        mstore v37 v38 i256;
+        v40.i256 = add v23 160.i256;
+        v42.i256 = extract_value v21 5.i256;
+        mstore v40 v42 i256;
+        v44.i256 = add v23 192.i256;
+        v45.i1 = extract_value v21 6.i256;
+        br v45 block6 block7;
+
+    block6:
+        jump block7;
+
+    block7:
+        v46.i256 = phi (1.i256 block6) (0.i256 block4);
+        mstore v44 v46 i256;
+        evm_return v23 224.i256;
+
+    block9:
+        v49.*i8 = evm_malloc 0.i256;
+        v50.i256 = ptr_to_int v49 i256;
+        evm_revert v50 0.i256;
+}
+
+object @Contract {
+    section runtime {
+        entry %run;
+    }
+    section init {
+        entry %init;
+        embed .runtime as &runtime;
+    }
+}

--- a/crates/filecheck/src/adce.rs
+++ b/crates/filecheck/src/adce.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use sonatina_codegen::optim::adce::AdceSolver;
+use sonatina_codegen::optim::adce::{AdceCallPolicy, AdceSolver};
 use sonatina_ir::Function;
 
 use super::{FIXTURE_ROOT, FuncTransform};
@@ -10,7 +10,7 @@ pub struct AdceTransform {}
 
 impl FuncTransform for AdceTransform {
     fn transform(&mut self, func: &mut Function) {
-        let mut solver = AdceSolver::new();
+        let mut solver = AdceSolver::with_call_policy(AdceCallPolicy::UseCurrentFuncEffects);
         solver.run(func);
     }
 


### PR DESCRIPTION
- fix stackify spill-slot interference for phi edges and finalize stable spill storage
- make ADCE conservative by default for calls, with opt-in call removal only when effects are current
- teach ADCE to handle divergent/infinite-loop regions instead of disabling itself