### PR TITLE
Improve perf of operand prep

### DIFF
--- a/crates/codegen/src/stackalloc/stackify/builder.rs
+++ b/crates/codegen/src/stackalloc/stackify/builder.rs
@@ -13,6 +13,7 @@ use sonatina_ir::{BlockId, Function, ValueId, cfg::ControlFlowGraph};
 use super::{
     alloc::{SpillStorage, StackifyAlloc},
     iteration::IterationPlanner,
+    planner::NormalizeSearchScratch,
     slots::{FreeSlotPools, SpillSlotInterference, SpillSlotPools},
     spill::SpillSet,
     sym_stack::SymStack,
@@ -211,6 +212,7 @@ impl<'a> StackifyBuilder<'a> {
         // can rely on loads being correct.
         let mut spill_set: BitSet<ValueId> = BitSet::default();
         let mut forced_object_spills: BitSet<ValueId> = BitSet::default();
+        let mut search_scratch = NormalizeSearchScratch::default();
         loop {
             let checkpoint = observer.checkpoint();
             let mut slots: SpillSlotPools = SpillSlotPools::default();
@@ -221,6 +223,7 @@ impl<'a> StackifyBuilder<'a> {
                 SpillSet::new(&spill_set),
                 &forced_object_spills,
                 &mut slots,
+                &mut search_scratch,
             );
 
             let spill_stable = spill_requests.is_subset(&spill_set);
@@ -249,6 +252,7 @@ impl<'a> StackifyBuilder<'a> {
         spill: SpillSet<'_>,
         forced_object_spills: &BitSet<ValueId>,
         slots: &mut SpillSlotPools,
+        search_scratch: &mut NormalizeSearchScratch,
     ) -> (StackifyAlloc, BitSet<ValueId>, BitSet<ValueId>) {
         let mut object_spill_requests: BitSet<ValueId> = BitSet::default();
         let mut arg_free_slots: FreeSlotPools = FreeSlotPools::default();
@@ -312,6 +316,7 @@ impl<'a> StackifyBuilder<'a> {
             &mut object_spill_requests,
             forced_object_spills,
             inherited_stack,
+            search_scratch,
             observer,
         );
         planner.plan_blocks();

--- a/crates/codegen/src/stackalloc/stackify/iteration.rs
+++ b/crates/codegen/src/stackalloc/stackify/iteration.rs
@@ -38,7 +38,7 @@ pub(super) struct IterationPlanner<'a, 'ctx, O: StackifyObserver> {
     inherited_stack: BTreeMap<BlockId, (BlockId, SymStack)>,
     pending_edges: BTreeMap<BlockId, Vec<PendingEdge<O::DeferredExit>>>,
     planned_blocks: BitSet<BlockId>,
-    search_scratch: NormalizeSearchScratch,
+    search_scratch: &'a mut NormalizeSearchScratch,
     observer: &'a mut O,
 }
 
@@ -65,6 +65,7 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
         object_spill_requests: &'a mut BitSet<ValueId>,
         forced_object_spills: &'a BitSet<ValueId>,
         inherited_stack: BTreeMap<BlockId, (BlockId, SymStack)>,
+        search_scratch: &'a mut NormalizeSearchScratch,
         observer: &'a mut O,
     ) -> Self {
         Self {
@@ -81,7 +82,7 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
             inherited_stack,
             pending_edges: BTreeMap::new(),
             planned_blocks: BitSet::default(),
-            search_scratch: NormalizeSearchScratch::default(),
+            search_scratch,
             observer,
         }
     }
@@ -104,7 +105,7 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
             free_slots,
             &mut *self.slots,
         );
-        let mut planner = Planner::new(self.ctx, stack, actions, mem, &mut self.search_scratch);
+        let mut planner = Planner::new(self.ctx, stack, actions, mem, &mut *self.search_scratch);
         f(&mut planner)
     }
 
@@ -327,7 +328,7 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
                     stack,
                     &mut self.alloc.pre_actions[inst],
                     mem,
-                    &mut self.search_scratch,
+                    &mut *self.search_scratch,
                 );
                 f(&mut planner)
             }
@@ -348,7 +349,7 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
                     stack,
                     &mut self.alloc.post_actions[inst],
                     mem,
-                    &mut self.search_scratch,
+                    &mut *self.search_scratch,
                 );
                 f(&mut planner)
             }
@@ -373,8 +374,13 @@ impl<'a, 'ctx, O: StackifyObserver> IterationPlanner<'a, 'ctx, O> {
                     &mut *self.slots,
                 );
                 let result = {
-                    let mut planner =
-                        Planner::new(self.ctx, stack, &mut actions, mem, &mut self.search_scratch);
+                    let mut planner = Planner::new(
+                        self.ctx,
+                        stack,
+                        &mut actions,
+                        mem,
+                        &mut *self.search_scratch,
+                    );
                     f(&mut planner)
                 };
                 debug_assert_eq!(self.alloc.brtable_actions[inst].len(), case_idx);

--- a/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
@@ -15,7 +15,7 @@ use super::{
         sym_stack::{StackItem, SymStack},
     },
     Planner,
-    operand_prep::OperandPrepPlanCache,
+    operand_prep::{CachedOperandPrepPlan, OperandPrepPlanCache},
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -151,6 +151,8 @@ pub(super) enum Step {
     LoadVal(u8),
 }
 
