### PR TITLE
Add Ord bound for Q in Default impl of SearchScratch

### DIFF
--- a/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
+++ b/crates/codegen/src/stackalloc/stackify/planner/normalize_search.rs
@@ -393,7 +393,7 @@ struct SearchNode<S> {
     parent: Option<(S, Step)>,
 }
 
-impl<S, Q> Default for SearchScratch<S, Q> {
+impl<S, Q: Ord> Default for SearchScratch<S, Q> {
     fn default() -> Self {
         Self {
             nodes: FxHashMap::default(),


### PR DESCRIPTION
Current tip of main is broken; this PR fixes it by adding an `Ord` bound to the type parameter of `Q` in the `Default` impl for `SearchScratch`.