### PR TITLE
Source location tracking and debug infrastructure

### DIFF
--- a/crates/codegen/src/cache.rs
+++ b/crates/codegen/src/cache.rs
@@ -1,0 +1,142 @@
+//! Content-addressed incremental compilation cache.
+//!
+//! Following Cranelift's `incremental_cache` pattern: hash the function's IR
+//! content to produce a cache key, then store/retrieve compiled artifacts
+//! (machine code + debug info) keyed by that hash.
+//!
+//! This module provides the trait and key computation. Actual cache storage
+//! is pluggable via the `CompilationCache` trait.
+
+use std::hash::{Hash, Hasher};
+
+use sonatina_ir::{Function, module::FuncRef};
+
+/// Opaque cache key derived from a function's IR content.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CacheKey {
+    hash: [u8; 32],
+}
+
+impl CacheKey {
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.hash
+    }
+}
+
+impl std::fmt::Display for CacheKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in &self.hash {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Trait for pluggable cache storage backends.
+pub trait CompilationCache {
+    fn get(&self, key: &CacheKey) -> Option<CachedCompilation>;
+    fn insert(&mut self, key: CacheKey, value: CachedCompilation);
+}
+
+/// A cached compilation result for a single function.
+#[derive(Clone, Debug)]
+pub struct CachedCompilation {
+    pub machine_code: Vec<u8>,
+    pub source_map_entries: Vec<CachedSourceMapEntry>,
+}
+
+/// A source map entry from a cached compilation.
+#[derive(Clone, Debug)]
+pub struct CachedSourceMapEntry {
+    pub offset: u32,
+    pub length: u32,
+    pub source_loc: u32,
+}
+
+/// Compute a cache key for a function by hashing its IR content.
+///
+/// The key is a SHA-256 hash of the function's structural content:
+/// instruction types, operand values, block structure, and source locations.
+/// Two functions with identical IR will produce the same key.
+pub fn compute_cache_key(func: &Function, func_ref: FuncRef) -> CacheKey {
+    use std::collections::hash_map::DefaultHasher;
+
+    let mut hasher = DefaultHasher::new();
+
+    // Hash the function reference for identity
+    func_ref.as_u32().hash(&mut hasher);
+
+    // Hash the IR structure (blocks + instructions + source locations)
+    for block in func.layout.iter_block() {
+        block.hash(&mut hasher);
+        for inst in func.layout.iter_inst(block) {
+            inst.hash(&mut hasher);
+            func.source_locs[inst].hash(&mut hasher);
+        }
+    }
+
+    let hash_value = hasher.finish();
+    let mut hash = [0u8; 32];
+    hash[..8].copy_from_slice(&hash_value.to_le_bytes());
+
+    CacheKey { hash }
+}
+
+/// In-memory cache implementation for testing and single-compilation use.
+#[derive(Default)]
+pub struct InMemoryCache {
+    entries: std::collections::HashMap<CacheKey, CachedCompilation>,
+}
+
+impl CompilationCache for InMemoryCache {
+    fn get(&self, key: &CacheKey) -> Option<CachedCompilation> {
+        self.entries.get(key).cloned()
+    }
+
+    fn insert(&mut self, key: CacheKey, value: CachedCompilation) {
+        self.entries.insert(key, value);
+    }
+}
+
+impl InMemoryCache {
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_display() {
+        let key = CacheKey { hash: [0xab; 32] };
+        let display = format!("{key}");
+        assert_eq!(display.len(), 64);
+        assert!(display.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn in_memory_cache_insert_get() {
+        let mut cache = InMemoryCache::default();
+        let key = CacheKey { hash: [1; 32] };
+        let value = CachedCompilation {
+            machine_code: vec![0x60, 0x00],
+            source_map_entries: vec![],
+        };
+        cache.insert(key.clone(), value);
+        assert!(cache.get(&key).is_some());
+        assert_eq!(cache.get(&key).unwrap().machine_code, vec![0x60, 0x00]);
+    }
+
+    #[test]
+    fn cache_miss_returns_none() {
+        let cache = InMemoryCache::default();
+        let key = CacheKey { hash: [99; 32] };
+        assert!(cache.get(&key).is_none());
+    }
+}

--- a/crates/codegen/src/cache.rs
+++ b/crates/codegen/src/cache.rs
@@ -55,29 +55,41 @@ pub struct CachedSourceMapEntry {
 
 /// Compute a cache key for a function by hashing its IR content.
 ///
-/// The key is a SHA-256 hash of the function's structural content:
-/// instruction types, operand values, block structure, and source locations.
-/// Two functions with identical IR will produce the same key.
+/// The key combines the function's structural content: block topology,
+/// instruction identity, and source locations. Two functions with
+/// identical IR will produce the same key.
 pub fn compute_cache_key(func: &Function, func_ref: FuncRef) -> CacheKey {
     use std::collections::hash_map::DefaultHasher;
 
-    let mut hasher = DefaultHasher::new();
+    let mut hash = [0u8; 32];
 
-    // Hash the function reference for identity
-    func_ref.as_u32().hash(&mut hasher);
+    // Four independent hashers for better distribution across 256 bits
+    let mut hashers: [DefaultHasher; 4] = [
+        DefaultHasher::new(),
+        DefaultHasher::new(),
+        DefaultHasher::new(),
+        DefaultHasher::new(),
+    ];
 
-    // Hash the IR structure (blocks + instructions + source locations)
+    func_ref.as_u32().hash(&mut hashers[0]);
+    func.arg_values.len().hash(&mut hashers[1]);
+
+    let mut inst_count = 0u32;
     for block in func.layout.iter_block() {
-        block.hash(&mut hasher);
+        block.hash(&mut hashers[inst_count as usize % 4]);
         for inst in func.layout.iter_inst(block) {
-            inst.hash(&mut hasher);
-            func.source_locs[inst].hash(&mut hasher);
+            let idx = inst_count as usize % 4;
+            inst.hash(&mut hashers[idx]);
+            func.source_locs[inst].hash(&mut hashers[idx]);
+            inst_count += 1;
         }
     }
+    inst_count.hash(&mut hashers[3]);
 
-    let hash_value = hasher.finish();
-    let mut hash = [0u8; 32];
-    hash[..8].copy_from_slice(&hash_value.to_le_bytes());
+    for (i, hasher) in hashers.iter().enumerate() {
+        let h = hasher.finish();
+        hash[i * 8..(i + 1) * 8].copy_from_slice(&h.to_le_bytes());
+    }
 
     CacheKey { hash }
 }

--- a/crates/codegen/src/cache.rs
+++ b/crates/codegen/src/cache.rs
@@ -53,6 +53,63 @@ pub struct CachedSourceMapEntry {
     pub source_loc: u32,
 }
 
+impl CachedCompilation {
+    /// Serialize to a binary blob for persistent storage.
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let code_len = self.machine_code.len() as u32;
+        buf.extend_from_slice(&code_len.to_le_bytes());
+        buf.extend_from_slice(&self.machine_code);
+        let entries_len = self.source_map_entries.len() as u32;
+        buf.extend_from_slice(&entries_len.to_le_bytes());
+        for entry in &self.source_map_entries {
+            buf.extend_from_slice(&entry.offset.to_le_bytes());
+            buf.extend_from_slice(&entry.length.to_le_bytes());
+            buf.extend_from_slice(&entry.source_loc.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Deserialize from a binary blob.
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        let mut pos = 0;
+        if data.len() < 4 {
+            return None;
+        }
+        let code_len = u32::from_le_bytes(data[pos..pos + 4].try_into().ok()?) as usize;
+        pos += 4;
+        if data.len() < pos + code_len {
+            return None;
+        }
+        let machine_code = data[pos..pos + code_len].to_vec();
+        pos += code_len;
+        if data.len() < pos + 4 {
+            return None;
+        }
+        let entries_len = u32::from_le_bytes(data[pos..pos + 4].try_into().ok()?) as usize;
+        pos += 4;
+        let mut source_map_entries = Vec::with_capacity(entries_len);
+        for _ in 0..entries_len {
+            if data.len() < pos + 12 {
+                return None;
+            }
+            let offset = u32::from_le_bytes(data[pos..pos + 4].try_into().ok()?);
+            let length = u32::from_le_bytes(data[pos + 4..pos + 8].try_into().ok()?);
+            let source_loc = u32::from_le_bytes(data[pos + 8..pos + 12].try_into().ok()?);
+            source_map_entries.push(CachedSourceMapEntry {
+                offset,
+                length,
+                source_loc,
+            });
+            pos += 12;
+        }
+        Some(CachedCompilation {
+            machine_code,
+            source_map_entries,
+        })
+    }
+}
+
 /// Compute a cache key for a function by hashing its IR content.
 ///
 /// The key combines the function's structural content: block topology,
@@ -143,6 +200,31 @@ mod tests {
         cache.insert(key.clone(), value);
         assert!(cache.get(&key).is_some());
         assert_eq!(cache.get(&key).unwrap().machine_code, vec![0x60, 0x00]);
+    }
+
+    #[test]
+    fn cached_compilation_serialization_round_trip() {
+        let original = CachedCompilation {
+            machine_code: vec![0x60, 0x00, 0x60, 0x01, 0x01],
+            source_map_entries: vec![
+                CachedSourceMapEntry {
+                    offset: 0,
+                    length: 2,
+                    source_loc: 42,
+                },
+                CachedSourceMapEntry {
+                    offset: 2,
+                    length: 3,
+                    source_loc: 100,
+                },
+            ],
+        };
+        let serialized = original.serialize();
+        let deserialized = CachedCompilation::deserialize(&serialized).unwrap();
+        assert_eq!(deserialized.machine_code, original.machine_code);
+        assert_eq!(deserialized.source_map_entries.len(), 2);
+        assert_eq!(deserialized.source_map_entries[0].source_loc, 42);
+        assert_eq!(deserialized.source_map_entries[1].offset, 2);
     }
 
     #[test]

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod analysis;
 mod bitset;
+pub mod cache;
 pub mod cfg_edit;
 pub mod cfg_scc;
 pub mod compile;

--- a/crates/codegen/src/object/mod.rs
+++ b/crates/codegen/src/object/mod.rs
@@ -11,6 +11,7 @@ pub use artifact::{
     PcMapEntry, SectionArtifact, SectionObservability, SymbolDef, SymbolId, UnmappedReason,
     UnmappedReasonCoverage,
 };
+pub use crate::cache::{CacheKey, CachedCompilation, CompilationCache, InMemoryCache, compute_cache_key};
 pub use compile::{compile_all_objects, compile_object};
 pub use data::encode_gv_initializer_to_bytes;
 pub use error::ObjectCompileError;

--- a/crates/codegen/src/object/mod.rs
+++ b/crates/codegen/src/object/mod.rs
@@ -5,13 +5,15 @@ pub mod error;
 pub mod link;
 pub mod resolve;
 
+pub use crate::cache::{
+    CacheKey, CachedCompilation, CompilationCache, InMemoryCache, compute_cache_key,
+};
 use crate::isa::evm::PushWidthPolicy;
 pub use artifact::{
     FrontendProvenanceMap, OBSERVABILITY_SCHEMA_VERSION, ObjectArtifact, ObjectObservability,
     PcMapEntry, SectionArtifact, SectionObservability, SymbolDef, SymbolId, UnmappedReason,
     UnmappedReasonCoverage,
 };
-pub use crate::cache::{CacheKey, CachedCompilation, CompilationCache, InMemoryCache, compute_cache_key};
 pub use compile::{compile_all_objects, compile_object};
 pub use data::encode_gv_initializer_to_bytes;
 pub use error::ObjectCompileError;

--- a/crates/codegen/src/optim/inliner/full.rs
+++ b/crates/codegen/src/optim/inliner/full.rs
@@ -182,6 +182,12 @@ pub(super) fn try_inline_callsite_full(
                 editor.append_inst_with_results(new_block, cloned, result_tys.as_slice());
             inserted_insts += 1;
 
+            // Propagate source location from callee instruction to inlined copy
+            let callee_source = callee.source_locs[old_inst];
+            if callee_source != 0 {
+                editor.func_mut().source_locs[new_inst] = callee_source;
+            }
+
             assert_eq!(
                 old_results.len(),
                 new_results.len(),

--- a/crates/ir/src/debug_tags.rs
+++ b/crates/ir/src/debug_tags.rs
@@ -1,0 +1,123 @@
+use std::collections::BTreeMap;
+use std::ops::Range;
+
+use crate::InstId;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum DebugTag {
+    SourceLoc(u32),
+    InlineCallsite(u32),
+    SemanticScope(u32),
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DebugTags {
+    tags: Vec<DebugTag>,
+    insts: BTreeMap<InstId, Range<u32>>,
+}
+
+impl DebugTags {
+    pub fn set(&mut self, inst: InstId, new_tags: impl IntoIterator<Item = DebugTag>) {
+        let start = self.tags.len() as u32;
+        self.tags.extend(new_tags);
+        let end = self.tags.len() as u32;
+        if end > start {
+            self.insts.insert(inst, start..end);
+        } else {
+            self.insts.remove(&inst);
+        }
+    }
+
+    pub fn get(&self, inst: InstId) -> &[DebugTag] {
+        if let Some(range) = self.insts.get(&inst) {
+            &self.tags[range.start as usize..range.end as usize]
+        } else {
+            &[]
+        }
+    }
+
+    pub fn has(&self, inst: InstId) -> bool {
+        self.insts.contains_key(&inst)
+    }
+
+    pub fn clone_tags(&mut self, from: InstId, to: InstId) {
+        if let Some(range) = self.insts.get(&from).cloned() {
+            self.insts.insert(to, range);
+        } else {
+            self.insts.remove(&to);
+        }
+    }
+
+    /// Prepend tags from `prefix_inst` onto `target_inst`'s existing tags.
+    /// Used during inlining: the callsite's tags are prepended to all inlined
+    /// instructions, preserving the virtual call stack.
+    pub fn prepend_tags(&mut self, prefix_inst: InstId, target_inst: InstId) {
+        let prefix_tags: Vec<_> = self.get(prefix_inst).to_vec();
+        if prefix_tags.is_empty() {
+            return;
+        }
+        let existing_tags: Vec<_> = self.get(target_inst).to_vec();
+        let start = self.tags.len() as u32;
+        self.tags.extend(prefix_tags);
+        self.tags.extend(existing_tags);
+        let end = self.tags.len() as u32;
+        self.insts.insert(target_inst, start..end);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.insts.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.tags.clear();
+        self.insts.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_and_get_tags() {
+        let mut tags = DebugTags::default();
+        let inst = InstId(0);
+        tags.set(inst, [DebugTag::SourceLoc(42)]);
+        assert_eq!(tags.get(inst), &[DebugTag::SourceLoc(42)]);
+        assert!(tags.has(inst));
+    }
+
+    #[test]
+    fn clone_tags_shares_range() {
+        let mut tags = DebugTags::default();
+        let from = InstId(0);
+        let to = InstId(1);
+        tags.set(from, [DebugTag::SourceLoc(10), DebugTag::InlineCallsite(20)]);
+        tags.clone_tags(from, to);
+        assert_eq!(tags.get(from), tags.get(to));
+    }
+
+    #[test]
+    fn prepend_tags_preserves_order() {
+        let mut tags = DebugTags::default();
+        let callsite = InstId(0);
+        let inlined = InstId(1);
+
+        tags.set(callsite, [DebugTag::SourceLoc(100)]);
+        tags.set(inlined, [DebugTag::SourceLoc(200)]);
+
+        tags.prepend_tags(callsite, inlined);
+
+        assert_eq!(
+            tags.get(inlined),
+            &[DebugTag::SourceLoc(100), DebugTag::SourceLoc(200)]
+        );
+    }
+
+    #[test]
+    fn empty_inst_returns_empty_slice() {
+        let tags = DebugTags::default();
+        assert!(tags.get(InstId(99)).is_empty());
+        assert!(!tags.has(InstId(99)));
+    }
+}

--- a/crates/ir/src/debug_tags.rs
+++ b/crates/ir/src/debug_tags.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-use std::ops::Range;
+use std::{collections::BTreeMap, ops::Range};
 
 use crate::InstId;
 

--- a/crates/ir/src/debug_tags.rs
+++ b/crates/ir/src/debug_tags.rs
@@ -92,7 +92,10 @@ mod tests {
         let mut tags = DebugTags::default();
         let from = InstId(0);
         let to = InstId(1);
-        tags.set(from, [DebugTag::SourceLoc(10), DebugTag::InlineCallsite(20)]);
+        tags.set(
+            from,
+            [DebugTag::SourceLoc(10), DebugTag::InlineCallsite(20)],
+        );
         tags.clone_tags(from, to);
         assert_eq!(tags.get(from), tags.get(to));
     }

--- a/crates/ir/src/function.rs
+++ b/crates/ir/src/function.rs
@@ -1,15 +1,25 @@
 use std::io;
 
+use cranelift_entity::SecondaryMap;
 use smallvec::SmallVec;
 
 use super::{BlockId, DataFlowGraph, InstId, Layout, Type, ValueId};
 use crate::{InstSetBase, Linkage, ir_writer::IrWrite, module::ModuleCtx};
+
+/// Opaque source location ordinal attached to instructions by the frontend.
+/// The frontend assigns meaning to these values via a lookup table.
+/// Default value (u32::MAX) means "no source location."
+pub type SourceLoc = u32;
+
+/// Default value indicating no source location.
+pub const SOURCE_LOC_NONE: SourceLoc = u32::MAX;
 
 #[derive(Clone)]
 pub struct Function {
     pub arg_values: smallvec::SmallVec<[ValueId; 8]>,
     pub dfg: DataFlowGraph,
     pub layout: Layout,
+    pub source_locs: SecondaryMap<InstId, SourceLoc>,
 }
 
 impl Function {
@@ -29,6 +39,7 @@ impl Function {
             arg_values,
             dfg,
             layout: Layout::default(),
+            source_locs: SecondaryMap::new(),
         }
     }
 

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bitset;
 pub mod builder;
 pub mod cfg;
+pub mod debug_tags;
 pub mod dfg;
 pub mod effects;
 pub mod func_cursor;

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -31,7 +31,7 @@ pub use effects::{
     EffectBits, EffectCostClass, FuncEffectSummary, InstEffectSummary, InstEffects, MemoryAccess,
     OtherEffects,
 };
-pub use function::{Function, Signature};
+pub use function::{Function, SOURCE_LOC_NONE, Signature, SourceLoc};
 pub use global_variable::{GlobalVariableData, GlobalVariableRef};
 pub use graphviz::render_to;
 pub use inst::{


### PR DESCRIPTION
Per-instruction source locations on `Function`, debug tags for inlining, compilation cache API. Inliner propagates source locations when cloning instructions.