+pub(super) type StepList = SmallVec<[Step; 8]>;
+
 #[derive(Clone, Copy, Debug)]
 pub(super) struct SearchCfg {
     pub(super) dup_max: usize,
@@ -163,7 +165,7 @@ pub(super) struct SearchCfg {
 pub(super) struct NormalizePlan {
     #[cfg_attr(not(test), allow(dead_code))]
     pub(super) cost: Cost,
-    pub(super) steps: Vec<Step>,
+    pub(super) steps: StepList,
     pub(super) key_infos: KeyInfos,
     #[allow(dead_code)]
     pub(super) goal_keys: KeyIds,
@@ -384,7 +386,7 @@ struct PlanCacheKey {
 #[derive(Clone, Debug)]
 enum PlanCacheVal {
     None,
-    Steps(Vec<Step>),
+    Steps(StepList),
 }
 
 struct PlanCache {
@@ -605,8 +607,12 @@ impl OperandPrepCostTable {
         })
     }
 
+    fn materialize_cost(&self, kid: u8) -> Cost {
+        self.materialize[kid as usize]
+    }
+
     fn materialize_gas(&self, kid: u8) -> u32 {
-        self.materialize[kid as usize].gas
+        self.materialize_cost(kid).gas
     }
 
     fn cost_hash(&self, key_infos: &[KeyInfo], cfg: SearchCfg) -> u64 {
@@ -639,6 +645,15 @@ impl OperandPrepCostTable {
 fn write_cost_to_hash(h: &mut FxHasher, cost: Cost) {
     h.write_u32(cost.gas);
     h.write_u32(cost.bytes);
+}
+
+fn find_push0_kid(key_infos: &[KeyInfo], materializable_imm: &[u8]) -> Option<u8> {
+    materializable_imm.iter().copied().find(|&kid| {
+        matches!(
+            key_infos[kid as usize],
+            KeyInfo::Imm { canon, .. } if canon.is_zero()
+        )
+    })
 }
 
 fn common_suffix_len(state: PackedState, goal: PackedState) -> usize {
@@ -798,10 +813,10 @@ pub(super) fn solve_optimal_normalize_plan(
     if start == goal {
         scratch
             .plan_cache
-            .insert(cache_key, PlanCacheVal::Steps(Vec::new()));
+            .insert(cache_key, PlanCacheVal::Steps(StepList::new()));
         return Some(NormalizePlan {
             cost: Cost::default(),
-            steps: Vec::new(),
+            steps: StepList::new(),
             key_infos,
             goal_keys,
         });
@@ -814,7 +829,7 @@ pub(super) fn solve_optimal_normalize_plan(
     let goal_mask = key_mask_from_counts(&goal_counts);
 
     let mut upper_bound = estimate_flush_rebuild_cost(ctx, stack, desired, cost);
-    let mut incumbent_steps: Option<Vec<Step>> = None;
+    let mut incumbent_steps: Option<StepList> = None;
 
     if let Some(steps) = build_delete_tail_under_prefix_upper_bound(&start_keys, &goal_keys, cfg) {
         let greedy_cost = cost_for_steps(&steps, &key_infos, cost);
@@ -844,12 +859,7 @@ pub(super) fn solve_optimal_normalize_plan(
         }
     }
 
-    let push0_kid: Option<u8> = materializable_imm.iter().copied().find(|&kid| {
-        matches!(
-            key_infos[kid as usize],
-            KeyInfo::Imm { canon, .. } if canon.is_zero()
-        )
-    });
+    let push0_kid = find_push0_kid(&key_infos, &materializable_imm);
     let push0_cost = push0_kid.map(|kid| {
         let KeyInfo::Imm { canon, .. } = key_infos[kid as usize] else {
             unreachable!("expected imm key info")
@@ -987,17 +997,13 @@ pub(super) fn solve_optimal_normalize_plan(
         if cur_len < cfg.max_len
             && let (Some(kid), Some(push0_cost)) = (push0_kid, push0_cost)
         {
-            let bit = 1u64 << kid;
-            let dominated = (duplicable & bit) != 0 && push0_cost >= dup_cost_for_kid[kid as usize];
-            if !dominated {
-                consider_succ(
-                    entry.state.push(kid),
-                    g.saturating_add(push0_cost),
-                    entry.state,
-                    Step::PushImm(kid),
-                    &mut consider_ctx,
-                );
-            }
+            consider_succ(
+                entry.state.push(kid),
+                g.saturating_add(push0_cost),
+                entry.state,
+                Step::PushImm(kid),
+                &mut consider_ctx,
+            );
         }
 
         // SWAP
@@ -1037,10 +1043,7 @@ pub(super) fn solve_optimal_normalize_plan(
                 }
                 seen |= bit;
 
-                if Some(kid) == push0_kid
-                    && let Some(push0_cost) = push0_cost
-                    && push0_cost < dup_cost_for_kid[kid as usize]
-                {
+                if Some(kid) == push0_kid {
                     continue;
                 }
                 consider_succ(
@@ -1278,10 +1281,10 @@ pub(super) fn solve_optimal_repair_prefix_plan(
     if start == goal {
         scratch
             .plan_cache
-            .insert(cache_key, PlanCacheVal::Steps(Vec::new()));
+            .insert(cache_key, PlanCacheVal::Steps(StepList::new()));
         return Some(NormalizePlan {
             cost: Cost::default(),
-            steps: Vec::new(),
+            steps: StepList::new(),
             key_infos,
             goal_keys,
         });
@@ -1315,7 +1318,7 @@ pub(super) fn solve_optimal_repair_prefix_plan(
             upper_bound = upper_bound.saturating_add(cost.cost_load(v));
         }
     }
-    let mut incumbent_steps: Option<Vec<Step>> = None;
+    let mut incumbent_steps: Option<StepList> = None;
 
     if let Some(steps) = build_greedy_repair_prefix_upper_bound(
         &start_keys,
@@ -1337,12 +1340,7 @@ pub(super) fn solve_optimal_repair_prefix_plan(
         }
     }
 
-    let push0_kid: Option<u8> = materializable_imm.iter().copied().find(|&kid| {
-        matches!(
-            key_infos[kid as usize],
-            KeyInfo::Imm { canon, .. } if canon.is_zero()
-        )
-    });
+    let push0_kid = find_push0_kid(&key_infos, &materializable_imm);
     let push0_cost = push0_kid.map(|kid| {
         let KeyInfo::Imm { canon, .. } = key_infos[kid as usize] else {
             unreachable!("expected imm key info")
@@ -1489,17 +1487,13 @@ pub(super) fn solve_optimal_repair_prefix_plan(
         if cur_len < cfg.max_len
             && let (Some(kid), Some(push0_cost)) = (push0_kid, push0_cost)
         {
-            let bit = 1u64 << kid;
-            let dominated = (duplicable & bit) != 0 && push0_cost >= dup_cost_for_kid[kid as usize];
-            if !dominated {
-                consider_succ(
-                    entry.state.push(kid),
-                    g.saturating_add(push0_cost),
-                    entry.state,
-                    Step::PushImm(kid),
-                    &mut consider_ctx,
-                );
-            }
+            consider_succ(
+                entry.state.push(kid),
+                g.saturating_add(push0_cost),
+                entry.state,
+                Step::PushImm(kid),
+                &mut consider_ctx,
+            );
         }
 
         // SWAP (restricted to the repair region).
@@ -1555,10 +1549,7 @@ pub(super) fn solve_optimal_repair_prefix_plan(
                     }
                     seen |= bit;
 
-                    if Some(kid) == push0_kid
-                        && let Some(push0_cost) = push0_cost
-                        && push0_cost < dup_cost_for_kid[kid as usize]
-                    {
+                    if Some(kid) == push0_kid {
                         continue;
                     }
 
@@ -1653,6 +1644,12 @@ struct OperandPrepProblem {
     start_state: PrepState,
     goal_state: PackedState,
     max_len: usize,
+}
+
+impl OperandPrepProblem {
+    fn push0_kid(&self) -> Option<u8> {
+        find_push0_kid(&self.key_infos, &self.materializable_imm)
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1855,39 +1852,6 @@ fn operand_prep_cache_key(
     }
 }
 
-fn operand_prep_push0_cost(
-    problem: &OperandPrepProblem,
-    cost: &impl CostModel,
-) -> (Option<u8>, Option<Cost>) {
-    let push0_kid = problem.materializable_imm.iter().copied().find(|&kid| {
-        matches!(
-            problem.key_infos[kid as usize],
-            KeyInfo::Imm { canon, .. } if canon.is_zero()
-        )
-    });
-    let push0_cost = push0_kid.map(|kid| {
-        let KeyInfo::Imm { canon, .. } = problem.key_infos[kid as usize] else {
-            unreachable!("expected imm key info")
-        };
-        cost.cost_push_imm(canon)
-    });
-    (push0_kid, push0_cost)
-}
-
-fn operand_prep_push0_cost_from_table(
-    problem: &OperandPrepProblem,
-    costs: &OperandPrepCostTable,
-) -> (Option<u8>, Option<Cost>) {
-    let push0_kid = problem.materializable_imm.iter().copied().find(|&kid| {
-        matches!(
-            problem.key_infos[kid as usize],
-            KeyInfo::Imm { canon, .. } if canon.is_zero()
-        )
-    });
-    let push0_cost = push0_kid.map(|kid| costs.materialize[kid as usize]);
-    (push0_kid, push0_cost)
-}
-
 fn prep_window_copy_count(state: PrepState, kid: u8) -> u8 {
     let mut count = 0u8;
     for idx in 0..state.window.len() {
@@ -1952,7 +1916,7 @@ fn operand_prep_swap_pos(
 
 fn apply_operand_prep_swap(
     state: &mut PrepState,
-    steps: &mut Vec<Step>,
+    steps: &mut StepList,
     total_cost: &mut Cost,
     pos: usize,
     goal_prefix: &[u8],
@@ -1993,7 +1957,7 @@ struct OperandPrepUpperBoundCtx<'a, C: CostModel> {
 fn apply_operand_prep_copy<C: CostModel>(
     ctx: &OperandPrepUpperBoundCtx<'_, C>,
     state: &mut PrepState,
-    steps: &mut Vec<Step>,
+    steps: &mut StepList,
     total_cost: &mut Cost,
     prepared: usize,
     kid: u8,
@@ -2058,7 +2022,7 @@ fn build_linear_operand_prep_upper_bound(
     allow_copy_swap: bool,
     cost: &impl CostModel,
     cfg: SearchCfg,
-) -> Option<(Vec<Step>, Cost)> {
+) -> Option<(StepList, Cost)> {
     let cfg = SearchCfg {
         max_len: problem.max_len,
         ..cfg
@@ -2070,7 +2034,7 @@ fn build_linear_operand_prep_upper_bound(
         cfg,
     };
     let mut state = problem.start_state;
-    let mut steps: Vec<Step> = Vec::new();
+    let mut steps = StepList::new();
     let mut total_cost = Cost::default();
     let mut prepared: usize = 0;
 
@@ -2229,8 +2193,8 @@ fn prep_greedy_node_better(lhs: &PrepGreedyNode, rhs: &PrepGreedyNode) -> bool {
     prep_greedy_node_cmp(lhs, rhs).is_lt()
 }
 
-fn prep_greedy_steps(nodes: &[PrepGreedyNode], mut idx: usize) -> Vec<Step> {
-    let mut steps = Vec::new();
+fn prep_greedy_steps(nodes: &[PrepGreedyNode], mut idx: usize) -> StepList {
+    let mut steps = StepList::new();
     loop {
         let node = nodes[idx];
         if let Some(step) = node.step {
@@ -2250,7 +2214,7 @@ fn build_greedy_operand_prep_upper_bound(
     cost: &impl CostModel,
     cfg: SearchCfg,
     upper_bound: Cost,
-) -> Option<(Vec<Step>, Cost)> {
+) -> Option<(StepList, Cost)> {
     let cfg = SearchCfg {
         max_len: problem.max_len,
         ..cfg
@@ -2261,7 +2225,7 @@ fn build_greedy_operand_prep_upper_bound(
         problem.preserve_mask,
         &problem.goal_counts,
     ) {
-        return Some((Vec::new(), Cost::default()));
+        return Some((StepList::new(), Cost::default()));
     }
 
     let last_use_count = problem.last_use_mask.count_ones() as usize;
@@ -2269,7 +2233,13 @@ fn build_greedy_operand_prep_upper_bound(
         return None;
     }
 
-    let (push0_kid, push0_cost) = operand_prep_push0_cost(problem, cost);
+    let push0_kid = problem.push0_kid();
+    let push0_cost = push0_kid.map(|kid| {
+        let KeyInfo::Imm { canon, .. } = problem.key_infos[kid as usize] else {
+            unreachable!("expected imm key info")
+        };
+        cost.cost_push_imm(canon)
+    });
     let surplus_last_use_penalty = cost.cost_pop().saturating_add(cost.cost_swap(1));
     let max_depth = problem.goal_keys.len().saturating_add(cfg.swap_max).min(24);
     let beam_width = 192usize;
@@ -2396,10 +2366,7 @@ fn build_greedy_operand_prep_upper_bound(
                     }
                     seen_kids |= bit;
 
-                    if Some(kid) == push0_kid
-                        && let Some(push0_cost) = push0_cost
-                        && push0_cost < dup_cost_for_kid[kid as usize]
-                    {
+                    if Some(kid) == push0_kid {
                         continue;
                     }
 
@@ -2422,26 +2389,20 @@ fn build_greedy_operand_prep_upper_bound(
             }
 
             if let (Some(kid), Some(push0_cost)) = (push0_kid, push0_cost) {
-                let bit = 1u64 << kid;
-                let dominated =
-                    (duplicable & bit) != 0 && push0_cost >= dup_cost_for_kid[kid as usize];
-                if !dominated {
-                    let next =
-                        prep_insert(node.state, kid, problem.preserve_mask, false, cfg.max_len);
-                    consider(
+                let next = prep_insert(node.state, kid, problem.preserve_mask, false, cfg.max_len);
+                consider(
+                    next,
+                    node.cost.saturating_add(operand_prep_insert_cost(
+                        node.state,
                         next,
-                        node.cost.saturating_add(operand_prep_insert_cost(
-                            node.state,
-                            next,
-                            kid,
-                            &problem.goal_counts,
-                            problem.last_use_mask,
-                            push0_cost,
-                            surplus_last_use_penalty,
-                        )),
-                        Step::PushImm(kid),
-                    );
-                }
+                        kid,
+                        &problem.goal_counts,
+                        problem.last_use_mask,
+                        push0_cost,
+                        surplus_last_use_penalty,
+                    )),
+                    Step::PushImm(kid),
+                );
             }
 
             for &kid in &problem.materializable_imm {
@@ -2554,7 +2515,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
     if args.is_empty() {
         return Some(NormalizePlan {
             cost: Cost::default(),
-            steps: Vec::new(),
+            steps: StepList::new(),
             key_infos: KeyInfos::new(),
             goal_keys: KeyIds::new(),
         });
@@ -2608,16 +2569,17 @@ pub(super) fn solve_optimal_operand_prep_plan(
     ) {
         scratch
             .plan_cache
-            .insert(cache_key, PlanCacheVal::Steps(Vec::new()));
+            .insert(cache_key, PlanCacheVal::Steps(StepList::new()));
         return Some(NormalizePlan {
             cost: Cost::default(),
-            steps: Vec::new(),
+            steps: StepList::new(),
             key_infos: problem.key_infos,
             goal_keys: problem.goal_keys,
         });
     }
 
-    let (push0_kid, push0_cost) = operand_prep_push0_cost_from_table(&problem, &prep_costs);
+    let push0_kid = problem.push0_kid();
+    let push0_cost = push0_kid.map(|kid| prep_costs.materialize_cost(kid));
     let surplus_last_use_penalty = prep_costs.surplus_last_use_penalty;
     let Some((linear_steps, linear_cost)) =
         build_linear_operand_prep_upper_bound(&problem, true, cost, cfg)
@@ -2634,7 +2596,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
         && problem.preserve_mask == 0;
 
     let mut upper_bound = linear_cost;
-    let mut incumbent_steps: Vec<Step> = linear_steps;
+    let mut incumbent_steps = linear_steps;
     let mut incumbent_cost = upper_bound;
 
     if let Some((steps, greedy_cost)) =
@@ -2652,7 +2614,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
     }
 
     let finish_incumbent = |scratch: &mut NormalizeSearchScratch,
-                            steps: Vec<Step>,
+                            steps: StepList,
                             plan_cost: Cost,
                             key_infos: KeyInfos,
                             goal_keys: KeyIds| {
@@ -2856,10 +2818,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
                 }
                 seen |= bit;
 
-                if Some(kid) == push0_kid
-                    && let Some(push0_cost) = push0_cost
-                    && push0_cost < dup_cost_for_kid[kid as usize]
-                {
+                if Some(kid) == push0_kid {
                     continue;
                 }
 
@@ -2883,26 +2842,22 @@ pub(super) fn solve_optimal_operand_prep_plan(
         }
 
         if let (Some(kid), Some(push0_cost)) = (push0_kid, push0_cost) {
-            let bit = 1u64 << kid;
-            let dominated = (duplicable & bit) != 0 && push0_cost >= dup_cost_for_kid[kid as usize];
-            if !dominated {
-                let next = prep_insert(entry.state, kid, problem.preserve_mask, false, cfg.max_len);
-                consider_prep_succ(
-                    next,
-                    g.saturating_add(operand_prep_insert_cost(
-                        entry.state,
-                        next,
-                        kid,
-                        &problem.goal_counts,
-                        problem.last_use_mask,
-                        push0_cost,
-                        surplus_last_use_penalty,
-                    )),
+            let next = prep_insert(entry.state, kid, problem.preserve_mask, false, cfg.max_len);
+            consider_prep_succ(
+                next,
+                g.saturating_add(operand_prep_insert_cost(
                     entry.state,
-                    Step::PushImm(kid),
-                    &mut consider_ctx,
-                );
-            }
+                    next,
+                    kid,
+                    &problem.goal_counts,
+                    problem.last_use_mask,
+                    push0_cost,
+                    surplus_last_use_penalty,
+                )),
+                entry.state,
+                Step::PushImm(kid),
+                &mut consider_ctx,
+            );
         }
 
         for &kid in &problem.materializable_imm {
@@ -2979,14 +2934,13 @@ pub(super) fn rebuild_operand_prep_plan(
     stack: &SymStack,
     args: &[ValueId],
     consume_last_use: &BitSet<ValueId>,
-    cost: &impl CostModel,
     cfg: SearchCfg,
-    steps: Vec<Step>,
+    cached: CachedOperandPrepPlan,
 ) -> Option<NormalizePlan> {
     if args.is_empty() {
         return Some(NormalizePlan {
-            cost: Cost::default(),
-            steps,
+            cost: cached.modeled_cost,
+            steps: cached.steps,
             key_infos: KeyInfos::new(),
             goal_keys: KeyIds::new(),
         });
@@ -2994,8 +2948,8 @@ pub(super) fn rebuild_operand_prep_plan(
 
     let problem = build_operand_prep_problem(ctx, stack, args, consume_last_use, cfg)?;
     Some(NormalizePlan {
-        cost: cost_for_steps(&steps, &problem.key_infos, cost),
-        steps,
+        cost: cached.modeled_cost,
+        steps: cached.steps,
         key_infos: problem.key_infos,
         goal_keys: problem.goal_keys,
     })
@@ -3086,8 +3040,8 @@ fn reconstruct_steps<S: Eq + Hash + Copy>(
     start: S,
     goal: S,
     nodes: &FxHashMap<S, SearchNode<S>>,
-) -> Option<Vec<Step>> {
-    let mut steps: Vec<Step> = Vec::new();
+) -> Option<StepList> {
+    let mut steps = StepList::new();
     let mut cur = goal;
     while cur != start {
         let (prev, step) = nodes.get(&cur)?.parent?;
@@ -3220,7 +3174,7 @@ fn apply_repair_step_to_vec(cur: &mut Vec<u8>, suffix_ctx_keys: &[u8], step: Ste
     }
 }
 
-fn build_star_swap_plan(cur: &mut Vec<u8>, goal: &[u8], swap_max: usize) -> Option<Vec<Step>> {
+fn build_star_swap_plan(cur: &mut Vec<u8>, goal: &[u8], swap_max: usize) -> Option<StepList> {
     if cur.len() != goal.len() {
         return None;
     }
@@ -3234,7 +3188,7 @@ fn build_star_swap_plan(cur: &mut Vec<u8>, goal: &[u8], swap_max: usize) -> Opti
 
     let n = cur.len();
     if n <= 1 {
-        return Some(Vec::new());
+        return Some(StepList::new());
     }
 
     let mut goal_pos: Vec<Vec<usize>> = vec![Vec::new(); 64];
@@ -3259,7 +3213,7 @@ fn build_star_swap_plan(cur: &mut Vec<u8>, goal: &[u8], swap_max: usize) -> Opti
     // - cycle containing 0: (0 a1 a2 .. ak) => (0 a1)(0 a2)...(0 ak)
     // - other cycle: (a1 a2 .. ak) => (0 a1)(0 a2)...(0 ak)(0 a1)
     let mut visited = vec![false; n];
-    let mut steps: Vec<Step> = Vec::new();
+    let mut steps = StepList::new();
 
     for i in 0..n {
         if visited[i] {
@@ -3315,7 +3269,7 @@ fn build_delete_tail_under_prefix_upper_bound(
     start_keys: &[u8],
     goal_keys: &[u8],
     cfg: SearchCfg,
-) -> Option<Vec<Step>> {
+) -> Option<StepList> {
     if goal_keys.len() >= start_keys.len() {
         return None;
     }
@@ -3331,7 +3285,7 @@ fn build_delete_tail_under_prefix_upper_bound(
 
     let keep = goal_keys.len();
     let mut cur: Vec<u8> = start_keys.to_vec();
-    let mut steps: Vec<Step> = Vec::new();
+    let mut steps = StepList::new();
 
     let mut dead = cur.len().saturating_sub(keep);
     let bury = keep.min(dead);
@@ -3366,7 +3320,7 @@ fn trim_excess_keys<F>(
     cur_counts: &mut [u8; 64],
     goal_counts: &[u8; 64],
     swap_max: usize,
-    steps: &mut Vec<Step>,
+    steps: &mut StepList,
     mut apply_step: F,
 ) -> Option<()>
 where
@@ -3401,7 +3355,7 @@ fn finish_count_fixup_plan(
     goal_keys: &[u8],
     goal_counts: &[u8; 64],
     swap_max: usize,
-    steps: &mut Vec<Step>,
+    steps: &mut StepList,
 ) -> Option<()> {
     if cur.len() != goal_keys.len() || cur_counts != goal_counts {
         return None;
@@ -3730,7 +3684,7 @@ fn trim_repair_excess_keys<C: CostModel>(
     cur: &mut Vec<u8>,
     cur_counts: &mut [u8; 64],
     env: &RepairGreedyEnv<'_, C>,
-    steps: &mut Vec<Step>,
+    steps: &mut StepList,
 ) -> Option<()> {
     while cur
         .iter()
@@ -3792,7 +3746,7 @@ fn trim_repair_excess_keys<C: CostModel>(
 fn apply_repair_candidate(
     cur: &mut Vec<u8>,
     suffix_ctx_keys: &[u8],
-    steps: &mut Vec<Step>,
+    steps: &mut StepList,
     candidate: CopySourceCandidate,
 ) -> u8 {
     let kid = candidate.kid();
@@ -3836,7 +3790,7 @@ fn build_greedy_repair_prefix_upper_bound(
     key_infos: &[KeyInfo],
     cost: &impl CostModel,
     cfg: SearchCfg,
-) -> Option<Vec<Step>> {
+) -> Option<StepList> {
     if start_keys.len() > cfg.swap_max
         || goal_keys.len() > cfg.swap_max
         || goal_keys.len() > cfg.max_len
@@ -3847,7 +3801,7 @@ fn build_greedy_repair_prefix_upper_bound(
     let goal_counts = compute_goal_counts(goal_keys);
     let mut cur = start_keys.to_vec();
     let mut cur_counts = compute_counts(&cur);
-    let mut steps = Vec::new();
+    let mut steps = StepList::new();
     let env = RepairGreedyEnv {
         goal_keys,
         goal_counts: &goal_counts,
@@ -3923,7 +3877,7 @@ fn build_dup_and_star_swap_upper_bound(
     goal_keys: &[u8],
     goal_counts: &[u8; 64],
     cfg: SearchCfg,
-) -> Option<Vec<Step>> {
+) -> Option<StepList> {
     if goal_keys.len() > cfg.max_len {
         return None;
     }
@@ -3939,7 +3893,7 @@ fn build_dup_and_star_swap_upper_bound(
         }
     }
 
-    let mut steps: Vec<Step> = Vec::new();
+    let mut steps = StepList::new();
 
     trim_excess_keys(
         &mut cur,
@@ -6152,119 +6106,6 @@ block0:
     }
 
     #[test]
-    fn operand_prep_random_ignored_value_pairs_replay_equivalently() {
-        const SRC: &str = r#"
-target = "evm-ethereum-osaka"
-
-func public %f() {
-block0:
-    return;
-}
-"#;
-        let parsed = parse_module(SRC).unwrap();
-        let func_ref = parsed.debug.func_order[0];
-
-        parsed.module.func_store.modify(func_ref, |func| {
-            let a = func.dfg.make_undef_value(Type::I256);
-            let b = func.dfg.make_undef_value(Type::I256);
-            let c = func.dfg.make_undef_value(Type::I256);
-            let imm0 = func.dfg.make_imm_value(Immediate::I8(0));
-            let imm1 = func.dfg.make_imm_value(Immediate::I8(1));
-            let relevant = [a, b, c, imm0, imm1];
-            let ignored_lhs: [ValueId; 8] =
-                std::array::from_fn(|_| func.dfg.make_undef_value(Type::I256));
-            let ignored_rhs: [ValueId; 8] =
-                std::array::from_fn(|_| func.dfg.make_undef_value(Type::I256));
-
-            let mut cfg = ControlFlowGraph::new();
-            cfg.compute(func);
-            let entry = cfg.entry().expect("missing entry block");
-
-            let mut liveness = Liveness::new();
-            liveness.compute(func, &cfg);
-
-            let mut dom = DomTree::new();
-            dom.compute(&cfg);
-
-            let mut scc = CfgSccAnalysis::new();
-            scc.compute(&cfg);
-
-            let reach = StackifyReachability::new(16);
-            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
-            let search_cfg = SearchCfg {
-                dup_max: 6,
-                swap_max: 6,
-                max_len: 6,
-                max_expansions: 100_000,
-            };
-            let cost = EstimatedCostModel::default();
-
-            struct Rng(u64);
-            impl Rng {
-                fn next_u32(&mut self) -> u32 {
-                    let mut x = self.0;
-                    x ^= x << 13;
-                    x ^= x >> 7;
-                    x ^= x << 17;
-                    self.0 = x;
-                    (x >> 32) as u32
-                }
-
-                fn gen_range(&mut self, n: usize) -> usize {
-                    (self.next_u32() as usize) % n
-                }
-            }
-
-            let mut rng = Rng(0x7c15_9e37_79b9_4a7c);
-            for _ in 0..80 {
-                let args_len = 2 + rng.gen_range(2);
-                let stack_len = args_len + rng.gen_range(search_cfg.max_len + 1 - args_len);
-                let mut args = Vec::with_capacity(args_len);
-                let mut last_use = BitSet::default();
-                for _ in 0..args_len {
-                    let arg = relevant[rng.gen_range(relevant.len())];
-                    args.push(arg);
-                    last_use.insert(arg);
-                }
-
-                let mut lhs_stack = SymStack::entry_stack(func, false);
-                let mut rhs_stack = SymStack::entry_stack(func, false);
-                for slot in (0..stack_len).rev() {
-                    if rng.gen_range(3) == 0 {
-                        let value = relevant[rng.gen_range(relevant.len())];
-                        lhs_stack.push_value(value);
-                        rhs_stack.push_value(value);
-                    } else {
-                        lhs_stack.push_value(ignored_lhs[slot]);
-                        rhs_stack.push_value(ignored_rhs[slot]);
-                    }
-                }
-
-                let lhs_plan = solve_test_optimal_operand_prep_plan(
-                    &ctx, &lhs_stack, &args, &last_use, &cost, search_cfg,
-                )
-                .expect("expected lhs operand-prep plan");
-                let rhs_plan = solve_test_optimal_operand_prep_plan(
-                    &ctx, &rhs_stack, &args, &last_use, &cost, search_cfg,
-                )
-                .expect("expected rhs operand-prep plan");
-                let lhs_replayed = replay_plan(&lhs_stack, &lhs_plan);
-                let rhs_replayed = replay_plan(&rhs_stack, &rhs_plan);
-
-                assert_eq!(
-                    cost_for_steps(&lhs_plan.steps, &lhs_plan.key_infos, &cost),
-                    cost_for_steps(&rhs_plan.steps, &rhs_plan.key_infos, &cost),
-                    "paired ignored values should not change operand-prep cost: args={args:?}"
-                );
-                for (idx, &arg) in args.iter().enumerate() {
-                    assert_eq!(lhs_replayed.item_at(idx), Some(&StackItem::Value(arg)));
-                    assert_eq!(rhs_replayed.item_at(idx), Some(&StackItem::Value(arg)));
-                }
-            }
-        });
-    }
-
-    #[test]
     fn operand_prep_duplicate_non_last_use_keeps_operand_and_preserve_copies() {
         const SRC: &str = r#"
 target = "evm-ethereum-osaka"
@@ -6491,7 +6332,7 @@ block0:
 
             let plan = NormalizePlan {
                 cost: Cost::default(),
-                steps: vec![Step::PushImm(0)],
+                steps: smallvec::smallvec![Step::PushImm(0)],
                 key_infos: smallvec::smallvec![KeyInfo::Imm {
                     canon: I256::from(1),
                     rep_vid: imm1,
@@ -6571,7 +6412,7 @@ block0:
 
             let plan = NormalizePlan {
                 cost: Cost::default(),
-                steps: vec![Step::PushImm(0)],
+                steps: smallvec::smallvec![Step::PushImm(0)],
                 key_infos: smallvec::smallvec![KeyInfo::Imm {
                     canon: I256::from(1),
                     rep_vid: imm1,

--- a/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
@@ -47,6 +47,11 @@ impl Ord for Cost {
     }
 }
 
+const UNAVAILABLE_COST: Cost = Cost {
+    gas: u32::MAX,
+    bytes: u32::MAX,
+};
+
 pub(super) trait CostModel {
     fn cost_pop(&self) -> Cost;
     fn cost_dup(&self, pos: u8) -> Cost;
@@ -533,6 +538,107 @@ fn compute_cost_hash(cost: &impl CostModel, key_infos: &[KeyInfo], cfg: SearchCf
     }
 
     h.finish()
+}
+
+const OPERAND_PREP_DUP_COSTS: usize = 16;
+const OPERAND_PREP_SWAP_COSTS: usize = 17;
+const OPERAND_PREP_KEY_COSTS: usize = 64;
+
+#[derive(Clone)]
+struct OperandPrepCostTable {
+    pop: Cost,
+    dup: [Cost; OPERAND_PREP_DUP_COSTS],
+    swap: [Cost; OPERAND_PREP_SWAP_COSTS],
+    materialize: [Cost; OPERAND_PREP_KEY_COSTS],
+    min_dup_gas: u32,
+    surplus_last_use_penalty: Cost,
+}
+
+impl OperandPrepCostTable {
+    fn new(cost: &impl CostModel, key_infos: &[KeyInfo], cfg: SearchCfg) -> Option<Self> {
+        if cfg.dup_max > OPERAND_PREP_DUP_COSTS
+            || cfg.swap_max > OPERAND_PREP_SWAP_COSTS
+            || key_infos.len() > OPERAND_PREP_KEY_COSTS
+        {
+            return None;
+        }
+
+        let pop = cost.cost_pop();
+
+        let mut dup = [UNAVAILABLE_COST; OPERAND_PREP_DUP_COSTS];
+        for (pos, slot) in dup.iter_mut().take(cfg.dup_max).enumerate() {
+            *slot = cost.cost_dup(pos as u8);
+        }
+
+        let mut swap = [UNAVAILABLE_COST; OPERAND_PREP_SWAP_COSTS];
+        for (depth, slot) in swap.iter_mut().enumerate().take(cfg.swap_max).skip(1) {
+            *slot = cost.cost_swap(depth as u8);
+        }
+        if cfg.swap_max <= 1 {
+            swap[1] = cost.cost_swap(1);
+        }
+
+        let mut materialize = [UNAVAILABLE_COST; OPERAND_PREP_KEY_COSTS];
+        for (kid, info) in key_infos.iter().copied().enumerate() {
+            materialize[kid] = match info {
+                KeyInfo::Imm { canon, .. } => cost.cost_push_imm(canon),
+                KeyInfo::Val { vid } => cost.cost_load(vid),
+                KeyInfo::Ignored => UNAVAILABLE_COST,
+            };
+        }
+
+        let min_dup_gas = dup
+            .iter()
+            .take(cfg.dup_max)
+            .map(|cost| cost.gas)
+            .min()
+            .unwrap_or(u32::MAX);
+        let surplus_last_use_penalty = pop.saturating_add(swap[1]);
+
+        Some(Self {
+            pop,
+            dup,
+            swap,
+            materialize,
+            min_dup_gas,
+            surplus_last_use_penalty,
+        })
+    }
+
+    fn materialize_gas(&self, kid: u8) -> u32 {
+        self.materialize[kid as usize].gas
+    }
+
+    fn cost_hash(&self, key_infos: &[KeyInfo], cfg: SearchCfg) -> u64 {
+        let mut h = FxHasher::default();
+
+        write_cost_to_hash(&mut h, self.pop);
+        for &cost in self.dup.iter().take(cfg.dup_max) {
+            write_cost_to_hash(&mut h, cost);
+        }
+        for &cost in self.swap.iter().take(cfg.swap_max).skip(1) {
+            write_cost_to_hash(&mut h, cost);
+        }
+
+        for (kid, info) in key_infos.iter().enumerate() {
+            match info {
+                KeyInfo::Ignored => {
+                    h.write_u32(0);
+                    h.write_u32(0);
+                }
+                KeyInfo::Imm { .. } | KeyInfo::Val { .. } => {
+                    write_cost_to_hash(&mut h, self.materialize[kid]);
+                }
+            }
+        }
+
+        h.finish()
+    }
+}
+
+fn write_cost_to_hash(h: &mut FxHasher, cost: Cost) {
+    h.write_u32(cost.gas);
+    h.write_u32(cost.bytes);
 }
 
 fn common_suffix_len(state: PackedState, goal: PackedState) -> usize {
@@ -1726,7 +1832,7 @@ fn build_operand_prep_problem(
 
 fn operand_prep_cache_key(
     problem: &OperandPrepProblem,
-    cost: &impl CostModel,
+    costs: &OperandPrepCostTable,
     cfg: SearchCfg,
 ) -> PlanCacheKey {
     let effective_cfg = SearchCfg {
@@ -1739,7 +1845,7 @@ fn operand_prep_cache_key(
         swap_max: cfg.swap_max as u8,
         max_len: problem.max_len as u8,
         max_expansions: cfg.max_expansions as u32,
-        cost_hash: compute_cost_hash(cost, &problem.key_infos, effective_cfg),
+        cost_hash: costs.cost_hash(&problem.key_infos, effective_cfg),
         start: problem.start_state.window,
         goal: problem.goal_state,
         ctx: PackedState::EMPTY,
@@ -1768,6 +1874,20 @@ fn operand_prep_push0_cost(
     (push0_kid, push0_cost)
 }
 
+fn operand_prep_push0_cost_from_table(
+    problem: &OperandPrepProblem,
+    costs: &OperandPrepCostTable,
+) -> (Option<u8>, Option<Cost>) {
+    let push0_kid = problem.materializable_imm.iter().copied().find(|&kid| {
+        matches!(
+            problem.key_infos[kid as usize],
+            KeyInfo::Imm { canon, .. } if canon.is_zero()
+        )
+    });
+    let push0_cost = push0_kid.map(|kid| costs.materialize[kid as usize]);
+    (push0_kid, push0_cost)
+}
+
 fn prep_window_copy_count(state: PrepState, kid: u8) -> u8 {
     let mut count = 0u8;
     for idx in 0..state.window.len() {
@@ -1790,11 +1910,28 @@ fn prep_top_is_last_use(state: PrepState, last_use_mask: u64) -> bool {
 }
 
 fn prep_prefix_matches(window: PackedState, goal: &[u8]) -> bool {
-    window.len() >= goal.len()
-        && goal
-            .iter()
-            .enumerate()
-            .all(|(idx, &kid)| window.get(idx) == kid)
+    prep_prefix_len(window, goal) == goal.len()
+}
+
+fn prep_prefix_len(window: PackedState, goal: &[u8]) -> usize {
+    goal.iter()
+        .enumerate()
+        .take_while(|&(idx, &kid)| idx < window.len() && window.get(idx) == kid)
+        .count()
+}
+
+fn operand_prep_copy_can_help(
+    problem: &OperandPrepProblem,
+    state: PrepState,
+    kid: u8,
+    win: u8,
+) -> bool {
+    let bit = 1u64 << kid;
+    let prefix = prep_prefix_len(state.window, &problem.goal_keys);
+    win < problem.goal_counts[kid as usize]
+        || win.saturating_add(u8::from((state.tail & bit) != 0))
+            < prep_needed_copy_count(problem, state, kid)
+        || problem.goal_keys.get(prefix) == Some(&kid)
 }
 
 fn operand_prep_swap_pos(
@@ -2445,7 +2582,8 @@ pub(super) fn solve_optimal_operand_prep_plan(
         max_len: problem.max_len,
         ..cfg
     };
-    let cache_key = operand_prep_cache_key(&problem, cost, cfg);
+    let prep_costs = OperandPrepCostTable::new(cost, &problem.key_infos, cfg)?;
+    let cache_key = operand_prep_cache_key(&problem, &prep_costs, cfg);
 
     if let Some(hit) = scratch.plan_cache.get(&cache_key).cloned() {
         if debug {
@@ -2454,7 +2592,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
         return match hit {
             PlanCacheVal::None => None,
             PlanCacheVal::Steps(steps) => Some(NormalizePlan {
-                cost: cost_for_steps(&steps, &problem.key_infos, cost),
+                cost: cost_for_steps_with_table(&steps, &prep_costs),
                 steps,
                 key_infos: problem.key_infos,
                 goal_keys: problem.goal_keys,
@@ -2479,9 +2617,8 @@ pub(super) fn solve_optimal_operand_prep_plan(
         });
     }
 
-    let (push0_kid, push0_cost) = operand_prep_push0_cost(&problem, cost);
-    let pop_cost = cost.cost_pop();
-    let surplus_last_use_penalty = pop_cost.saturating_add(cost.cost_swap(1));
+    let (push0_kid, push0_cost) = operand_prep_push0_cost_from_table(&problem, &prep_costs);
+    let surplus_last_use_penalty = prep_costs.surplus_last_use_penalty;
     let Some((linear_steps, linear_cost)) =
         build_linear_operand_prep_upper_bound(&problem, true, cost, cfg)
     else {
@@ -2551,15 +2688,14 @@ pub(super) fn solve_optimal_operand_prep_plan(
         );
     }
 
-    let dup_gas_lb = minimal_dup_gas(cost, cfg.dup_max);
+    let dup_gas_lb = prep_costs.min_dup_gas;
     let start_h = heuristic_operand_prep(
         problem.start_state,
         &problem.goal_counts,
         problem.goal_mask,
         problem.preserve_mask,
         dup_gas_lb,
-        &problem.key_infos,
-        cost,
+        &prep_costs,
     );
 
     if should_prune(start_h, upper_bound, true) {
@@ -2650,6 +2786,12 @@ pub(super) fn solve_optimal_operand_prep_plan(
 
         let cur_len = entry.state.window.len();
 
+        let mut win_counts = [0u8; 64];
+        for pos in 0..cur_len {
+            let kid = entry.state.window.get(pos) as usize;
+            win_counts[kid] = win_counts[kid].saturating_add(1);
+        }
+
         let mut dup_cost_for_kid = [Cost {
             gas: u32::MAX,
             bytes: u32::MAX,
@@ -2660,7 +2802,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
             for pos in 0..=max_pos {
                 let kid = entry.state.window.get(pos) as usize;
                 duplicable |= 1u64 << kid;
-                dup_cost_for_kid[kid] = dup_cost_for_kid[kid].min(cost.cost_dup(pos as u8));
+                dup_cost_for_kid[kid] = dup_cost_for_kid[kid].min(prep_costs.dup[pos]);
             }
         }
 
@@ -2669,8 +2811,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
             goal_mask: problem.goal_mask,
             preserve_mask: problem.preserve_mask,
             dup_gas: dup_gas_lb,
-            key_infos: &problem.key_infos,
-            cost,
+            costs: &prep_costs,
             upper_bound,
             nodes: &mut *nodes,
             open: &mut *open,
@@ -2693,7 +2834,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
                 };
                 consider_prep_succ(
                     next,
-                    g.saturating_add(cost.cost_swap(depth as u8)),
+                    g.saturating_add(prep_costs.swap[depth]),
                     entry.state,
                     Step::Swap(depth as u8),
                     &mut consider_ctx,
@@ -2731,7 +2872,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
                         kid,
                         &problem.goal_counts,
                         problem.last_use_mask,
-                        cost.cost_dup(pos as u8),
+                        prep_costs.dup[pos],
                         surplus_last_use_penalty,
                     )),
                     entry.state,
@@ -2768,10 +2909,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
             if Some(kid) == push0_kid {
                 continue;
             }
-            let KeyInfo::Imm { canon, .. } = problem.key_infos[kid as usize] else {
-                unreachable!("expected imm key info")
-            };
-            let push_cost = cost.cost_push_imm(canon);
+            let push_cost = prep_costs.materialize[kid as usize];
             let bit = 1u64 << kid;
             let dominated = (duplicable & bit) != 0 && push_cost >= dup_cost_for_kid[kid as usize];
             if dominated {
@@ -2798,10 +2936,10 @@ pub(super) fn solve_optimal_operand_prep_plan(
 
         for &kid in &problem.materializable_val {
             let bit = 1u64 << kid;
+            if !operand_prep_copy_can_help(&problem, entry.state, kid, win_counts[kid as usize]) {
+                continue;
+            }
             let set_mem = (problem.preserve_mask & bit) != 0;
-            let KeyInfo::Val { vid } = problem.key_infos[kid as usize] else {
-                unreachable!("expected val key info")
-            };
             let next = prep_insert(
                 entry.state,
                 kid,
@@ -2817,7 +2955,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
                     kid,
                     &problem.goal_counts,
                     problem.last_use_mask,
-                    cost.cost_load(vid),
+                    prep_costs.materialize[kid as usize],
                     surplus_last_use_penalty,
                 )),
                 entry.state,
@@ -3018,6 +3156,18 @@ pub(super) fn cost_for_steps(steps: &[Step], key_infos: &[KeyInfo], cost: &impl 
                 };
                 cost.cost_load(vid)
             }
+        };
+        acc.saturating_add(c)
+    })
+}
+
+fn cost_for_steps_with_table(steps: &[Step], costs: &OperandPrepCostTable) -> Cost {
+    steps.iter().fold(Cost::default(), |acc, step| {
+        let c = match *step {
+            Step::Pop => costs.pop,
+            Step::Dup(pos) => costs.dup[pos as usize],
+            Step::Swap(depth) => costs.swap[depth as usize],
+            Step::PushImm(kid) | Step::LoadVal(kid) => costs.materialize[kid as usize],
         };
         acc.saturating_add(c)
     })
@@ -4021,14 +4171,13 @@ fn operand_prep_goal(
     true
 }
 
-fn heuristic_operand_prep<C: CostModel>(
+fn heuristic_operand_prep(
     state: PrepState,
     goal_counts: &[u8; 64],
     goal_mask: u64,
     preserve_mask: u64,
     dup_gas: u32,
-    key_infos: &[KeyInfo],
-    cost: &C,
+    costs: &OperandPrepCostTable,
 ) -> Cost {
     let mut win_counts = [0u8; 64];
     for i in 0..state.window.len() {
@@ -4059,7 +4208,7 @@ fn heuristic_operand_prep<C: CostModel>(
             continue;
         }
 
-        let mat = materialize_cost_gas(kid, key_infos, cost);
+        let mat = costs.materialize_gas(kid);
         let per_copy = mat.min(dup_gas);
         if have_window == 0 {
             gas = gas.saturating_add(mat);
@@ -4074,24 +4223,23 @@ fn heuristic_operand_prep<C: CostModel>(
     Cost { gas, bytes: 0 }
 }
 
-struct PrepConsiderCtx<'a, C: CostModel> {
+struct PrepConsiderCtx<'a> {
     goal_counts: &'a [u8; 64],
     goal_mask: u64,
     preserve_mask: u64,
     dup_gas: u32,
-    key_infos: &'a [KeyInfo],
-    cost: &'a C,
+    costs: &'a OperandPrepCostTable,
     upper_bound: Cost,
     nodes: &'a mut FxHashMap<PrepState, SearchNode<PrepState>>,
     open: &'a mut BinaryHeap<PrepQueueEntry>,
 }
 
-fn consider_prep_succ<C: CostModel>(
+fn consider_prep_succ(
     state: PrepState,
     g: Cost,
     parent_state: PrepState,
     step: Step,
-    ctx: &mut PrepConsiderCtx<'_, C>,
+    ctx: &mut PrepConsiderCtx<'_>,
 ) {
     let h = heuristic_operand_prep(
         state,
@@ -4099,8 +4247,7 @@ fn consider_prep_succ<C: CostModel>(
         ctx.goal_mask,
         ctx.preserve_mask,
         ctx.dup_gas,
-        ctx.key_infos,
-        ctx.cost,
+        ctx.costs,
     );
     let f = g.saturating_add(h);
     if should_prune(f, ctx.upper_bound, true) {
@@ -4233,6 +4380,45 @@ mod tests {
         (0..state.len()).map(|idx| state.get(idx)).collect()
     }
 
+    fn prep_state(ids: &[u8], tail: u64, mem: u64) -> PrepState {
+        PrepState {
+            window: PackedState::from_ids(ids).unwrap(),
+            tail,
+            mem,
+        }
+    }
+
+    fn operand_prep_test_problem(goal: &[u8], preserve_mask: u64) -> OperandPrepProblem {
+        let mut goal_counts = [0u8; 64];
+        let mut goal_mask = 0u64;
+        for &kid in goal {
+            goal_counts[kid as usize] += 1;
+            goal_mask |= 1u64 << kid;
+        }
+        let mut key_infos = KeyInfos::new();
+        key_infos.resize(
+            goal.iter().copied().max().unwrap_or(0) as usize + 1,
+            KeyInfo::Ignored,
+        );
+        OperandPrepProblem {
+            key_infos,
+            goal_keys: goal.iter().copied().collect(),
+            goal_mask,
+            goal_counts,
+            preserve_mask,
+            last_use_mask: 0,
+            materializable_imm: KeyIds::new(),
+            materializable_val: KeyIds::new(),
+            start_state: prep_state(&[], 0, 0),
+            goal_state: PackedState::from_ids(goal).unwrap(),
+            max_len: 6,
+        }
+    }
+
+    fn copy_can_help(problem: &OperandPrepProblem, state: PrepState, kid: u8) -> bool {
+        operand_prep_copy_can_help(problem, state, kid, prep_window_copy_count(state, kid))
+    }
+
     #[test]
     fn packed_state_roundtrip_ops_and_layout() {
         assert_eq!(std::mem::size_of::<PackedState>(), 16);
@@ -4260,6 +4446,25 @@ mod tests {
         assert_eq!(packed_state_ids(state.push_truncated(4, 3)), [4, 1, 2]);
         assert_eq!(packed_state_ids(state.push_truncated(4, 5)), [4, 1, 2, 3]);
         assert!(PackedState::from_ids(&[63]).unwrap() < PackedState::from_ids(&[0, 0]).unwrap());
+    }
+
+    #[test]
+    fn operand_prep_copy_help_prunes_surplus_available_copy() {
+        let problem = operand_prep_test_problem(&[0], 0);
+        assert!(!copy_can_help(&problem, prep_state(&[0, 0], 0, 0), 0));
+    }
+
+    #[test]
+    fn operand_prep_copy_help_keeps_next_prefix_copy() {
+        let problem = operand_prep_test_problem(&[0, 1], 0);
+        assert!(copy_can_help(&problem, prep_state(&[0, 2, 1], 0, 0), 1));
+    }
+
+    #[test]
+    fn operand_prep_copy_help_keeps_preserve_deficit_only() {
+        let problem = operand_prep_test_problem(&[0], 1);
+        assert!(copy_can_help(&problem, prep_state(&[0], 0, 0), 0));
+        assert!(!copy_can_help(&problem, prep_state(&[0], 1, 0), 0));
     }
 
     fn consider_brute_succ(

--- a/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
@@ -1,5 +1,6 @@
 use crate::bitset::BitSet;
 use rustc_hash::{FxHashMap, FxHasher};
+use smallvec::SmallVec;
 use sonatina_ir::{I256, Immediate, ValueId};
 use std::{
     cmp::Ordering,
@@ -129,7 +130,12 @@ pub(super) enum KeyInfo {
     Val {
         vid: ValueId,
     },
+    Ignored,
 }
+
+pub(super) type KeyInfos = SmallVec<[KeyInfo; 8]>;
+pub(super) type KeyIds = SmallVec<[u8; 8]>;
+type StackKeyIds = SmallVec<[u8; 21]>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum Step {
@@ -153,9 +159,9 @@ pub(super) struct NormalizePlan {
     #[cfg_attr(not(test), allow(dead_code))]
     pub(super) cost: Cost,
     pub(super) steps: Vec<Step>,
-    pub(super) key_infos: Vec<KeyInfo>,
+    pub(super) key_infos: KeyInfos,
     #[allow(dead_code)]
-    pub(super) goal_keys: Vec<u8>,
+    pub(super) goal_keys: KeyIds,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -519,6 +525,10 @@ fn compute_cost_hash(cost: &impl CostModel, key_infos: &[KeyInfo], cfg: SearchCf
                 h.write_u32(c.gas);
                 h.write_u32(c.bytes);
             }
+            KeyInfo::Ignored => {
+                h.write_u32(0);
+                h.write_u32(0);
+            }
         }
     }
 
@@ -608,11 +618,11 @@ pub(super) fn solve_optimal_normalize_plan(
     }
 
     let mut key_ids: FxHashMap<Key, u8> = FxHashMap::default();
-    let mut key_infos: Vec<KeyInfo> = Vec::new();
+    let mut key_infos: KeyInfos = SmallVec::new();
 
-    let mut goal_keys: Vec<u8> = Vec::with_capacity(desired.len());
-    let mut materializable_imm: Vec<u8> = Vec::new();
-    let mut materializable_val: Vec<u8> = Vec::new();
+    let mut goal_keys: KeyIds = SmallVec::new();
+    let mut materializable_imm: KeyIds = SmallVec::new();
+    let mut materializable_val: KeyIds = SmallVec::new();
     let mut seen_push: u64 = 0;
     let mut seen_load: u64 = 0;
 
@@ -632,7 +642,7 @@ pub(super) fn solve_optimal_normalize_plan(
         }
     }
 
-    let mut start_keys: Vec<u8> = Vec::with_capacity(start_limit);
+    let mut start_keys: StackKeyIds = SmallVec::new();
     for depth in 0..start_limit {
         let Some(StackItem::Value(v)) = stack.item_at(depth) else {
             return None;
@@ -1076,11 +1086,11 @@ pub(super) fn solve_optimal_repair_prefix_plan(
     }
 
     let mut key_ids: FxHashMap<Key, u8> = FxHashMap::default();
-    let mut key_infos: Vec<KeyInfo> = Vec::new();
+    let mut key_infos: KeyInfos = SmallVec::new();
 
-    let mut goal_keys: Vec<u8> = Vec::with_capacity(desired_prefix.len());
-    let mut materializable_imm: Vec<u8> = Vec::new();
-    let mut materializable_val: Vec<u8> = Vec::new();
+    let mut goal_keys: KeyIds = SmallVec::new();
+    let mut materializable_imm: KeyIds = SmallVec::new();
+    let mut materializable_val: KeyIds = SmallVec::new();
     let mut seen_push: u64 = 0;
     let mut seen_load: u64 = 0;
 
@@ -1100,7 +1110,7 @@ pub(super) fn solve_optimal_repair_prefix_plan(
         }
     }
 
-    let mut start_keys: Vec<u8> = Vec::with_capacity(start_repair);
+    let mut start_keys: StackKeyIds = SmallVec::new();
     for depth in 0..start_repair {
         let Some(StackItem::Value(v)) = stack.item_at(depth) else {
             return None;
@@ -1526,16 +1536,78 @@ pub(super) fn solve_optimal_repair_prefix_plan(
 }
 
 struct OperandPrepProblem {
-    key_infos: Vec<KeyInfo>,
-    goal_keys: Vec<u8>,
+    key_infos: KeyInfos,
+    goal_keys: KeyIds,
     goal_mask: u64,
     goal_counts: [u8; 64],
     preserve_mask: u64,
     last_use_mask: u64,
-    materializable_imm: Vec<u8>,
-    materializable_val: Vec<u8>,
+    materializable_imm: KeyIds,
+    materializable_val: KeyIds,
     start_state: PrepState,
     goal_state: PackedState,
+    max_len: usize,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct OperandPrepEffectiveWindow {
+    pub(super) start_len: usize,
+    pub(super) max_len: usize,
+}
+
+pub(super) fn operand_prep_effective_window(
+    ctx: &StackifyContext<'_>,
+    stack: &SymStack,
+    args: &[ValueId],
+    cfg: SearchCfg,
+) -> OperandPrepEffectiveWindow {
+    let arg_len = args.len().min(cfg.max_len);
+    if cfg.max_len == 0 || arg_len == 0 {
+        return OperandPrepEffectiveWindow {
+            start_len: 0,
+            max_len: arg_len,
+        };
+    }
+
+    let stack_cap = stack.len_above_func_ret().min(cfg.max_len);
+    let mut source_counts: FxHashMap<Key, usize> = FxHashMap::default();
+    for &arg in args {
+        *source_counts.entry(canonical_key(ctx, arg)).or_default() += 1;
+    }
+
+    let mut deepest_source: Option<usize> = None;
+    let mut remaining = args.len();
+    for depth in 0..stack_cap {
+        let Some(StackItem::Value(value)) = stack.item_at(depth) else {
+            continue;
+        };
+        let key = canonical_key(ctx, *value);
+        let Some(count) = source_counts.get_mut(&key) else {
+            continue;
+        };
+        if *count == 0 {
+            continue;
+        }
+
+        *count -= 1;
+        remaining -= 1;
+        deepest_source = Some(depth);
+        if remaining == 0 {
+            break;
+        }
+    }
+
+    let source_len = deepest_source.map_or(0, |depth| depth + 1);
+    let start_len = stack_cap.min(arg_len.max(source_len));
+    let max_len = if deepest_source.is_some() {
+        cfg.max_len.min(start_len.saturating_add(arg_len))
+    } else {
+        arg_len
+    }
+    .max(start_len)
+    .min(cfg.max_len);
+
+    OperandPrepEffectiveWindow { start_len, max_len }
 }
 
 fn build_operand_prep_problem(
@@ -1546,19 +1618,20 @@ fn build_operand_prep_problem(
     cfg: SearchCfg,
 ) -> Option<OperandPrepProblem> {
     let start_limit = stack.len_above_func_ret();
-    let window_len = start_limit.min(cfg.max_len);
+    let effective_window = operand_prep_effective_window(ctx, stack, args, cfg);
+    let window_len = start_limit.min(effective_window.start_len);
 
     let mut key_ids: FxHashMap<Key, u8> = FxHashMap::default();
-    let mut key_infos: Vec<KeyInfo> = Vec::new();
+    let mut key_infos: KeyInfos = SmallVec::new();
 
-    let mut goal_keys: Vec<u8> = Vec::with_capacity(args.len());
+    let mut goal_keys: KeyIds = SmallVec::new();
     let mut goal_mask: u64 = 0;
     let mut goal_counts: [u8; 64] = [0u8; 64];
     let mut preserve_mask: u64 = 0;
     let mut last_use_mask: u64 = 0;
 
-    let mut materializable_imm: Vec<u8> = Vec::new();
-    let mut materializable_val: Vec<u8> = Vec::new();
+    let mut materializable_imm: KeyIds = SmallVec::new();
+    let mut materializable_val: KeyIds = SmallVec::new();
     let mut seen_push: u64 = 0;
     let mut seen_load: u64 = 0;
 
@@ -1587,13 +1660,22 @@ fn build_operand_prep_problem(
         }
     }
 
-    let mut start_keys: Vec<u8> = Vec::with_capacity(window_len);
+    let mut start_keys: StackKeyIds = SmallVec::new();
     for depth in 0..window_len {
         let Some(StackItem::Value(v)) = stack.item_at(depth) else {
             return None;
         };
         let key = canonical_key(ctx, *v);
-        let kid = intern_key(ctx, key, *v, &mut key_ids, &mut key_infos)?;
+        let kid = if let Some(&kid) = key_ids.get(&key) {
+            kid
+        } else {
+            if key_infos.len() >= 64 {
+                return None;
+            }
+            let kid = key_infos.len() as u8;
+            key_infos.push(KeyInfo::Ignored);
+            kid
+        };
         start_keys.push(kid);
     }
 
@@ -1638,6 +1720,7 @@ fn build_operand_prep_problem(
             tail: tail_present,
             mem: 0,
         },
+        max_len: effective_window.max_len,
     })
 }
 
@@ -1646,13 +1729,17 @@ fn operand_prep_cache_key(
     cost: &impl CostModel,
     cfg: SearchCfg,
 ) -> PlanCacheKey {
+    let effective_cfg = SearchCfg {
+        max_len: problem.max_len,
+        ..cfg
+    };
     PlanCacheKey {
         mode: 2,
         dup_max: cfg.dup_max as u8,
         swap_max: cfg.swap_max as u8,
-        max_len: cfg.max_len as u8,
+        max_len: problem.max_len as u8,
         max_expansions: cfg.max_expansions as u32,
-        cost_hash: compute_cost_hash(cost, &problem.key_infos, cfg),
+        cost_hash: compute_cost_hash(cost, &problem.key_infos, effective_cfg),
         start: problem.start_state.window,
         goal: problem.goal_state,
         ctx: PackedState::EMPTY,
@@ -1835,6 +1922,10 @@ fn build_linear_operand_prep_upper_bound(
     cost: &impl CostModel,
     cfg: SearchCfg,
 ) -> Option<(Vec<Step>, Cost)> {
+    let cfg = SearchCfg {
+        max_len: problem.max_len,
+        ..cfg
+    };
     let ctx = OperandPrepUpperBoundCtx {
         problem,
         allow_copy_swap,
@@ -2023,6 +2114,10 @@ fn build_greedy_operand_prep_upper_bound(
     cfg: SearchCfg,
     upper_bound: Cost,
 ) -> Option<(Vec<Step>, Cost)> {
+    let cfg = SearchCfg {
+        max_len: problem.max_len,
+        ..cfg
+    };
     if operand_prep_goal(
         problem.start_state,
         &problem.goal_keys,
@@ -2294,6 +2389,10 @@ pub(super) fn solve_greedy_operand_prep_plan(
     cfg: SearchCfg,
 ) -> Option<NormalizePlan> {
     let problem = build_operand_prep_problem(ctx, stack, args, consume_last_use, cfg)?;
+    let cfg = SearchCfg {
+        max_len: problem.max_len,
+        ..cfg
+    };
     let (steps, cost) =
         build_linear_operand_prep_upper_bound(&problem, allow_copy_swap, cost, cfg)?;
     Some(NormalizePlan {
@@ -2319,8 +2418,8 @@ pub(super) fn solve_optimal_operand_prep_plan(
         return Some(NormalizePlan {
             cost: Cost::default(),
             steps: Vec::new(),
-            key_infos: Vec::new(),
-            goal_keys: Vec::new(),
+            key_infos: KeyInfos::new(),
+            goal_keys: KeyIds::new(),
         });
     }
 
@@ -2342,6 +2441,10 @@ pub(super) fn solve_optimal_operand_prep_plan(
     }
 
     let problem = build_operand_prep_problem(ctx, stack, args, consume_last_use, cfg)?;
+    let cfg = SearchCfg {
+        max_len: problem.max_len,
+        ..cfg
+    };
     let cache_key = operand_prep_cache_key(&problem, cost, cfg);
 
     if let Some(hit) = scratch.plan_cache.get(&cache_key).cloned() {
@@ -2411,17 +2514,41 @@ pub(super) fn solve_optimal_operand_prep_plan(
         incumbent_cost = greedy_cost;
     }
 
-    if high_arity_consuming {
+    let finish_incumbent = |scratch: &mut NormalizeSearchScratch,
+                            steps: Vec<Step>,
+                            plan_cost: Cost,
+                            key_infos: KeyInfos,
+                            goal_keys: KeyIds| {
         scratch
             .plan_cache
-            .insert(cache_key, PlanCacheVal::Steps(incumbent_steps.clone()));
+            .insert(cache_key, PlanCacheVal::Steps(steps.clone()));
 
-        return Some(NormalizePlan {
-            cost: incumbent_cost,
-            steps: incumbent_steps,
-            key_infos: problem.key_infos,
-            goal_keys: problem.goal_keys,
-        });
+        Some(NormalizePlan {
+            cost: plan_cost,
+            steps,
+            key_infos,
+            goal_keys,
+        })
+    };
+
+    if high_arity_consuming {
+        return finish_incumbent(
+            scratch,
+            incumbent_steps,
+            incumbent_cost,
+            problem.key_infos,
+            problem.goal_keys,
+        );
+    }
+
+    if cfg.max_expansions == 0 {
+        return finish_incumbent(
+            scratch,
+            incumbent_steps,
+            incumbent_cost,
+            problem.key_infos,
+            problem.goal_keys,
+        );
     }
 
     let dup_gas_lb = minimal_dup_gas(cost, cfg.dup_max);
@@ -2434,6 +2561,16 @@ pub(super) fn solve_optimal_operand_prep_plan(
         &problem.key_infos,
         cost,
     );
+
+    if should_prune(start_h, upper_bound, true) {
+        return finish_incumbent(
+            scratch,
+            incumbent_steps,
+            incumbent_cost,
+            problem.key_infos,
+            problem.goal_keys,
+        );
+    }
 
     scratch.clear_prep();
     let prep = &mut scratch.prep;
@@ -2690,16 +2827,13 @@ pub(super) fn solve_optimal_operand_prep_plan(
         }
     }
 
-    scratch
-        .plan_cache
-        .insert(cache_key, PlanCacheVal::Steps(incumbent_steps.clone()));
-
-    Some(NormalizePlan {
-        cost: incumbent_cost,
-        steps: incumbent_steps,
-        key_infos: problem.key_infos,
-        goal_keys: problem.goal_keys,
-    })
+    finish_incumbent(
+        scratch,
+        incumbent_steps,
+        incumbent_cost,
+        problem.key_infos,
+        problem.goal_keys,
+    )
 }
 
 pub(super) fn rebuild_operand_prep_plan(
@@ -2715,8 +2849,8 @@ pub(super) fn rebuild_operand_prep_plan(
         return Some(NormalizePlan {
             cost: Cost::default(),
             steps,
-            key_infos: Vec::new(),
-            goal_keys: Vec::new(),
+            key_infos: KeyInfos::new(),
+            goal_keys: KeyIds::new(),
         });
     }
 
@@ -2747,7 +2881,7 @@ fn intern_key(
     key: Key,
     rep_vid: ValueId,
     ids: &mut FxHashMap<Key, u8>,
-    infos: &mut Vec<KeyInfo>,
+    infos: &mut KeyInfos,
 ) -> Option<u8> {
     if let Some(&kid) = ids.get(&key) {
         return Some(kid);
@@ -3352,6 +3486,7 @@ fn materialize_copy_source<C: CostModel>(
             kid,
             cost: cost.cost_load(vid),
         },
+        KeyInfo::Ignored => unreachable!("ignored key is not materializable"),
     }
 }
 
@@ -3716,6 +3851,7 @@ fn materialize_cost_gas(kid: u8, key_infos: &[KeyInfo], cost: &impl CostModel) -
     match key_infos[kid as usize] {
         KeyInfo::Imm { canon, .. } => cost.cost_push_imm(canon).gas,
         KeyInfo::Val { vid } => cost.cost_load(vid).gas,
+        KeyInfo::Ignored => u32::MAX,
     }
 }
 
@@ -5452,11 +5588,11 @@ func public %f() {
                     .unwrap_or(flush_cost);
 
                 let mut key_ids: FxHashMap<Key, u8> = FxHashMap::default();
-                let mut key_infos: Vec<KeyInfo> = Vec::new();
+                let mut key_infos: KeyInfos = SmallVec::new();
 
-                let mut goal_keys: Vec<u8> = Vec::with_capacity(desired.len());
-                let mut materializable_imm: Vec<u8> = Vec::new();
-                let mut materializable_val: Vec<u8> = Vec::new();
+                let mut goal_keys: KeyIds = SmallVec::new();
+                let mut materializable_imm: KeyIds = SmallVec::new();
+                let mut materializable_val: KeyIds = SmallVec::new();
                 let mut seen_push: u64 = 0;
                 let mut seen_load: u64 = 0;
 
@@ -5477,7 +5613,7 @@ func public %f() {
                     }
                 }
 
-                let mut start_keys: Vec<u8> = Vec::with_capacity(stack.len_above_func_ret());
+                let mut start_keys: StackKeyIds = SmallVec::new();
                 for depth in 0..stack.len_above_func_ret() {
                     let Some(StackItem::Value(v)) = stack.item_at(depth) else {
                         panic!("unexpected non-value in start stack");
@@ -5511,6 +5647,497 @@ func public %f() {
                     "solver not optimal: solver={solver_cost:?} brute={brute_cost:?} start={start_vals:?} desired={desired:?}"
                 );
             }
+        });
+    }
+
+    #[test]
+    fn operand_prep_effective_window_shrinks_materialize_only_query() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+        let parsed = parse_module(SRC).unwrap();
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let args = [
+                func.dfg.make_imm_value(Immediate::I8(1)),
+                func.dfg.make_imm_value(Immediate::I8(2)),
+            ];
+            let unrelated: Vec<ValueId> = (0..20)
+                .map(|_| func.dfg.make_undef_value(Type::I256))
+                .collect();
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+
+            let mut stack = SymStack::entry_stack(func, false);
+            for &value in unrelated.iter().rev() {
+                stack.push_value(value);
+            }
+
+            let search_cfg = SearchCfg {
+                dup_max: ctx.reach.dup_max,
+                swap_max: ctx.reach.swap_max,
+                max_len: ctx.reach.swap_max,
+                max_expansions: 0,
+            };
+            let problem =
+                build_operand_prep_problem(&ctx, &stack, &args, &BitSet::default(), search_cfg)
+                    .expect("expected operand-prep problem");
+
+            assert_eq!(problem.start_state.window.len(), args.len());
+            assert_eq!(problem.max_len, args.len());
+            assert_eq!(problem.start_state.tail, 0);
+
+            let cost = EstimatedCostModel::default();
+            let plan = solve_test_optimal_operand_prep_plan(
+                &ctx,
+                &stack,
+                &args,
+                &BitSet::default(),
+                &cost,
+                search_cfg,
+            )
+            .expect("expected operand-prep plan");
+            let replayed = replay_plan(&stack, &plan);
+            assert_eq!(replayed.item_at(0), Some(&StackItem::Value(args[0])));
+            assert_eq!(replayed.item_at(1), Some(&StackItem::Value(args[1])));
+        });
+    }
+
+    #[test]
+    fn operand_prep_effective_window_uses_tail_for_deep_preserve_copy() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+        let parsed = parse_module(SRC).unwrap();
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let x = func.dfg.make_undef_value(Type::I256);
+            let imm = func.dfg.make_imm_value(Immediate::I8(7));
+            let filler: Vec<ValueId> = (0..10)
+                .map(|_| func.dfg.make_undef_value(Type::I256))
+                .collect();
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+
+            let mut stack = SymStack::entry_stack(func, false);
+            stack.push_value(x);
+            for &value in filler.iter().rev() {
+                stack.push_value(value);
+            }
+            stack.push_value(x);
+
+            let args = [x, imm];
+            let search_cfg = SearchCfg {
+                dup_max: ctx.reach.dup_max,
+                swap_max: ctx.reach.swap_max,
+                max_len: ctx.reach.swap_max,
+                max_expansions: 0,
+            };
+            let problem =
+                build_operand_prep_problem(&ctx, &stack, &args, &BitSet::default(), search_cfg)
+                    .expect("expected operand-prep problem");
+
+            assert_eq!(problem.start_state.window.len(), args.len());
+            assert_eq!(problem.max_len, args.len() * 2);
+            assert_ne!(problem.preserve_mask, 0);
+            assert_eq!(
+                problem.start_state.tail & problem.preserve_mask,
+                problem.preserve_mask
+            );
+        });
+    }
+
+    #[test]
+    fn operand_prep_effective_window_keeps_deep_operand_source() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+        let parsed = parse_module(SRC).unwrap();
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let x = func.dfg.make_undef_value(Type::I256);
+            let imm = func.dfg.make_imm_value(Immediate::I8(9));
+            let filler: Vec<ValueId> = (0..15)
+                .map(|_| func.dfg.make_undef_value(Type::I256))
+                .collect();
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+
+            let mut stack = SymStack::entry_stack(func, false);
+            stack.push_value(x);
+            for &value in filler.iter().rev() {
+                stack.push_value(value);
+            }
+
+            let args = [imm, x];
+            let search_cfg = SearchCfg {
+                dup_max: ctx.reach.dup_max,
+                swap_max: ctx.reach.swap_max,
+                max_len: ctx.reach.swap_max,
+                max_expansions: 50_000,
+            };
+            let problem =
+                build_operand_prep_problem(&ctx, &stack, &args, &BitSet::default(), search_cfg)
+                    .expect("expected operand-prep problem");
+
+            assert_eq!(problem.start_state.window.len(), 16);
+            assert_eq!(problem.max_len, ctx.reach.swap_max);
+
+            let cost = EstimatedCostModel {
+                load_cost: Cost {
+                    gas: 1_000,
+                    bytes: 1_000,
+                },
+            };
+            let plan = solve_test_optimal_operand_prep_plan(
+                &ctx,
+                &stack,
+                &args,
+                &BitSet::default(),
+                &cost,
+                search_cfg,
+            )
+            .expect("expected operand-prep plan");
+
+            assert!(
+                plan.steps.iter().any(|step| matches!(step, Step::Dup(15))),
+                "expected plan to reuse deep source: {:?}",
+                plan.steps
+            );
+            assert!(
+                !plan
+                    .steps
+                    .iter()
+                    .any(|step| matches!(step, Step::LoadVal(_))),
+                "expected plan to avoid load: {:?}",
+                plan.steps
+            );
+        });
+    }
+
+    #[test]
+    fn operand_prep_anonymizes_ignored_values_in_effective_window() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+        let parsed = parse_module(SRC).unwrap();
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let x = func.dfg.make_undef_value(Type::I256);
+            let ignored_a = func.dfg.make_undef_value(Type::I256);
+            let ignored_b = func.dfg.make_undef_value(Type::I256);
+            let ignored_c = func.dfg.make_undef_value(Type::I256);
+            let ignored_d = func.dfg.make_undef_value(Type::I256);
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let search_cfg = SearchCfg {
+                dup_max: ctx.reach.dup_max,
+                swap_max: ctx.reach.swap_max,
+                max_len: ctx.reach.swap_max,
+                max_expansions: 50_000,
+            };
+
+            let build_problem = |top: ValueId, mid: ValueId| {
+                let mut stack = SymStack::entry_stack(func, false);
+                stack.push_value(x);
+                stack.push_value(mid);
+                stack.push_value(top);
+                build_operand_prep_problem(&ctx, &stack, &[x], &BitSet::default(), search_cfg)
+                    .expect("expected operand-prep problem")
+            };
+
+            let lhs = build_problem(ignored_a, ignored_b);
+            let rhs = build_problem(ignored_c, ignored_d);
+            let ids = packed_state_ids(lhs.start_state.window);
+
+            assert_eq!(ids.len(), 3);
+            assert_eq!(lhs.start_state.window, rhs.start_state.window);
+            assert_eq!(lhs.key_infos.len(), 3);
+            assert_ne!(ids[0], ids[1]);
+            assert_ne!(ids[0], ids[2]);
+            assert!(matches!(lhs.key_infos[ids[0] as usize], KeyInfo::Ignored));
+            assert!(matches!(lhs.key_infos[ids[1] as usize], KeyInfo::Ignored));
+            assert!(matches!(
+                lhs.key_infos[ids[2] as usize],
+                KeyInfo::Val { vid } if vid == x
+            ));
+            assert_eq!(lhs.goal_keys.as_slice(), &[ids[2]]);
+            assert_eq!(lhs.materializable_val.as_slice(), &[ids[2]]);
+        });
+    }
+
+    #[test]
+    fn operand_prep_random_ignored_value_pairs_replay_equivalently() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+        let parsed = parse_module(SRC).unwrap();
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let a = func.dfg.make_undef_value(Type::I256);
+            let b = func.dfg.make_undef_value(Type::I256);
+            let c = func.dfg.make_undef_value(Type::I256);
+            let imm0 = func.dfg.make_imm_value(Immediate::I8(0));
+            let imm1 = func.dfg.make_imm_value(Immediate::I8(1));
+            let relevant = [a, b, c, imm0, imm1];
+            let ignored_lhs: [ValueId; 8] =
+                std::array::from_fn(|_| func.dfg.make_undef_value(Type::I256));
+            let ignored_rhs: [ValueId; 8] =
+                std::array::from_fn(|_| func.dfg.make_undef_value(Type::I256));
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let search_cfg = SearchCfg {
+                dup_max: 6,
+                swap_max: 6,
+                max_len: 6,
+                max_expansions: 100_000,
+            };
+            let cost = EstimatedCostModel::default();
+
+            struct Rng(u64);
+            impl Rng {
+                fn next_u32(&mut self) -> u32 {
+                    let mut x = self.0;
+                    x ^= x << 13;
+                    x ^= x >> 7;
+                    x ^= x << 17;
+                    self.0 = x;
+                    (x >> 32) as u32
+                }
+
+                fn gen_range(&mut self, n: usize) -> usize {
+                    (self.next_u32() as usize) % n
+                }
+            }
+
+            let mut rng = Rng(0x7c15_9e37_79b9_4a7c);
+            for _ in 0..80 {
+                let args_len = 2 + rng.gen_range(2);
+                let stack_len = args_len + rng.gen_range(search_cfg.max_len + 1 - args_len);
+                let mut args = Vec::with_capacity(args_len);
+                let mut last_use = BitSet::default();
+                for _ in 0..args_len {
+                    let arg = relevant[rng.gen_range(relevant.len())];
+                    args.push(arg);
+                    last_use.insert(arg);
+                }
+
+                let mut lhs_stack = SymStack::entry_stack(func, false);
+                let mut rhs_stack = SymStack::entry_stack(func, false);
+                for slot in (0..stack_len).rev() {
+                    if rng.gen_range(3) == 0 {
+                        let value = relevant[rng.gen_range(relevant.len())];
+                        lhs_stack.push_value(value);
+                        rhs_stack.push_value(value);
+                    } else {
+                        lhs_stack.push_value(ignored_lhs[slot]);
+                        rhs_stack.push_value(ignored_rhs[slot]);
+                    }
+                }
+
+                let lhs_plan = solve_test_optimal_operand_prep_plan(
+                    &ctx, &lhs_stack, &args, &last_use, &cost, search_cfg,
+                )
+                .expect("expected lhs operand-prep plan");
+                let rhs_plan = solve_test_optimal_operand_prep_plan(
+                    &ctx, &rhs_stack, &args, &last_use, &cost, search_cfg,
+                )
+                .expect("expected rhs operand-prep plan");
+                let lhs_replayed = replay_plan(&lhs_stack, &lhs_plan);
+                let rhs_replayed = replay_plan(&rhs_stack, &rhs_plan);
+
+                assert_eq!(
+                    cost_for_steps(&lhs_plan.steps, &lhs_plan.key_infos, &cost),
+                    cost_for_steps(&rhs_plan.steps, &rhs_plan.key_infos, &cost),
+                    "paired ignored values should not change operand-prep cost: args={args:?}"
+                );
+                for (idx, &arg) in args.iter().enumerate() {
+                    assert_eq!(lhs_replayed.item_at(idx), Some(&StackItem::Value(arg)));
+                    assert_eq!(rhs_replayed.item_at(idx), Some(&StackItem::Value(arg)));
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn operand_prep_duplicate_non_last_use_keeps_operand_and_preserve_copies() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+        let parsed = parse_module(SRC).unwrap();
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let x = func.dfg.make_undef_value(Type::I256);
+            let filler = func.dfg.make_undef_value(Type::I256);
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+
+            let mut stack = SymStack::entry_stack(func, false);
+            stack.push_value(x);
+            stack.push_value(filler);
+            stack.push_value(x);
+
+            let args = [x, x];
+            let search_cfg = SearchCfg {
+                dup_max: ctx.reach.dup_max,
+                swap_max: ctx.reach.swap_max,
+                max_len: ctx.reach.swap_max,
+                max_expansions: 50_000,
+            };
+            let problem =
+                build_operand_prep_problem(&ctx, &stack, &args, &BitSet::default(), search_cfg)
+                    .expect("expected operand-prep problem");
+
+            assert_eq!(problem.start_state.window.len(), 3);
+            assert_eq!(problem.max_len, 5);
+
+            let cost = EstimatedCostModel {
+                load_cost: Cost {
+                    gas: 1_000,
+                    bytes: 1_000,
+                },
+            };
+            let plan = solve_test_optimal_operand_prep_plan(
+                &ctx,
+                &stack,
+                &args,
+                &BitSet::default(),
+                &cost,
+                search_cfg,
+            )
+            .expect("expected operand-prep plan");
+
+            assert!(
+                !plan
+                    .steps
+                    .iter()
+                    .any(|step| matches!(step, Step::LoadVal(_))),
+                "expected stack copies to satisfy duplicate operands and preserve copy: {:?}",
+                plan.steps
+            );
+            let replayed = replay_plan(&stack, &plan);
+            assert_eq!(replayed.item_at(0), Some(&StackItem::Value(x)));
+            assert_eq!(replayed.item_at(1), Some(&StackItem::Value(x)));
         });
     }
 
@@ -5660,12 +6287,12 @@ block0:
             let plan = NormalizePlan {
                 cost: Cost::default(),
                 steps: vec![Step::PushImm(0)],
-                key_infos: vec![KeyInfo::Imm {
+                key_infos: smallvec::smallvec![KeyInfo::Imm {
                     canon: I256::from(1),
                     rep_vid: imm1,
                     rep_imm: Immediate::I8(1),
                 }],
-                goal_keys: vec![0],
+                goal_keys: smallvec::smallvec![0],
             };
 
             assert!(
@@ -5740,12 +6367,12 @@ block0:
             let plan = NormalizePlan {
                 cost: Cost::default(),
                 steps: vec![Step::PushImm(0)],
-                key_infos: vec![KeyInfo::Imm {
+                key_infos: smallvec::smallvec![KeyInfo::Imm {
                     canon: I256::from(1),
                     rep_vid: imm1,
                     rep_imm: Immediate::I8(1),
                 }],
-                goal_keys: vec![0],
+                goal_keys: smallvec::smallvec![0],
             };
 
             assert!(

--- a/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
@@ -5,7 +5,7 @@ use std::{
     cmp::Ordering,
     collections::{BinaryHeap, VecDeque},
     hash::{Hash, Hasher},
-    sync::{Mutex, OnceLock},
+    sync::OnceLock,
 };
 
 use super::{
@@ -14,6 +14,7 @@ use super::{
         sym_stack::{StackItem, SymStack},
     },
     Planner,
+    operand_prep::OperandPrepPlanCache,
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -356,7 +357,6 @@ const NORMALIZE_PLAN_CACHE_CAP: usize = 4096;
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 struct PlanCacheKey {
     mode: u8,
-    func_ptr: usize,
     dup_max: u8,
     swap_max: u8,
     max_len: u8,
@@ -414,6 +414,8 @@ impl<S: Eq + Hash, Q> SearchScratch<S, Q> {
 pub(in crate::stackalloc::stackify) struct NormalizeSearchScratch {
     exact: SearchScratch<PackedState, QueueEntry>,
     prep: SearchScratch<PrepState, PrepQueueEntry>,
+    plan_cache: PlanCache,
+    pub(super) operand_prep_plan_cache: OperandPrepPlanCache,
 }
 
 impl NormalizeSearchScratch {
@@ -468,9 +470,10 @@ impl PlanCache {
     }
 }
 
-fn plan_cache() -> &'static Mutex<PlanCache> {
-    static CACHE: OnceLock<Mutex<PlanCache>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(PlanCache::new()))
+impl Default for PlanCache {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 fn normalize_search_debug_enabled() -> bool {
@@ -648,7 +651,6 @@ pub(super) fn solve_optimal_normalize_plan(
 
     let cache_key = PlanCacheKey {
         mode: 0,
-        func_ptr: ctx.func as *const _ as usize,
         dup_max: cfg.dup_max as u8,
         swap_max: cfg.swap_max as u8,
         max_len: cfg.max_len as u8,
@@ -662,10 +664,7 @@ pub(super) fn solve_optimal_normalize_plan(
         ctx_bits2: 0,
     };
 
-    if let Some(hit) = {
-        let cache = plan_cache().lock().unwrap();
-        cache.get(&cache_key).cloned()
-    } {
+    if let Some(hit) = scratch.plan_cache.get(&cache_key).cloned() {
         if debug {
             eprintln!("normalize_search: cache hit");
         }
@@ -681,9 +680,8 @@ pub(super) fn solve_optimal_normalize_plan(
     }
 
     if start == goal {
-        plan_cache()
-            .lock()
-            .unwrap()
+        scratch
+            .plan_cache
             .insert(cache_key, PlanCacheVal::Steps(Vec::new()));
         return Some(NormalizePlan {
             cost: Cost::default(),
@@ -991,7 +989,7 @@ pub(super) fn solve_optimal_normalize_plan(
         );
     }
 
-    plan_cache().lock().unwrap().insert(
+    scratch.plan_cache.insert(
         cache_key,
         incumbent_steps
             .as_ref()
@@ -1133,7 +1131,6 @@ pub(super) fn solve_optimal_repair_prefix_plan(
 
     let cache_key = PlanCacheKey {
         mode: 1,
-        func_ptr: ctx.func as *const _ as usize,
         dup_max: cfg.dup_max as u8,
         swap_max: cfg.swap_max as u8,
         max_len: cfg.max_len as u8,
@@ -1147,10 +1144,7 @@ pub(super) fn solve_optimal_repair_prefix_plan(
         ctx_bits2: 0,
     };
 
-    if let Some(hit) = {
-        let cache = plan_cache().lock().unwrap();
-        cache.get(&cache_key).cloned()
-    } {
+    if let Some(hit) = scratch.plan_cache.get(&cache_key).cloned() {
         if debug {
             eprintln!("repair_normalize_search: cache hit");
         }
@@ -1166,9 +1160,8 @@ pub(super) fn solve_optimal_repair_prefix_plan(
     }
 
     if start == goal {
-        plan_cache()
-            .lock()
-            .unwrap()
+        scratch
+            .plan_cache
             .insert(cache_key, PlanCacheVal::Steps(Vec::new()));
         return Some(NormalizePlan {
             cost: Cost::default(),
@@ -1515,7 +1508,7 @@ pub(super) fn solve_optimal_repair_prefix_plan(
         );
     }
 
-    plan_cache().lock().unwrap().insert(
+    scratch.plan_cache.insert(
         cache_key,
         incumbent_steps
             .as_ref()
@@ -1649,14 +1642,12 @@ fn build_operand_prep_problem(
 }
 
 fn operand_prep_cache_key(
-    ctx: &StackifyContext<'_>,
     problem: &OperandPrepProblem,
     cost: &impl CostModel,
     cfg: SearchCfg,
 ) -> PlanCacheKey {
     PlanCacheKey {
         mode: 2,
-        func_ptr: ctx.func as *const _ as usize,
         dup_max: cfg.dup_max as u8,
         swap_max: cfg.swap_max as u8,
         max_len: cfg.max_len as u8,
@@ -2351,12 +2342,9 @@ pub(super) fn solve_optimal_operand_prep_plan(
     }
 
     let problem = build_operand_prep_problem(ctx, stack, args, consume_last_use, cfg)?;
-    let cache_key = operand_prep_cache_key(ctx, &problem, cost, cfg);
+    let cache_key = operand_prep_cache_key(&problem, cost, cfg);
 
-    if let Some(hit) = {
-        let cache = plan_cache().lock().unwrap();
-        cache.get(&cache_key).cloned()
-    } {
+    if let Some(hit) = scratch.plan_cache.get(&cache_key).cloned() {
         if debug {
             eprintln!("operand_prep_search: cache hit");
         }
@@ -2377,9 +2365,8 @@ pub(super) fn solve_optimal_operand_prep_plan(
         problem.preserve_mask,
         &problem.goal_counts,
     ) {
-        plan_cache()
-            .lock()
-            .unwrap()
+        scratch
+            .plan_cache
             .insert(cache_key, PlanCacheVal::Steps(Vec::new()));
         return Some(NormalizePlan {
             cost: Cost::default(),
@@ -2398,10 +2385,7 @@ pub(super) fn solve_optimal_operand_prep_plan(
         if debug {
             eprintln!("operand_prep_search: linear greedy plan failed goal check");
         }
-        plan_cache()
-            .lock()
-            .unwrap()
-            .insert(cache_key, PlanCacheVal::None);
+        scratch.plan_cache.insert(cache_key, PlanCacheVal::None);
         return None;
     };
 
@@ -2428,9 +2412,8 @@ pub(super) fn solve_optimal_operand_prep_plan(
     }
 
     if high_arity_consuming {
-        plan_cache()
-            .lock()
-            .unwrap()
+        scratch
+            .plan_cache
             .insert(cache_key, PlanCacheVal::Steps(incumbent_steps.clone()));
 
         return Some(NormalizePlan {
@@ -2707,9 +2690,8 @@ pub(super) fn solve_optimal_operand_prep_plan(
         }
     }
 
-    plan_cache()
-        .lock()
-        .unwrap()
+    scratch
+        .plan_cache
         .insert(cache_key, PlanCacheVal::Steps(incumbent_steps.clone()));
 
     Some(NormalizePlan {

--- a/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
@@ -8,7 +8,7 @@ use super::{
     Planner,
     normalize::SpillAwareCostModel,
     normalize_search::{
-        Cost, CostModel, KeyInfo, NormalizePlan, SearchCfg, Step, cost_for_steps,
+        Cost, CostModel, KeyInfo, NormalizePlan, SearchCfg, Step, StepList, cost_for_steps,
         operand_prep_effective_window, rebuild_operand_prep_plan, solve_greedy_operand_prep_plan,
         solve_optimal_operand_prep_plan,
     },
@@ -24,7 +24,7 @@ struct UnaryOperandPrepCandidate {
     modeled_cost: Cost,
     emitted_cost: Cost,
     priority: u8,
-    steps: SmallVec<[Step; 2]>,
+    steps: StepList,
 }
 
 impl UnaryOperandPrepCandidate {
@@ -71,8 +71,23 @@ struct OperandPrepQueryKey {
     deep_preserve_mask: u64,
 }
 
+#[derive(Clone, Debug)]
+pub(super) struct CachedOperandPrepPlan {
+    pub(super) modeled_cost: Cost,
+    pub(super) steps: StepList,
+}
+
+impl CachedOperandPrepPlan {
+    fn from_plan(plan: &NormalizePlan) -> Self {
+        Self {
+            modeled_cost: plan.cost,
+            steps: plan.steps.clone(),
+        }
+    }
+}
+
 pub(super) struct OperandPrepPlanCache {
-    map: FxHashMap<OperandPrepQueryKey, Vec<Step>>,
+    map: FxHashMap<OperandPrepQueryKey, CachedOperandPrepPlan>,
     order: VecDeque<OperandPrepQueryKey>,
 }
 
@@ -84,11 +99,11 @@ impl OperandPrepPlanCache {
         }
     }
 
-    fn get(&self, key: &OperandPrepQueryKey) -> Option<&Vec<Step>> {
+    fn get(&self, key: &OperandPrepQueryKey) -> Option<&CachedOperandPrepPlan> {
         self.map.get(key)
     }
 
-    fn insert(&mut self, key: OperandPrepQueryKey, val: Vec<Step>) {
+    fn insert(&mut self, key: OperandPrepQueryKey, val: CachedOperandPrepPlan) {
         if let Some(existing) = self.map.get_mut(&key) {
             *existing = val;
             return;
@@ -103,6 +118,10 @@ impl OperandPrepPlanCache {
             };
             self.map.remove(&old);
         }
+    }
+
+    fn insert_plan(&mut self, key: OperandPrepQueryKey, plan: &NormalizePlan) {
+        self.insert(key, CachedOperandPrepPlan::from_plan(plan));
     }
 }
 
@@ -315,7 +334,6 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
             self.stack,
             args,
             consume_last_use,
-            &cost,
             search_cfg,
             hit,
         ) {
@@ -334,7 +352,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         if let (Some(cache_key), Some(plan)) = (cache_key, &plan) {
             self.search_scratch
                 .operand_prep_plan_cache
-                .insert(cache_key, plan.steps.clone());
+                .insert_plan(cache_key, plan);
         }
         plan
     }
@@ -373,7 +391,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
                 modeled_cost: Cost::default(),
                 emitted_cost: Cost::default(),
                 priority: 0,
-                steps: SmallVec::new(),
+                steps: StepList::new(),
             });
         }
 
@@ -425,7 +443,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
                 modeled_cost: emitted_cost,
                 emitted_cost,
                 priority: 3,
-                steps: SmallVec::from_buf([Step::Swap(pos as u8), Step::Dup(0)]),
+                steps: smallvec::smallvec![Step::Swap(pos as u8), Step::Dup(0)],
             });
         }
 
@@ -445,7 +463,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
 
         Some(NormalizePlan {
             cost: candidate.modeled_cost,
-            steps: candidate.steps.into_vec(),
+            steps: candidate.steps,
             key_infos: smallvec::smallvec![key_info],
             goal_keys: smallvec::smallvec![0],
         })
@@ -909,18 +927,22 @@ mod tests {
         stack
     }
 
+    fn step_list<const N: usize>(steps: [Step; N]) -> StepList {
+        steps.into_iter().collect()
+    }
+
     #[test]
     fn commutative_plan_comparison_uses_emitted_step_cost() {
         let cost = EstimatedCostModel::default();
         let cheaper_emitted = NormalizePlan {
             cost: Cost { gas: 99, bytes: 99 },
-            steps: vec![Step::Dup(0)],
+            steps: smallvec::smallvec![Step::Dup(0)],
             key_infos: SmallVec::new(),
             goal_keys: SmallVec::new(),
         };
         let pricier_emitted = NormalizePlan {
             cost: Cost::default(),
-            steps: vec![Step::Swap(1), Step::Swap(1)],
+            steps: smallvec::smallvec![Step::Swap(1), Step::Swap(1)],
             key_infos: SmallVec::new(),
             goal_keys: SmallVec::new(),
         };
@@ -942,7 +964,7 @@ mod tests {
         };
         let pop = NormalizePlan {
             cost: cost.cost_pop(),
-            steps: vec![Step::Pop],
+            steps: smallvec::smallvec![Step::Pop],
             key_infos: SmallVec::new(),
             goal_keys: SmallVec::new(),
         };
@@ -952,7 +974,7 @@ mod tests {
         };
         let swap = NormalizePlan {
             cost: cost.cost_swap(1),
-            steps: vec![Step::Swap(1)],
+            steps: smallvec::smallvec![Step::Swap(1)],
             key_infos: SmallVec::new(),
             goal_keys: SmallVec::new(),
         };
@@ -961,7 +983,7 @@ mod tests {
         assert!(commutative_plan_is_unbeatable(
             &NormalizePlan {
                 cost: Cost::default(),
-                steps: Vec::new(),
+                steps: StepList::new(),
                 key_infos: SmallVec::new(),
                 goal_keys: SmallVec::new(),
             },
@@ -970,122 +992,6 @@ mod tests {
         ));
         assert!(!commutative_plan_is_unbeatable(&penalized_pop, &cost, cfg));
         assert!(!commutative_plan_is_unbeatable(&swap, &cost, cfg));
-    }
-
-    #[test]
-    fn operand_prep_query_key_tracks_immediate_payloads() {
-        const SRC: &str = r#"
-target = "evm-ethereum-osaka"
-
-func public %f() {
-block0:
-    return;
-}
-"#;
-
-        let parsed = parse_module(SRC).expect("module parses");
-        let func_ref = parsed.debug.func_order[0];
-
-        parsed.module.func_store.modify(func_ref, |func| {
-            let imm = func.dfg.make_imm_value(Immediate::I8(1));
-
-            let key_before = {
-                let mut cfg = ControlFlowGraph::new();
-                cfg.compute(func);
-                let entry = cfg.entry().expect("missing entry block");
-
-                let mut liveness = Liveness::new();
-                liveness.compute(func, &cfg);
-
-                let mut dom = DomTree::new();
-                dom.compute(&cfg);
-
-                let mut scc = CfgSccAnalysis::new();
-                scc.compute(&cfg);
-
-                let reach = StackifyReachability::new(16);
-                let ctx =
-                    build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
-
-                let spill_set = BitSet::default();
-                let mut spill_requests = BitSet::default();
-                let mut object_spill_requests = BitSet::default();
-                let forced_object_spills = BitSet::default();
-                let spill_obj = SecondaryMap::new();
-                let mut free_slots = FreeSlotPools::default();
-                let mut slots = SpillSlotPools::default();
-                let mem = MemPlan::new(
-                    SpillSet::new(&spill_set),
-                    &mut spill_requests,
-                    &ctx,
-                    &spill_obj,
-                    &ctx.exact_local_addr,
-                    &mut object_spill_requests,
-                    &forced_object_spills,
-                    &mut free_slots,
-                    &mut slots,
-                );
-
-                let mut stack = SymStack::entry_stack(func, false);
-                let mut actions = crate::stackalloc::Actions::new();
-                let mut search_scratch = NormalizeSearchScratch::default();
-                let planner =
-                    Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
-                let search_cfg = planner.operand_prep_search_cfg(1);
-                planner.operand_prep_query_key(&[imm], &BitSet::default(), search_cfg)
-            };
-
-            func.dfg.immediates.remove(&Immediate::I8(1));
-            func.dfg.values[imm] = Value::Immediate {
-                imm: Immediate::I8(2),
-                ty: Type::I8,
-            };
-            func.dfg.immediates.insert(Immediate::I8(2), imm);
-
-            let mut cfg = ControlFlowGraph::new();
-            cfg.compute(func);
-            let entry = cfg.entry().expect("missing entry block");
-
-            let mut liveness = Liveness::new();
-            liveness.compute(func, &cfg);
-
-            let mut dom = DomTree::new();
-            dom.compute(&cfg);
-
-            let mut scc = CfgSccAnalysis::new();
-            scc.compute(&cfg);
-
-            let reach = StackifyReachability::new(16);
-            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
-
-            let spill_set = BitSet::default();
-            let mut spill_requests = BitSet::default();
-            let mut object_spill_requests = BitSet::default();
-            let forced_object_spills = BitSet::default();
-            let spill_obj = SecondaryMap::new();
-            let mut free_slots = FreeSlotPools::default();
-            let mut slots = SpillSlotPools::default();
-            let mem = MemPlan::new(
-                SpillSet::new(&spill_set),
-                &mut spill_requests,
-                &ctx,
-                &spill_obj,
-                &ctx.exact_local_addr,
-                &mut object_spill_requests,
-                &forced_object_spills,
-                &mut free_slots,
-                &mut slots,
-            );
-
-            let mut stack = SymStack::entry_stack(func, false);
-            let mut actions = crate::stackalloc::Actions::new();
-            let mut search_scratch = NormalizeSearchScratch::default();
-            let planner = Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
-            let search_cfg = planner.operand_prep_search_cfg(1);
-            let key_after = planner.operand_prep_query_key(&[imm], &BitSet::default(), search_cfg);
-
-            assert_ne!(key_before, key_after);
-        });
     }
 
     #[test]
@@ -1157,13 +1063,20 @@ block0:
             let old_key = planner.operand_prep_query_key(&old_args, &BitSet::default(), search_cfg);
             let current_key =
                 planner.operand_prep_query_key(&current_args, &BitSet::default(), search_cfg);
+            let changed_key =
+                planner.operand_prep_query_key(&[imm2, imm2, imm3], &BitSet::default(), search_cfg);
 
             assert_eq!(old_key, current_key);
+            assert_ne!(current_key, changed_key);
 
-            planner
-                .search_scratch
-                .operand_prep_plan_cache
-                .insert(old_key, vec![Step::PushImm(0)]);
+            let modeled_cost = Cost { gas: 99, bytes: 99 };
+            planner.search_scratch.operand_prep_plan_cache.insert(
+                old_key,
+                CachedOperandPrepPlan {
+                    modeled_cost,
+                    steps: [Step::PushImm(0)].into_iter().collect(),
+                },
+            );
 
             let plan = planner
                 .solve_operand_prep_cached(&current_args, &BitSet::default())
@@ -1181,6 +1094,7 @@ block0:
 
             assert_eq!(*rep_vid, current_imm);
             assert_eq!(*rep_imm, Immediate::I8(1));
+            assert_eq!(plan.cost, modeled_cost);
         });
     }
 
@@ -1307,6 +1221,8 @@ block0:
 
             let query_key = |values: &[ValueId]| {
                 let mut spill_requests = BitSet::default();
+                let mut object_spill_requests = BitSet::default();
+                let forced_object_spills = BitSet::default();
                 let mut free_slots = FreeSlotPools::default();
                 let mut slots = SpillSlotPools::default();
                 let mem = MemPlan::new(
@@ -1315,6 +1231,8 @@ block0:
                     &ctx,
                     &spill_obj,
                     &ctx.exact_local_addr,
+                    &mut object_spill_requests,
+                    &forced_object_spills,
                     &mut free_slots,
                     &mut slots,
                 );
@@ -1376,6 +1294,8 @@ block0:
 
             let query_key = |top: ValueId| {
                 let mut spill_requests = BitSet::default();
+                let mut object_spill_requests = BitSet::default();
+                let forced_object_spills = BitSet::default();
                 let mut free_slots = FreeSlotPools::default();
                 let mut slots = SpillSlotPools::default();
                 let mem = MemPlan::new(
@@ -1384,6 +1304,8 @@ block0:
                     &ctx,
                     &spill_obj,
                     &ctx.exact_local_addr,
+                    &mut object_spill_requests,
+                    &forced_object_spills,
                     &mut free_slots,
                     &mut slots,
                 );
@@ -1448,6 +1370,8 @@ block0:
             let spill_set = BitSet::default();
             let spill_obj = SecondaryMap::new();
             let mut spill_requests = BitSet::default();
+            let mut object_spill_requests = BitSet::default();
+            let forced_object_spills = BitSet::default();
             let mut free_slots = FreeSlotPools::default();
             let mut slots = SpillSlotPools::default();
             let mem = MemPlan::new(
@@ -1456,6 +1380,8 @@ block0:
                 &ctx,
                 &spill_obj,
                 &ctx.exact_local_addr,
+                &mut object_spill_requests,
+                &forced_object_spills,
                 &mut free_slots,
                 &mut slots,
             );
@@ -1518,6 +1444,8 @@ block0:
 
             let query_key = |values: &[ValueId]| {
                 let mut spill_requests = BitSet::default();
+                let mut object_spill_requests = BitSet::default();
+                let forced_object_spills = BitSet::default();
                 let mut free_slots = FreeSlotPools::default();
                 let mut slots = SpillSlotPools::default();
                 let mem = MemPlan::new(
@@ -1526,6 +1454,8 @@ block0:
                     &ctx,
                     &spill_obj,
                     &ctx.exact_local_addr,
+                    &mut object_spill_requests,
+                    &forced_object_spills,
                     &mut free_slots,
                     &mut slots,
                 );
@@ -1590,6 +1520,8 @@ block0:
             let mut search_scratch = NormalizeSearchScratch::default();
             let mut solve_with = |ignored: ValueId| {
                 let mut spill_requests = BitSet::default();
+                let mut object_spill_requests = BitSet::default();
+                let forced_object_spills = BitSet::default();
                 let mut free_slots = FreeSlotPools::default();
                 let mut slots = SpillSlotPools::default();
                 let mem = MemPlan::new(
@@ -1598,6 +1530,8 @@ block0:
                     &ctx,
                     &spill_obj,
                     &ctx.exact_local_addr,
+                    &mut object_spill_requests,
+                    &forced_object_spills,
                     &mut free_slots,
                     &mut slots,
                 );
@@ -1663,6 +1597,8 @@ block0:
 
             let solve_steps = |mut stack: SymStack, arg: ValueId, last_use: &BitSet<ValueId>| {
                 let mut spill_requests = BitSet::default();
+                let mut object_spill_requests = BitSet::default();
+                let forced_object_spills = BitSet::default();
                 let mut free_slots = FreeSlotPools::default();
                 let mut slots = SpillSlotPools::default();
                 let mem = MemPlan::new(
@@ -1671,6 +1607,8 @@ block0:
                     &ctx,
                     &spill_obj,
                     &ctx.exact_local_addr,
+                    &mut object_spill_requests,
+                    &forced_object_spills,
                     &mut free_slots,
                     &mut slots,
                 );
@@ -1692,7 +1630,7 @@ block0:
             let stack = SymStack::entry_stack(func, false);
             assert_eq!(
                 solve_steps(stack, arg, &BitSet::default()),
-                vec![Step::Dup(0)]
+                step_list([Step::Dup(0)])
             );
 
             let mut stack = SymStack::entry_stack(func, false);
@@ -1707,12 +1645,15 @@ block0:
             let mut last_use = BitSet::default();
             last_use.insert(arg);
             let stack = SymStack::entry_stack(func, false);
-            assert_eq!(solve_steps(stack, arg, &last_use), vec![Step::Swap(2)]);
+            assert_eq!(
+                solve_steps(stack, arg, &last_use),
+                step_list([Step::Swap(2)])
+            );
 
             let stack = SymStack::entry_stack(func, false);
             assert_eq!(
                 solve_steps(stack, arg, &BitSet::default()),
-                vec![Step::Swap(2), Step::Dup(0)]
+                step_list([Step::Swap(2), Step::Dup(0)])
             );
         });
     }
@@ -1761,6 +1702,8 @@ block0:
                        commutative| {
                 let spill_set: BitSet<ValueId> = spill_values.iter().copied().collect();
                 let mut spill_requests = BitSet::default();
+                let mut object_spill_requests = BitSet::default();
+                let forced_object_spills = BitSet::default();
                 let mut free_slots = FreeSlotPools::default();
                 let mut slots = SpillSlotPools::default();
                 let mem = MemPlan::new(
@@ -1769,6 +1712,8 @@ block0:
                     &ctx,
                     &spill_obj,
                     &ctx.exact_local_addr,
+                    &mut object_spill_requests,
+                    &forced_object_spills,
                     &mut free_slots,
                     &mut slots,
                 );

--- a/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
@@ -2,10 +2,7 @@ use crate::bitset::BitSet;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use sonatina_ir::{Immediate, InstId, ValueId};
-use std::{
-    collections::VecDeque,
-    sync::{Mutex, OnceLock},
-};
+use std::collections::VecDeque;
 
 use super::{
     Planner,
@@ -36,7 +33,6 @@ enum OperandPrepStackKey {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct OperandPrepQueryKey {
-    func_ptr: usize,
     dup_max: u8,
     swap_max: u8,
     max_len: u8,
@@ -48,7 +44,7 @@ struct OperandPrepQueryKey {
     deep_preserve_mask: u64,
 }
 
-struct OperandPrepPlanCache {
+pub(super) struct OperandPrepPlanCache {
     map: FxHashMap<OperandPrepQueryKey, Vec<Step>>,
     order: VecDeque<OperandPrepQueryKey>,
 }
@@ -83,9 +79,10 @@ impl OperandPrepPlanCache {
     }
 }
 
-fn operand_prep_plan_cache() -> &'static Mutex<OperandPrepPlanCache> {
-    static CACHE: OnceLock<Mutex<OperandPrepPlanCache>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(OperandPrepPlanCache::new()))
+impl Default for OperandPrepPlanCache {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 fn commutative_plan_cmp_key(
@@ -178,7 +175,6 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
     ) -> OperandPrepQueryKey {
         let stack_len = self.stack.len_above_func_ret().min(search_cfg.max_len);
         OperandPrepQueryKey {
-            func_ptr: self.ctx.func as *const _ as usize,
             dup_max: search_cfg.dup_max as u8,
             swap_max: search_cfg.swap_max as u8,
             max_len: search_cfg.max_len as u8,
@@ -217,8 +213,10 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
             .then(|| self.operand_prep_query_key(args, consume_last_use, search_cfg));
 
         if let Some(hit) = cache_key.as_ref().and_then(|cache_key| {
-            let cache = operand_prep_plan_cache().lock().unwrap();
-            cache.get(cache_key).cloned()
+            self.search_scratch
+                .operand_prep_plan_cache
+                .get(cache_key)
+                .cloned()
         }) && let Some(plan) = rebuild_operand_prep_plan(
             self.ctx,
             self.stack,
@@ -241,9 +239,8 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
             self.search_scratch,
         );
         if let (Some(cache_key), Some(plan)) = (cache_key, &plan) {
-            operand_prep_plan_cache()
-                .lock()
-                .unwrap()
+            self.search_scratch
+                .operand_prep_plan_cache
                 .insert(cache_key, plan.steps.clone());
         }
         plan
@@ -756,9 +753,9 @@ block0:
 
             assert_eq!(old_key, current_key);
 
-            operand_prep_plan_cache()
-                .lock()
-                .unwrap()
+            planner
+                .search_scratch
+                .operand_prep_plan_cache
                 .insert(old_key, vec![Step::PushImm(0)]);
 
             let plan = planner

--- a/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
@@ -127,6 +127,31 @@ fn commutative_plan_cmp_key(
     )
 }
 
+fn minimum_positive_operand_prep_cost(cost: &impl CostModel, cfg: SearchCfg) -> Cost {
+    let mut best = cost.cost_pop().min(cost.cost_push_imm(I256::zero()));
+    for pos in 0..cfg.dup_max.min(usize::from(u8::MAX) + 1) {
+        best = best.min(cost.cost_dup(pos as u8));
+    }
+    for depth in 1..=cfg.swap_max.min(usize::from(u8::MAX)) {
+        best = best.min(cost.cost_swap(depth as u8));
+    }
+    best
+}
+
+fn commutative_plan_is_unbeatable(
+    plan: &NormalizePlan,
+    cost: &impl CostModel,
+    cfg: SearchCfg,
+) -> bool {
+    let key = commutative_plan_cmp_key(plan, cost);
+    if key.0 == Cost::default() {
+        return true;
+    }
+
+    let min = minimum_positive_operand_prep_cost(cost, cfg);
+    key == (min, min, 1)
+}
+
 impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
     fn use_operand_prep_query_cache(&self, args_len: usize) -> bool {
         // The exact solver already has its own structural cache. Keep unary uncached because
@@ -329,7 +354,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         let top_matches = self
             .stack
             .top()
-            .is_some_and(|item| self.unary_operand_prep_item_matches_arg(item, arg, arg_imm));
+            .is_some_and(|item| self.operand_prep_item_matches_arg(item, arg, arg_imm));
         let preserve_satisfied = arg_is_imm || last_use || copy_count >= 2;
         let surplus_last_use_penalty = cost.cost_pop().saturating_add(cost.cost_swap(1));
 
@@ -438,7 +463,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         }
     }
 
-    fn unary_operand_prep_item_matches_arg(
+    fn operand_prep_item_matches_arg(
         &self,
         item: &StackItem,
         arg: ValueId,
@@ -464,7 +489,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         self.stack
             .iter()
             .take(self.stack.len_above_func_ret())
-            .filter(|item| self.unary_operand_prep_item_matches_arg(item, arg, arg_imm))
+            .filter(|item| self.operand_prep_item_matches_arg(item, arg, arg_imm))
             .count()
     }
 
@@ -484,7 +509,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
             .iter()
             .skip(start)
             .take(limit - start)
-            .position(|item| self.unary_operand_prep_item_matches_arg(item, arg, arg_imm))
+            .position(|item| self.operand_prep_item_matches_arg(item, arg, arg_imm))
             .map(|off| start + off)
     }
 
@@ -512,41 +537,38 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         consume_last_use: &BitSet<ValueId>,
         commutative_pair: bool,
     ) {
-        // If all operands are last-use values that are already in the required order on the
-        // current stack top, avoid the operand-preparation machinery entirely. The instruction
-        // will consume them directly.
-        if !args.is_empty()
-            && args.iter().all(|&v| consume_last_use.contains(v))
-            && self.stack_prefix_matches(args)
-        {
-            return;
-        }
-
         // For commutative binary ops, try both operand orders and choose the cheaper
         // operand-preparation plan. This is purely a bytecode optimization (SSA semantics are
         // unchanged).
         if commutative_pair && args.len() == 2 && args[0] != args[1] {
-            // Fast path: if the operands are last-use and already occupy the top two stack slots
-            // (in either order), use that order and consume them as-is.
-            if consume_last_use.contains(args[0]) && consume_last_use.contains(args[1]) {
-                if self.stack_prefix_matches(args) {
-                    return;
-                }
-                let mut swapped: SmallVec<[ValueId; 8]> = args.clone();
-                swapped.swap(0, 1);
-                if self.stack_prefix_matches(&swapped) {
-                    args.swap(0, 1);
-                    return;
-                }
+            if self.stack_prefix_matches_and_preserved(args, consume_last_use) {
+                return;
             }
 
-            let original_plan = self.solve_operand_prep_cached(args.as_slice(), consume_last_use);
+            let mut swapped: SmallVec<[ValueId; 8]> = args.clone();
+            swapped.swap(0, 1);
+            if self.stack_prefix_matches_and_preserved(&swapped, consume_last_use) {
+                args.swap(0, 1);
+                return;
+            }
 
-            let mut swapped_args = args.clone();
+            let cost = SpillAwareCostModel::new(self.mem.spill_set());
+            let search_cfg = self.operand_prep_search_cfg(args.len());
+            let original_plan = self.solve_operand_prep_cached(args.as_slice(), consume_last_use);
+            if let Some(plan) = original_plan.as_ref()
+                && commutative_plan_is_unbeatable(plan, &cost, search_cfg)
+            {
+                if !self.apply_operand_prep_plan(plan, args.as_slice()) {
+                    self.prepare_operands_greedy(args.as_slice(), consume_last_use);
+                }
+                debug_assert!(self.stack_prefix_matches(args.as_slice()));
+                return;
+            }
+
+            let mut swapped_args: SmallVec<[ValueId; 8]> = args.clone();
             swapped_args.swap(0, 1);
             let swapped_plan =
                 self.solve_operand_prep_cached(swapped_args.as_slice(), consume_last_use);
-            let cost = SpillAwareCostModel::new(self.mem.spill_set());
 
             let (plan, swapped) = match (original_plan, swapped_plan) {
                 (Some(plan), None) => (plan, false),
@@ -611,6 +633,90 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
             .all(|(item, arg)| item == &StackItem::Value(arg))
     }
 
+    fn stack_item_matches_arg(&self, depth: usize, arg: ValueId) -> bool {
+        self.stack.item_at(depth).is_some_and(|item| {
+            self.operand_prep_item_matches_arg(item, arg, self.ctx.func.dfg.value_imm(arg))
+        })
+    }
+
+    fn stack_prefix_matches_and_preserved(
+        &mut self,
+        args: &[ValueId],
+        consume_last_use: &BitSet<ValueId>,
+    ) -> bool {
+        if args.is_empty() || self.stack.len_above_func_ret() < args.len() {
+            return false;
+        }
+
+        for (depth, &arg) in args.iter().enumerate() {
+            if !self.stack_item_matches_arg(depth, arg) {
+                return false;
+            }
+        }
+
+        let mut checked = BitSet::default();
+        let stack_len = self.stack.len_above_func_ret();
+        for &arg in args {
+            if self.ctx.func.dfg.value_is_imm(arg)
+                || consume_last_use.contains(arg)
+                || !checked.insert(arg)
+            {
+                continue;
+            }
+
+            let preserved_on_stack = self
+                .stack
+                .iter()
+                .take(stack_len)
+                .skip(args.len())
+                .any(|item| item == &StackItem::Value(arg));
+            if !preserved_on_stack && !self.mem.spill_set().contains(arg) {
+                return false;
+            }
+        }
+
+        self.rename_immediate_slots_to_match(args)
+    }
+
+    fn prepare_trivial_binary_operands(
+        &mut self,
+        args: &[ValueId],
+        consume_last_use: &BitSet<ValueId>,
+    ) -> bool {
+        let &[lhs, rhs] = args else {
+            return false;
+        };
+
+        if self.stack.len_above_func_ret() >= 3
+            && self.stack_item_matches_arg(0, rhs)
+            && self.stack_item_matches_arg(1, lhs)
+            && self.stack_item_matches_arg(2, rhs)
+        {
+            let stack_before = self.stack.clone();
+            let actions_before = self.actions.len();
+            self.stack.pop(self.actions);
+            if self.stack_prefix_matches_and_preserved(args, consume_last_use) {
+                return true;
+            }
+            *self.stack = stack_before;
+            self.actions.truncate(actions_before);
+        }
+
+        if !self.ctx.func.dfg.value_is_imm(lhs)
+            && !self.ctx.func.dfg.value_is_imm(rhs)
+            && self.stack_item_matches_arg(0, rhs)
+            && self.stack_item_matches_arg(1, lhs)
+        {
+            let reversed = [rhs, lhs];
+            if self.stack_prefix_matches_and_preserved(&reversed, consume_last_use) {
+                self.stack.swap(1, self.actions);
+                return true;
+            }
+        }
+
+        false
+    }
+
     fn operand_prep_search_cfg(&self, args_len: usize) -> SearchCfg {
         let max_len = if args_len > self.ctx.reach.swap_max {
             args_len.min(21)
@@ -659,6 +765,16 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         consume_last_use: &BitSet<ValueId>,
     ) {
         if args.is_empty() {
+            return;
+        }
+
+        if self.stack_prefix_matches_and_preserved(args, consume_last_use) {
+            debug_assert!(self.stack_prefix_matches(args));
+            return;
+        }
+
+        if self.prepare_trivial_binary_operands(args, consume_last_use) {
+            debug_assert!(self.stack_prefix_matches(args));
             return;
         }
 
@@ -772,7 +888,7 @@ mod tests {
                 builder::StackifyReachability,
                 planner::{
                     MemPlan, NormalizeSearchScratch, Planner,
-                    normalize_search::{Cost, EstimatedCostModel, KeyInfo, Step},
+                    normalize_search::{Cost, EstimatedCostModel, KeyInfo, SearchCfg, Step},
                     test_utils::build_stackify_test_context,
                 },
                 slots::{FreeSlotPools, SpillSlotPools},
@@ -784,6 +900,14 @@ mod tests {
     use cranelift_entity::SecondaryMap;
     use sonatina_ir::{I256, Immediate, Type, Value, cfg::ControlFlowGraph};
     use sonatina_parser::parse_module;
+
+    fn stack_from_top(values: &[ValueId]) -> SymStack {
+        let mut stack = SymStack::opaque_prefix_empty(false);
+        for &value in values.iter().rev() {
+            stack.push_value(value);
+        }
+        stack
+    }
 
     #[test]
     fn commutative_plan_comparison_uses_emitted_step_cost() {
@@ -805,6 +929,47 @@ mod tests {
             commutative_plan_cmp_key(&cheaper_emitted, &cost)
                 < commutative_plan_cmp_key(&pricier_emitted, &cost)
         );
+    }
+
+    #[test]
+    fn commutative_unbeatable_plan_requires_full_minimum_key() {
+        let cost = EstimatedCostModel::default();
+        let cfg = SearchCfg {
+            dup_max: 16,
+            swap_max: 16,
+            max_len: 16,
+            max_expansions: 50_000,
+        };
+        let pop = NormalizePlan {
+            cost: cost.cost_pop(),
+            steps: vec![Step::Pop],
+            key_infos: SmallVec::new(),
+            goal_keys: SmallVec::new(),
+        };
+        let penalized_pop = NormalizePlan {
+            cost: Cost { gas: 99, bytes: 99 },
+            ..pop.clone()
+        };
+        let swap = NormalizePlan {
+            cost: cost.cost_swap(1),
+            steps: vec![Step::Swap(1)],
+            key_infos: SmallVec::new(),
+            goal_keys: SmallVec::new(),
+        };
+
+        assert!(commutative_plan_is_unbeatable(&pop, &cost, cfg));
+        assert!(commutative_plan_is_unbeatable(
+            &NormalizePlan {
+                cost: Cost::default(),
+                steps: Vec::new(),
+                key_infos: SmallVec::new(),
+                goal_keys: SmallVec::new(),
+            },
+            &cost,
+            cfg
+        ));
+        assert!(!commutative_plan_is_unbeatable(&penalized_pop, &cost, cfg));
+        assert!(!commutative_plan_is_unbeatable(&swap, &cost, cfg));
     }
 
     #[test]
@@ -1549,6 +1714,111 @@ block0:
                 solve_steps(stack, arg, &BitSet::default()),
                 vec![Step::Swap(2), Step::Dup(0)]
             );
+        });
+    }
+
+    #[test]
+    fn already_prepared_prefix_fast_path_preserves_top_operands() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f(v0.i256, v1.i256, v2.i256) {
+block0:
+    return;
+}
+"#;
+
+        let parsed = parse_module(SRC).expect("module parses");
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let old_imm = func.dfg.make_imm_value(Immediate::I8(7));
+            let current_imm = func.dfg.make_value(Value::Immediate {
+                imm: Immediate::I8(7),
+                ty: Type::I8,
+            });
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let spill_obj = SecondaryMap::new();
+            let run = |stack_values: &[ValueId],
+                       args_values: &[ValueId],
+                       spill_values: &[ValueId],
+                       last_use_values: &[ValueId],
+                       commutative| {
+                let spill_set: BitSet<ValueId> = spill_values.iter().copied().collect();
+                let mut spill_requests = BitSet::default();
+                let mut free_slots = FreeSlotPools::default();
+                let mut slots = SpillSlotPools::default();
+                let mem = MemPlan::new(
+                    SpillSet::new(&spill_set),
+                    &mut spill_requests,
+                    &ctx,
+                    &spill_obj,
+                    &ctx.exact_local_addr,
+                    &mut free_slots,
+                    &mut slots,
+                );
+                let mut stack = stack_from_top(stack_values);
+                let mut args: SmallVec<[ValueId; 8]> = args_values.iter().copied().collect();
+                let mut last_use = BitSet::default();
+                for &value in last_use_values {
+                    last_use.insert(value);
+                }
+                let mut actions = crate::stackalloc::Actions::new();
+                let mut search_scratch = NormalizeSearchScratch::default();
+                {
+                    let mut planner =
+                        Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+                    planner.prepare_operands_maybe_commutative(&mut args, &last_use, commutative);
+                    assert!(planner.stack_prefix_matches(&args));
+                }
+                (stack, args, actions, spill_requests)
+            };
+
+            let [x, y, z] = func.arg_values.as_slice() else {
+                panic!("expected three function args")
+            };
+
+            let (_, _, actions, _) = run(&[*x, *y, *x, *y], &[*x, *y], &[], &[], false);
+            assert!(actions.is_empty());
+
+            let (_, _, actions, _) = run(&[*x, *x, *x], &[*x, *x], &[], &[], false);
+            assert!(actions.is_empty());
+
+            let (_, _, actions, _) = run(&[*x, *x], &[*x, *x], &[], &[], false);
+            assert!(!actions.is_empty());
+
+            let (_, _, actions, spill_requests) = run(&[*z], &[*z], &[*z], &[], false);
+            assert!(actions.is_empty());
+            assert!(spill_requests.is_empty());
+
+            let (_, args, actions, _) = run(&[*y, *x], &[*x, *y], &[*x, *y], &[], true);
+            assert_eq!(args.as_slice(), &[*y, *x]);
+            assert!(actions.is_empty());
+
+            let (_, _, actions, _) = run(&[*y, *x, *y], &[*x, *y], &[], &[*x, *y], false);
+            assert_eq!(actions.as_slice(), &[Action::Pop]);
+
+            let (_, _, actions, _) = run(&[*y, *x, *x, *y], &[*x, *y], &[], &[], false);
+            assert_eq!(actions.as_slice(), &[Action::StackSwap(1)]);
+
+            let (stack, _, actions, _) = run(&[old_imm], &[current_imm], &[], &[], false);
+            assert_eq!(stack.item_at(0), Some(&StackItem::Value(current_imm)));
+            assert!(actions.is_empty());
         });
     }
 

--- a/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/operand_prep.rs
@@ -1,15 +1,16 @@
 use crate::bitset::BitSet;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
-use sonatina_ir::{Immediate, InstId, ValueId};
+use sonatina_ir::{I256, Immediate, InstId, ValueId};
 use std::collections::VecDeque;
 
 use super::{
     Planner,
     normalize::SpillAwareCostModel,
     normalize_search::{
-        CostModel, NormalizePlan, SearchCfg, Step, cost_for_steps, rebuild_operand_prep_plan,
-        solve_greedy_operand_prep_plan, solve_optimal_operand_prep_plan,
+        Cost, CostModel, KeyInfo, NormalizePlan, SearchCfg, Step, cost_for_steps,
+        operand_prep_effective_window, rebuild_operand_prep_plan, solve_greedy_operand_prep_plan,
+        solve_optimal_operand_prep_plan,
     },
 };
 
@@ -18,6 +19,25 @@ use super::super::{CONSUME_LAST_USE_MAX_SWAPS, sym_stack::StackItem};
 const OPERAND_PREP_PLAN_CACHE_CAP: usize = 4096;
 const OPERAND_PREP_QUERY_MASK_BITS: usize = u64::BITS as usize;
 
+#[derive(Clone)]
+struct UnaryOperandPrepCandidate {
+    modeled_cost: Cost,
+    emitted_cost: Cost,
+    priority: u8,
+    steps: SmallVec<[Step; 2]>,
+}
+
+impl UnaryOperandPrepCandidate {
+    fn cmp_key(&self) -> (Cost, Cost, usize, u8) {
+        (
+            self.modeled_cost,
+            self.emitted_cost,
+            self.steps.len(),
+            self.priority,
+        )
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum OperandPrepValueKey {
     Imm(Immediate),
@@ -25,8 +45,15 @@ enum OperandPrepValueKey {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum OperandPrepCanonicalKey {
+    Imm(I256),
+    Val(ValueId),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum OperandPrepStackKey {
     Value(OperandPrepValueKey),
+    Ignored,
     FuncRetAddr,
     CallRetAddr,
 }
@@ -126,10 +153,9 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         &self,
         args: &[ValueId],
         consume_last_use: &BitSet<ValueId>,
-        search_cfg: SearchCfg,
+        window_len: usize,
     ) -> u64 {
         let start_limit = self.stack.len_above_func_ret();
-        let window_len = start_limit.min(search_cfg.max_len);
         if start_limit == window_len {
             return 0;
         }
@@ -157,10 +183,28 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         }
     }
 
-    fn operand_prep_stack_key(&self, item: &StackItem) -> OperandPrepStackKey {
+    fn operand_prep_canonical_key(&self, value: ValueId) -> OperandPrepCanonicalKey {
+        if let Some(imm) = self.ctx.func.dfg.value_imm(value) {
+            OperandPrepCanonicalKey::Imm(imm.as_i256())
+        } else {
+            OperandPrepCanonicalKey::Val(value)
+        }
+    }
+
+    fn operand_prep_stack_key(
+        &self,
+        item: &StackItem,
+        relevant_values: &[(OperandPrepCanonicalKey, OperandPrepValueKey)],
+    ) -> OperandPrepStackKey {
         match *item {
             StackItem::Value(value) => {
-                OperandPrepStackKey::Value(self.operand_prep_value_key(value))
+                let key = self.operand_prep_canonical_key(value);
+                relevant_values
+                    .iter()
+                    .find_map(|&(relevant, arg_key)| {
+                        (relevant == key).then_some(OperandPrepStackKey::Value(arg_key))
+                    })
+                    .unwrap_or(OperandPrepStackKey::Ignored)
             }
             StackItem::FuncRetAddr => OperandPrepStackKey::FuncRetAddr,
             StackItem::CallRetAddr => OperandPrepStackKey::CallRetAddr,
@@ -173,22 +217,38 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
         consume_last_use: &BitSet<ValueId>,
         search_cfg: SearchCfg,
     ) -> OperandPrepQueryKey {
-        let stack_len = self.stack.len_above_func_ret().min(search_cfg.max_len);
+        let effective_window =
+            operand_prep_effective_window(self.ctx, self.stack, args, search_cfg);
+        let stack_len = self
+            .stack
+            .len_above_func_ret()
+            .min(effective_window.start_len);
+        let mut arg_keys: SmallVec<[OperandPrepValueKey; 8]> = SmallVec::new();
+        let mut relevant_values: SmallVec<[(OperandPrepCanonicalKey, OperandPrepValueKey); 8]> =
+            SmallVec::new();
+        for &arg in args {
+            let arg_key = self.operand_prep_value_key(arg);
+            let canonical_key = self.operand_prep_canonical_key(arg);
+            if !relevant_values
+                .iter()
+                .any(|&(relevant, _)| relevant == canonical_key)
+            {
+                relevant_values.push((canonical_key, arg_key));
+            }
+            arg_keys.push(arg_key);
+        }
         OperandPrepQueryKey {
             dup_max: search_cfg.dup_max as u8,
             swap_max: search_cfg.swap_max as u8,
-            max_len: search_cfg.max_len as u8,
+            max_len: effective_window.max_len as u8,
             max_expansions: search_cfg.max_expansions as u32,
             stack: self
                 .stack
                 .iter()
                 .take(stack_len)
-                .map(|item| self.operand_prep_stack_key(item))
+                .map(|item| self.operand_prep_stack_key(item, &relevant_values))
                 .collect(),
-            args: args
-                .iter()
-                .map(|&arg| self.operand_prep_value_key(arg))
-                .collect(),
+            args: arg_keys,
             last_use_mask: self.operand_prep_query_mask(args, |arg| consume_last_use.contains(arg)),
             spilled_arg_mask: self.operand_prep_query_mask(args, |arg| {
                 !self.ctx.func.dfg.value_is_imm(arg) && self.mem.spill_set().contains(arg)
@@ -196,7 +256,7 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
             deep_preserve_mask: self.operand_prep_deep_preserve_mask(
                 args,
                 consume_last_use,
-                search_cfg,
+                effective_window.start_len,
             ),
         }
     }
@@ -208,6 +268,14 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
     ) -> Option<NormalizePlan> {
         let search_cfg = self.operand_prep_search_cfg(args.len());
         let cost = SpillAwareCostModel::new(self.mem.spill_set());
+
+        if let [arg] = args
+            && let Some(plan) =
+                self.solve_unary_operand_prep_fast(*arg, consume_last_use, &cost, search_cfg)
+        {
+            return Some(plan);
+        }
+
         let use_query_cache = self.use_operand_prep_query_cache(args.len());
         let cache_key = use_query_cache
             .then(|| self.operand_prep_query_key(args, consume_last_use, search_cfg));
@@ -244,6 +312,180 @@ impl<'a, 'ctx: 'a> Planner<'a, 'ctx> {
                 .insert(cache_key, plan.steps.clone());
         }
         plan
+    }
+
+    fn solve_unary_operand_prep_fast(
+        &self,
+        arg: ValueId,
+        consume_last_use: &BitSet<ValueId>,
+        cost: &impl CostModel,
+        search_cfg: SearchCfg,
+    ) -> Option<NormalizePlan> {
+        let key_info = self.unary_operand_prep_key_info(arg);
+        let arg_imm = self.ctx.func.dfg.value_imm(arg);
+        let arg_is_imm = arg_imm.is_some();
+        let last_use = consume_last_use.contains(arg);
+        let copy_count = self.unary_operand_prep_copy_count(arg, arg_imm);
+        let top_matches = self
+            .stack
+            .top()
+            .is_some_and(|item| self.unary_operand_prep_item_matches_arg(item, arg, arg_imm));
+        let preserve_satisfied = arg_is_imm || last_use || copy_count >= 2;
+        let surplus_last_use_penalty = cost.cost_pop().saturating_add(cost.cost_swap(1));
+
+        let copy_cost = |base: Cost| {
+            if last_use && copy_count != 0 {
+                base.saturating_add(surplus_last_use_penalty)
+            } else {
+                base
+            }
+        };
+
+        let mut candidates: SmallVec<[UnaryOperandPrepCandidate; 6]> = SmallVec::new();
+
+        if top_matches && preserve_satisfied {
+            candidates.push(UnaryOperandPrepCandidate {
+                modeled_cost: Cost::default(),
+                emitted_cost: Cost::default(),
+                priority: 0,
+                steps: SmallVec::new(),
+            });
+        }
+
+        if let Some(imm) = arg_imm {
+            let emitted_cost = cost.cost_push_imm(imm.as_i256());
+            candidates.push(UnaryOperandPrepCandidate {
+                modeled_cost: copy_cost(emitted_cost),
+                emitted_cost,
+                priority: 4,
+                steps: smallvec::smallvec![Step::PushImm(0)],
+            });
+        }
+
+        if let Some(pos) = self.unary_operand_prep_find_arg(arg, arg_imm, 0, search_cfg.dup_max) {
+            let emitted_cost = cost.cost_dup(pos as u8);
+            candidates.push(UnaryOperandPrepCandidate {
+                modeled_cost: copy_cost(emitted_cost),
+                emitted_cost,
+                priority: 2,
+                steps: smallvec::smallvec![Step::Dup(pos as u8)],
+            });
+        }
+
+        if let Some(pos) = self.unary_operand_prep_find_arg(arg, arg_imm, 0, search_cfg.swap_max)
+            && pos != 0
+            && (arg_is_imm || last_use || copy_count >= 2)
+        {
+            let emitted_cost = cost.cost_swap(pos as u8);
+            candidates.push(UnaryOperandPrepCandidate {
+                modeled_cost: emitted_cost,
+                emitted_cost,
+                priority: 1,
+                steps: smallvec::smallvec![Step::Swap(pos as u8)],
+            });
+        }
+
+        if !arg_is_imm
+            && !last_use
+            && copy_count < 2
+            && let Some(pos) = self.unary_operand_prep_find_arg(
+                arg,
+                arg_imm,
+                search_cfg.dup_max,
+                search_cfg.swap_max,
+            )
+        {
+            let emitted_cost = cost.cost_swap(pos as u8).saturating_add(cost.cost_dup(0));
+            candidates.push(UnaryOperandPrepCandidate {
+                modeled_cost: emitted_cost,
+                emitted_cost,
+                priority: 3,
+                steps: SmallVec::from_buf([Step::Swap(pos as u8), Step::Dup(0)]),
+            });
+        }
+
+        if !arg_is_imm {
+            let emitted_cost = cost.cost_load(arg);
+            candidates.push(UnaryOperandPrepCandidate {
+                modeled_cost: copy_cost(emitted_cost),
+                emitted_cost,
+                priority: 5,
+                steps: smallvec::smallvec![Step::LoadVal(0)],
+            });
+        }
+
+        let candidate = candidates
+            .into_iter()
+            .min_by(|lhs, rhs| lhs.cmp_key().cmp(&rhs.cmp_key()))?;
+
+        Some(NormalizePlan {
+            cost: candidate.modeled_cost,
+            steps: candidate.steps.into_vec(),
+            key_infos: smallvec::smallvec![key_info],
+            goal_keys: smallvec::smallvec![0],
+        })
+    }
+
+    fn unary_operand_prep_key_info(&self, arg: ValueId) -> KeyInfo {
+        if let Some(imm) = self.ctx.func.dfg.value_imm(arg) {
+            KeyInfo::Imm {
+                canon: imm.as_i256(),
+                rep_vid: arg,
+                rep_imm: imm,
+            }
+        } else {
+            KeyInfo::Val { vid: arg }
+        }
+    }
+
+    fn unary_operand_prep_item_matches_arg(
+        &self,
+        item: &StackItem,
+        arg: ValueId,
+        arg_imm: Option<Immediate>,
+    ) -> bool {
+        let StackItem::Value(value) = *item else {
+            return false;
+        };
+
+        if let Some(arg_imm) = arg_imm {
+            return self
+                .ctx
+                .func
+                .dfg
+                .value_imm(value)
+                .is_some_and(|imm| imm.as_i256() == arg_imm.as_i256());
+        }
+
+        value == arg
+    }
+
+    fn unary_operand_prep_copy_count(&self, arg: ValueId, arg_imm: Option<Immediate>) -> usize {
+        self.stack
+            .iter()
+            .take(self.stack.len_above_func_ret())
+            .filter(|item| self.unary_operand_prep_item_matches_arg(item, arg, arg_imm))
+            .count()
+    }
+
+    fn unary_operand_prep_find_arg(
+        &self,
+        arg: ValueId,
+        arg_imm: Option<Immediate>,
+        start: usize,
+        max_depth: usize,
+    ) -> Option<usize> {
+        let limit = self.stack.len_above_func_ret().min(max_depth);
+        if start >= limit {
+            return None;
+        }
+
+        self.stack
+            .iter()
+            .skip(start)
+            .take(limit - start)
+            .position(|item| self.unary_operand_prep_item_matches_arg(item, arg, arg_imm))
+            .map(|off| start + off)
     }
 
     fn inst_is_commutative(&self, inst: InstId) -> bool {
@@ -540,7 +782,7 @@ mod tests {
         },
     };
     use cranelift_entity::SecondaryMap;
-    use sonatina_ir::{Immediate, Type, Value, cfg::ControlFlowGraph};
+    use sonatina_ir::{I256, Immediate, Type, Value, cfg::ControlFlowGraph};
     use sonatina_parser::parse_module;
 
     #[test]
@@ -549,14 +791,14 @@ mod tests {
         let cheaper_emitted = NormalizePlan {
             cost: Cost { gas: 99, bytes: 99 },
             steps: vec![Step::Dup(0)],
-            key_infos: Vec::new(),
-            goal_keys: Vec::new(),
+            key_infos: SmallVec::new(),
+            goal_keys: SmallVec::new(),
         };
         let pricier_emitted = NormalizePlan {
             cost: Cost::default(),
             steps: vec![Step::Swap(1), Step::Swap(1)],
-            key_infos: Vec::new(),
-            goal_keys: Vec::new(),
+            key_infos: SmallVec::new(),
+            goal_keys: SmallVec::new(),
         };
 
         assert!(
@@ -846,8 +1088,466 @@ block0:
             assert!(!planner.use_operand_prep_query_cache(args.len()));
             assert_eq!(planner.operand_prep_query_mask(&args, |_| true), u64::MAX);
             assert_eq!(
-                planner.operand_prep_deep_preserve_mask(&args, &BitSet::default(), search_cfg),
+                planner.operand_prep_deep_preserve_mask(
+                    &args,
+                    &BitSet::default(),
+                    search_cfg.max_len,
+                ),
                 u64::MAX << search_cfg.max_len
+            );
+        });
+    }
+
+    #[test]
+    fn operand_prep_query_key_ignores_irrelevant_slots_below_effective_window() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+
+        let parsed = parse_module(SRC).expect("module parses");
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let imm_args = [
+                func.dfg.make_imm_value(Immediate::I8(1)),
+                func.dfg.make_imm_value(Immediate::I8(2)),
+            ];
+            let top0 = func.dfg.make_undef_value(Type::I256);
+            let top1 = func.dfg.make_undef_value(Type::I256);
+            let ignored_a = func.dfg.make_undef_value(Type::I256);
+            let ignored_b = func.dfg.make_undef_value(Type::I256);
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let spill_set = BitSet::default();
+            let spill_obj = SecondaryMap::new();
+
+            let query_key = |values: &[ValueId]| {
+                let mut spill_requests = BitSet::default();
+                let mut free_slots = FreeSlotPools::default();
+                let mut slots = SpillSlotPools::default();
+                let mem = MemPlan::new(
+                    SpillSet::new(&spill_set),
+                    &mut spill_requests,
+                    &ctx,
+                    &spill_obj,
+                    &ctx.exact_local_addr,
+                    &mut free_slots,
+                    &mut slots,
+                );
+                let mut stack = SymStack::entry_stack(func, false);
+                for &value in values.iter().rev() {
+                    stack.push_value(value);
+                }
+                let mut actions = crate::stackalloc::Actions::new();
+                let mut search_scratch = NormalizeSearchScratch::default();
+                let planner =
+                    Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+                let search_cfg = planner.operand_prep_search_cfg(imm_args.len());
+                planner.operand_prep_query_key(&imm_args, &BitSet::default(), search_cfg)
+            };
+
+            let lhs = query_key(&[top0, top1, ignored_a]);
+            let rhs = query_key(&[top0, top1, ignored_b]);
+            assert_eq!(lhs, rhs);
+        });
+    }
+
+    #[test]
+    fn operand_prep_query_key_ignores_irrelevant_slots_inside_effective_window() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+
+        let parsed = parse_module(SRC).expect("module parses");
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let source = func.dfg.make_undef_value(Type::I256);
+            let ignored_a = func.dfg.make_undef_value(Type::I256);
+            let ignored_b = func.dfg.make_undef_value(Type::I256);
+            let args = [source];
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let spill_set = BitSet::default();
+            let spill_obj = SecondaryMap::new();
+
+            let query_key = |top: ValueId| {
+                let mut spill_requests = BitSet::default();
+                let mut free_slots = FreeSlotPools::default();
+                let mut slots = SpillSlotPools::default();
+                let mem = MemPlan::new(
+                    SpillSet::new(&spill_set),
+                    &mut spill_requests,
+                    &ctx,
+                    &spill_obj,
+                    &ctx.exact_local_addr,
+                    &mut free_slots,
+                    &mut slots,
+                );
+                let mut stack = SymStack::entry_stack(func, false);
+                stack.push_value(source);
+                stack.push_value(top);
+                let mut actions = crate::stackalloc::Actions::new();
+                let mut search_scratch = NormalizeSearchScratch::default();
+                let planner =
+                    Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+                let search_cfg = planner.operand_prep_search_cfg(args.len());
+                planner.operand_prep_query_key(&args, &BitSet::default(), search_cfg)
+            };
+
+            let lhs = query_key(ignored_a);
+            let rhs = query_key(ignored_b);
+
+            assert_eq!(lhs, rhs);
+            assert_eq!(lhs.stack[0], OperandPrepStackKey::Ignored);
+            assert_eq!(
+                lhs.stack[1],
+                OperandPrepStackKey::Value(OperandPrepValueKey::Val(source))
+            );
+        });
+    }
+
+    #[test]
+    fn operand_prep_query_key_keeps_canonical_immediate_sources_relevant() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+
+        let parsed = parse_module(SRC).expect("module parses");
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let arg = func.dfg.make_imm_value(Immediate::I8(1));
+            let stack_source = func.dfg.make_imm_value(Immediate::I256(I256::from(1)));
+            let ignored = func.dfg.make_undef_value(Type::I256);
+            let args = [arg];
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let spill_set = BitSet::default();
+            let spill_obj = SecondaryMap::new();
+            let mut spill_requests = BitSet::default();
+            let mut free_slots = FreeSlotPools::default();
+            let mut slots = SpillSlotPools::default();
+            let mem = MemPlan::new(
+                SpillSet::new(&spill_set),
+                &mut spill_requests,
+                &ctx,
+                &spill_obj,
+                &ctx.exact_local_addr,
+                &mut free_slots,
+                &mut slots,
+            );
+            let mut stack = SymStack::entry_stack(func, false);
+            stack.push_value(stack_source);
+            stack.push_value(ignored);
+            let mut actions = crate::stackalloc::Actions::new();
+            let mut search_scratch = NormalizeSearchScratch::default();
+            let planner = Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+            let search_cfg = planner.operand_prep_search_cfg(args.len());
+            let key = planner.operand_prep_query_key(&args, &BitSet::default(), search_cfg);
+
+            assert_eq!(key.stack[0], OperandPrepStackKey::Ignored);
+            assert_eq!(
+                key.stack[1],
+                OperandPrepStackKey::Value(OperandPrepValueKey::Imm(Immediate::I8(1)))
+            );
+        });
+    }
+
+    #[test]
+    fn operand_prep_query_key_tracks_relevant_source_inside_effective_window() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+
+        let parsed = parse_module(SRC).expect("module parses");
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let source = func.dfg.make_undef_value(Type::I256);
+            let imm = func.dfg.make_imm_value(Immediate::I8(3));
+            let top = func.dfg.make_undef_value(Type::I256);
+            let unrelated = func.dfg.make_undef_value(Type::I256);
+            let ignored = func.dfg.make_undef_value(Type::I256);
+            let args = [source, imm];
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let spill_set = BitSet::default();
+            let spill_obj = SecondaryMap::new();
+
+            let query_key = |values: &[ValueId]| {
+                let mut spill_requests = BitSet::default();
+                let mut free_slots = FreeSlotPools::default();
+                let mut slots = SpillSlotPools::default();
+                let mem = MemPlan::new(
+                    SpillSet::new(&spill_set),
+                    &mut spill_requests,
+                    &ctx,
+                    &spill_obj,
+                    &ctx.exact_local_addr,
+                    &mut free_slots,
+                    &mut slots,
+                );
+                let mut stack = SymStack::entry_stack(func, false);
+                for &value in values.iter().rev() {
+                    stack.push_value(value);
+                }
+                let mut actions = crate::stackalloc::Actions::new();
+                let mut search_scratch = NormalizeSearchScratch::default();
+                let planner =
+                    Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+                let search_cfg = planner.operand_prep_search_cfg(args.len());
+                planner.operand_prep_query_key(&args, &BitSet::default(), search_cfg)
+            };
+
+            let no_source = query_key(&[top, unrelated, ignored]);
+            let with_source = query_key(&[top, source, ignored]);
+            assert_ne!(no_source, with_source);
+        });
+    }
+
+    #[test]
+    fn operand_prep_query_cache_replays_across_ignored_live_values() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f() {
+block0:
+    return;
+}
+"#;
+
+        let parsed = parse_module(SRC).expect("module parses");
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let imm = func.dfg.make_imm_value(Immediate::I8(7));
+            let source = func.dfg.make_undef_value(Type::I256);
+            let ignored_a = func.dfg.make_undef_value(Type::I256);
+            let ignored_b = func.dfg.make_undef_value(Type::I256);
+            let args = [imm, source];
+            let mut last_use = BitSet::default();
+            last_use.insert(source);
+
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(16);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let spill_set = BitSet::default();
+            let spill_obj = SecondaryMap::new();
+            let mut search_scratch = NormalizeSearchScratch::default();
+            let mut solve_with = |ignored: ValueId| {
+                let mut spill_requests = BitSet::default();
+                let mut free_slots = FreeSlotPools::default();
+                let mut slots = SpillSlotPools::default();
+                let mem = MemPlan::new(
+                    SpillSet::new(&spill_set),
+                    &mut spill_requests,
+                    &ctx,
+                    &spill_obj,
+                    &ctx.exact_local_addr,
+                    &mut free_slots,
+                    &mut slots,
+                );
+                let mut stack = SymStack::entry_stack(func, false);
+                stack.push_value(ignored);
+                stack.push_value(source);
+                let mut actions = crate::stackalloc::Actions::new();
+                let mut planner =
+                    Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+                let plan = planner
+                    .solve_operand_prep_cached(&args, &last_use)
+                    .expect("expected operand-prep plan");
+                let steps = plan.steps.clone();
+
+                assert!(planner.apply_operand_prep_plan(&plan, &args));
+                (
+                    steps,
+                    planner.search_scratch.operand_prep_plan_cache.map.len(),
+                )
+            };
+
+            let (lhs_steps, lhs_cache_len) = solve_with(ignored_a);
+            let (rhs_steps, rhs_cache_len) = solve_with(ignored_b);
+
+            assert_eq!(lhs_cache_len, 1);
+            assert_eq!(rhs_cache_len, 1);
+            assert_eq!(lhs_steps, rhs_steps);
+        });
+    }
+
+    #[test]
+    fn unary_operand_prep_fast_path_handles_preserve_and_consume_cases() {
+        const SRC: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %f(v0.i256, v1.i256, v2.i256) {
+block0:
+    return;
+}
+"#;
+
+        let parsed = parse_module(SRC).expect("module parses");
+        let func_ref = parsed.debug.func_order[0];
+
+        parsed.module.func_store.modify(func_ref, |func| {
+            let mut cfg = ControlFlowGraph::new();
+            cfg.compute(func);
+            let entry = cfg.entry().expect("missing entry block");
+
+            let mut liveness = Liveness::new();
+            liveness.compute(func, &cfg);
+
+            let mut dom = DomTree::new();
+            dom.compute(&cfg);
+
+            let mut scc = CfgSccAnalysis::new();
+            scc.compute(&cfg);
+
+            let reach = StackifyReachability::new(2);
+            let ctx = build_stackify_test_context(func, &cfg, &dom, &liveness, entry, scc, reach);
+            let spill_set = BitSet::default();
+            let spill_obj = SecondaryMap::new();
+
+            let solve_steps = |mut stack: SymStack, arg: ValueId, last_use: &BitSet<ValueId>| {
+                let mut spill_requests = BitSet::default();
+                let mut free_slots = FreeSlotPools::default();
+                let mut slots = SpillSlotPools::default();
+                let mem = MemPlan::new(
+                    SpillSet::new(&spill_set),
+                    &mut spill_requests,
+                    &ctx,
+                    &spill_obj,
+                    &ctx.exact_local_addr,
+                    &mut free_slots,
+                    &mut slots,
+                );
+
+                let mut actions = crate::stackalloc::Actions::new();
+                let mut search_scratch = NormalizeSearchScratch::default();
+                let mut planner =
+                    Planner::new(&ctx, &mut stack, &mut actions, mem, &mut search_scratch);
+                let plan = planner
+                    .solve_operand_prep_cached(&[arg], last_use)
+                    .expect("unary fast path should produce a plan");
+                let steps = plan.steps.clone();
+
+                assert!(planner.apply_operand_prep_plan(&plan, &[arg]));
+                steps
+            };
+
+            let arg = func.arg_values[0];
+            let stack = SymStack::entry_stack(func, false);
+            assert_eq!(
+                solve_steps(stack, arg, &BitSet::default()),
+                vec![Step::Dup(0)]
+            );
+
+            let mut stack = SymStack::entry_stack(func, false);
+            let mut setup_actions = crate::stackalloc::Actions::new();
+            stack.dup(0, &mut setup_actions);
+            assert!(
+                solve_steps(stack, arg, &BitSet::default()).is_empty(),
+                "already-prepared non-last-use operand with a preserved copy should be a no-op"
+            );
+
+            let arg = func.arg_values[2];
+            let mut last_use = BitSet::default();
+            last_use.insert(arg);
+            let stack = SymStack::entry_stack(func, false);
+            assert_eq!(solve_steps(stack, arg, &last_use), vec![Step::Swap(2)]);
+
+            let stack = SymStack::entry_stack(func, false);
+            assert_eq!(
+                solve_steps(stack, arg, &BitSet::default()),
+                vec![Step::Swap(2), Step::Dup(0)]
             );
         });
     }

--- a/crates/codegen/test_files/evm/arena_alloc_recursion_spills.snap
+++ b/crates/codegen/test_files/evm/arena_alloc_recursion_spills.snap
@@ -6,11 +6,11 @@ input_file: test_files/evm/arena_alloc_recursion_spills.sntn
 evm.config: stack_reach=4 vcode=false bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false
 
 object: Contract
-  section runtime: 235 bytes
-  total: 235 bytes
+  section runtime: 241 bytes
+  total: 241 bytes
 
 functions:
-  f: ir_blocks=3 ir_insts=28 vcode_ops=162 fixups=7 imm_bytes=34
+  f: ir_blocks=3 ir_insts=28 vcode_ops=164 fixups=7 imm_bytes=38
     mem: scratch_words=2 stable_words=1 stable_mode=DynamicFrame entry_abs_words=2 abs_words_end=2
   sink8: ir_blocks=1 ir_insts=8 vcode_ops=19 fixups=0 imm_bytes=0
     mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=2 abs_words_end=0
@@ -20,4 +20,4 @@ functions:
     mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=2 abs_words_end=0
 
 evm:
-  case ok: calldata_len=0 success reason=Return gas_used=22658 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=1658
+  case ok: calldata_len=0 success reason=Return gas_used=22676 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=1676

--- a/crates/codegen/test_files/evm/chz_castling_rights_gvn_regression_noopt.snap
+++ b/crates/codegen/test_files/evm/chz_castling_rights_gvn_regression_noopt.snap
@@ -6,8 +6,8 @@ input_file: test_files/evm/chz_castling_rights_gvn_regression_noopt.sntn
 evm.config: stack_reach=16 vcode=true bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false
 
 object: Contract
-  section runtime: 6810 bytes
-  total: 6810 bytes
+  section runtime: 6792 bytes
+  total: 6792 bytes
 
 functions:
   abs_diff: ir_blocks=9 ir_insts=36 vcode_ops=72 fixups=4 imm_bytes=14
@@ -64,7 +64,7 @@ functions:
     mem: scratch_words=0 stable_words=26 stable_mode=StaticAbs(base=0x520) entry_abs_words=36 abs_words_end=62
   meta_castling_rights: ir_blocks=1 ir_insts=7 vcode_ops=17 fixups=2 imm_bytes=3
     mem: scratch_words=1 stable_words=0 stable_mode=None entry_abs_words=162 abs_words_end=1
-  validate_rook_capture: ir_blocks=74 ir_insts=565 vcode_ops=1878 fixups=112 imm_bytes=510
+  validate_rook_capture: ir_blocks=74 ir_insts=565 vcode_ops=1862 fixups=111 imm_bytes=510
     mem: scratch_words=7 stable_words=100 stable_mode=StaticAbs(base=0x860) entry_abs_words=62 abs_words_end=162
   meta_custom: ir_blocks=1 ir_insts=58 vcode_ops=143 fixups=14 imm_bytes=21
     mem: scratch_words=1 stable_words=13 stable_mode=StaticAbs(base=0x14e0) entry_abs_words=162 abs_words_end=175
@@ -92,7 +92,7 @@ functions:
     mem: scratch_words=1 stable_words=0 stable_mode=None entry_abs_words=162 abs_words_end=1
 
 evm:
-  case captured_rook_clears_castling_rights: calldata_len=0 success reason=Return gas_used=36803 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=15803
+  case captured_rook_clears_castling_rights: calldata_len=0 success reason=Return gas_used=36792 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=15792
 
 
 --------------- DEBUG ---------------
@@ -3001,8 +3001,7 @@ validate_rook_capture:
     PUSH1 block6
     JUMPI
   block5:
-    DUP1  // v69.i1 = call %is_white_piece v62;
-    PUSH1 `pc + (4)`
+    PUSH1 `pc + (4)`  // v69.i1 = call %is_white_piece v62;
     SWAP1
     PUSH1 FuncRef(13)
     JUMP
@@ -3011,7 +3010,6 @@ validate_rook_capture:
     JUMPI
   block8:
     POP  // v621.*i256 = gep v619 0.i64 0.i64;
-    POP
     POP
     POP
     POP
@@ -3122,13 +3120,11 @@ validate_rook_capture:
     POP
     POP
     POP
-    POP
     PUSH1 block7
     JUMP
   block6:
     JUMPDEST
-    DUP1  // v72.i1 = call %is_black_piece v62;
-    PUSH1 `pc + (4)`
+    PUSH1 `pc + (4)`  // v72.i1 = call %is_black_piece v62;
     SWAP1
     PUSH1 FuncRef(11)
     JUMP
@@ -3137,7 +3133,6 @@ validate_rook_capture:
     JUMPI
   block11:
     POP  // v442.*i256 = gep v440 0.i64 0.i64;
-    POP
     POP
     POP
     POP
@@ -3248,7 +3243,6 @@ validate_rook_capture:
     POP
     POP
     POP
-    POP
   block7:
     JUMPDEST
     PUSH2 0x1280 (4736)  // v76.i256 = call %piece_at v35 v367;
@@ -3275,18 +3269,16 @@ validate_rook_capture:
     PUSH1 block18
     JUMPI
   block17:
-    DUP1  // v129.i1 = call %is_white_piece v76;
-    PUSH1 `pc + (4)`
+    PUSH1 `pc + (4)`  // v129.i1 = call %is_white_piece v76;
     SWAP1
     PUSH1 FuncRef(13)
     JUMP
     JUMPDEST
     ISZERO  // br v129 block20 block105;
-    PUSH1 block105
+    PUSH1 block19
     JUMPI
   block20:
-    POP  // v615.*i256 = gep v613 0.i64 0.i64;
-    PUSH2 0xc40 (3136)
+    PUSH2 0xc40 (3136)  // v615.*i256 = gep v613 0.i64 0.i64;
     PUSH2 0x9e0 (2528)  // mstore v615 undef.i256 i256;
     MLOAD
     SWAP1
@@ -3308,25 +3300,18 @@ validate_rook_capture:
     SWAP3
     SWAP4
     JUMP
-  block105:
-    JUMPDEST
-    POP  // jump block19;
-    PUSH1 block19
-    JUMP
   block18:
     JUMPDEST
-    DUP1  // v131.i1 = call %is_black_piece v76;
-    PUSH1 `pc + (4)`
+    PUSH1 `pc + (4)`  // v131.i1 = call %is_black_piece v76;
     SWAP1
     PUSH1 FuncRef(11)
     JUMP
     JUMPDEST
     ISZERO  // br v131 block23 block106;
-    PUSH1 block106
+    PUSH1 block19
     JUMPI
   block23:
-    POP  // v448.*i256 = gep v446 0.i64 0.i64;
-    PUSH2 0x1000 (4096)
+    PUSH2 0x1000 (4096)  // v448.*i256 = gep v446 0.i64 0.i64;
     PUSH2 0xa40 (2624)  // mstore v448 undef.i256 i256;
     MLOAD
     SWAP1
@@ -3348,9 +3333,6 @@ validate_rook_capture:
     SWAP3
     SWAP4
     JUMP
-  block106:
-    JUMPDEST
-    POP  // jump block19;
   block19:
     JUMPDEST
     PUSH2 0x8c0 (2240)  // v133.i256 = call %piece_kind v76;

--- a/crates/codegen/test_files/evm/fe_commutative_branch_array5_loop_regression.snap
+++ b/crates/codegen/test_files/evm/fe_commutative_branch_array5_loop_regression.snap
@@ -6,8 +6,8 @@ input_file: test_files/evm/fe_commutative_branch_array5_loop_regression.sntn
 evm.config: stack_reach=16 vcode=false bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false opt=2
 
 object: Contract
-  section runtime: 526 bytes
-  total: 526 bytes
+  section runtime: 527 bytes
+  total: 527 bytes
 
 functions:
   verify_checked: ir_blocks=17 ir_insts=95 vcode_ops=310 fixups=6 imm_bytes=91

--- a/crates/codegen/test_files/evm/fe_commutative_branch_array5_loop_regression.snap
+++ b/crates/codegen/test_files/evm/fe_commutative_branch_array5_loop_regression.snap
@@ -10,7 +10,7 @@ object: Contract
   total: 526 bytes
 
 functions:
-  verify_checked: ir_blocks=17 ir_insts=95 vcode_ops=311 fixups=6 imm_bytes=90
+  verify_checked: ir_blocks=17 ir_insts=95 vcode_ops=310 fixups=6 imm_bytes=91
     mem: scratch_words=28 stable_words=0 stable_mode=None entry_abs_words=38 abs_words_end=28
   run: ir_blocks=3 ir_insts=26 vcode_ops=73 fixups=3 imm_bytes=13
     mem: scratch_words=0 stable_words=10 stable_mode=StaticAbs(base=0x420) entry_abs_words=28 abs_words_end=38


### PR DESCRIPTION
- add fast paths for already-prepared operands, unary cases, and trivial binary cases
- Reduce commutative binary prep work by short-circuiting unbeatable original-order plans.
- Improve search performance with effective-window shrinking, greedy upper bounds, cached query keys, and precomputed costs.
- Preserve modeled operand-prep cost on cache hits so cached plans compare correctly.
