### PR TITLE
Fe trace attribution and EVM PC mapping

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -67,6 +67,14 @@ impl EvmCompile {
         &self.module
     }
 
+    /// Run the optimization pipeline (idempotent) and return the optimized
+    /// module for consumers that need to attach codegen-owned metadata before
+    /// backend preparation.
+    pub fn optimize_mut(&mut self) -> &mut Module {
+        self.optimize();
+        &mut self.module
+    }
+
     /// Optimize (if not already) and compile every object in the module.
     pub fn compile(mut self) -> Result<Vec<ObjectArtifact>, Vec<ObjectCompileError>> {
         self.optimize();
@@ -159,5 +167,13 @@ mod tests {
             target.operating_system,
             OperatingSystem::Evm(EvmVersion::London)
         );
+    }
+
+    #[test]
+    fn optimize_mut_exposes_the_optimized_module() {
+        let mut compile = EvmCompile::new(module_for_evm(EvmVersion::Osaka));
+        let module = compile.optimize_mut();
+
+        assert_eq!(module.ctx.triple, evm_osaka_triple());
     }
 }

--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -27,7 +27,10 @@ pub enum OptLevel {
 
 /// An optimized-IR instruction id, the namespace a frontend stamps provenance
 /// against. Distinct from `MachineInstId` so a machine id cannot be handed to
-/// the stamping door by mistake. Use `.raw()` to cross to a bare `InstId`.
+/// the stamping door by mistake. Use `.raw()` to cross to a bare `InstId`. The
+/// inner field is pub on purpose: crossing namespaces requires writing the wrap
+/// explicitly, which is the reviewable act; the type does not try to prevent
+/// deliberate reconstruction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct OptInstId(pub InstId);
@@ -80,8 +83,12 @@ impl EvmCompile {
         &self.module
     }
 
-    /// Stamp codegen-owned provenance after optimization without exposing
-    /// unrestricted structural mutation of the optimized module.
+    /// Stamp codegen-owned provenance after optimization. This is the sanctioned
+    /// door and the easy path, but it does not revoke the module's interior
+    /// mutability: `optimize()` still returns a `&Module` whose `pub func_store`
+    /// can be mutated, so the door disincentivizes reaching around the stamping
+    /// path, it does not close it. A read-only view return type is the real
+    /// close, deferred to the next API window.
     pub fn stamp_post_opt_provenance(
         &mut self,
         func: FuncRef,

--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -88,7 +88,8 @@ impl EvmCompile {
     /// mutability: `optimize()` still returns a `&Module` whose `pub func_store`
     /// can be mutated, so the door disincentivizes reaching around the stamping
     /// path, it does not close it. A read-only view return type is the real
-    /// close, deferred to the next API window.
+    /// close, deferred to the next API window and tracked as the ModuleView
+    /// follow-up so it does not calcify into a permanent excuse.
     pub fn stamp_post_opt_provenance(
         &mut self,
         func: FuncRef,
@@ -210,7 +211,7 @@ mod tests {
     use sonatina_ir::{InstId, Module, isa::evm::Evm, module::FuncRef};
     use sonatina_triple::{EvmVersion, OperatingSystem, TargetTriple};
 
-    use super::{EvmCompile, ObjectCompileError, evm_osaka_triple};
+    use super::{EvmCompile, ObjectCompileError, OptInstId, evm_osaka_triple};
 
     fn module_for_evm(version: EvmVersion) -> Module {
         let triple = evm_osaka_triple();
@@ -238,11 +239,7 @@ mod tests {
     fn post_opt_provenance_stamping_is_metadata_only() {
         let mut compile = EvmCompile::new(module_for_evm(EvmVersion::Osaka));
         let error = compile
-            .stamp_post_opt_provenance(
-                FuncRef::from_u32(0),
-                super::OptInstId(InstId(0)),
-                "post-opt:test",
-            )
+            .stamp_post_opt_provenance(FuncRef::from_u32(0), OptInstId(InstId(0)), "post-opt:test")
             .expect_err("undefined functions must be rejected");
 
         assert!(error.contains("undefined function"));

--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -6,7 +6,7 @@
 //! [`EvmCompile::optimize`], then produce object artifacts via
 //! [`EvmCompile::compile`].
 
-use sonatina_ir::{Module, isa::evm::Evm};
+use sonatina_ir::{InstId, Module, isa::evm::Evm, module::FuncRef};
 use sonatina_triple::{Architecture, EvmVersion, OperatingSystem, TargetTriple, Vendor};
 
 use crate::{
@@ -65,6 +65,34 @@ impl EvmCompile {
             self.optimized = true;
         }
         &self.module
+    }
+
+    /// Stamp codegen-owned provenance after optimization without exposing
+    /// unrestricted structural mutation of the optimized module.
+    pub fn stamp_post_opt_provenance(
+        &mut self,
+        func: FuncRef,
+        inst: InstId,
+        provenance: impl Into<String>,
+    ) -> Result<(), String> {
+        self.optimize();
+        if !self.module.funcs().contains(&func) {
+            return Err(format!("cannot stamp undefined function {func:?}"));
+        }
+        let valid = self
+            .module
+            .func_store
+            .view(func, |function| function.dfg.has_inst(inst));
+        if !valid {
+            return Err(format!(
+                "cannot stamp missing inst{} in function {func:?}",
+                inst.0
+            ));
+        }
+        self.module.func_store.modify(func, |function| {
+            function.set_inst_provenance(inst, provenance.into());
+        });
+        Ok(())
     }
 
     /// Optimize (if not already) and compile every object in the module.
@@ -134,7 +162,7 @@ fn evm_osaka_triple() -> TargetTriple {
 
 #[cfg(test)]
 mod tests {
-    use sonatina_ir::{Module, isa::evm::Evm};
+    use sonatina_ir::{InstId, Module, isa::evm::Evm, module::FuncRef};
     use sonatina_triple::{EvmVersion, OperatingSystem, TargetTriple};
 
     use super::{EvmCompile, ObjectCompileError, evm_osaka_triple};
@@ -159,5 +187,16 @@ mod tests {
             target.operating_system,
             OperatingSystem::Evm(EvmVersion::London)
         );
+    }
+
+    #[test]
+    fn post_opt_provenance_stamping_is_metadata_only() {
+        let mut compile = EvmCompile::new(module_for_evm(EvmVersion::Osaka));
+        let error = compile
+            .stamp_post_opt_provenance(FuncRef::from_u32(0), InstId(0), "post-opt:test")
+            .expect_err("undefined functions must be rejected");
+
+        assert!(error.contains("undefined function"));
+        assert_eq!(compile.optimize().ctx.triple, evm_osaka_triple());
     }
 }

--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -44,6 +44,7 @@ impl OptInstId {
 pub struct EvmCompile {
     module: Module,
     opt_level: OptLevel,
+    emit_symbol_table: bool,
     emit_observability: bool,
     optimized: bool,
 }
@@ -53,6 +54,7 @@ impl EvmCompile {
         Self {
             module,
             opt_level: OptLevel::default(),
+            emit_symbol_table: false,
             emit_observability: false,
             optimized: false,
         }
@@ -65,6 +67,15 @@ impl EvmCompile {
 
     pub fn with_observability(mut self, on: bool) -> Self {
         self.emit_observability = on;
+        self
+    }
+
+    /// Include linker symbol tables in the compiled object artifacts.
+    ///
+    /// Symbol tables are diagnostic metadata only and do not affect emitted
+    /// section bytes. They are omitted by default.
+    pub fn with_symbol_table(mut self, on: bool) -> Self {
+        self.emit_symbol_table = on;
         self
     }
 
@@ -146,6 +157,7 @@ impl EvmCompile {
         self.optimize();
         let backend = evm_backend_for_module(&self.module, self.opt_level)?;
         let opts = CompileOptions {
+            emit_symtab: self.emit_symbol_table,
             emit_observability: self.emit_observability,
             ..CompileOptions::default()
         };
@@ -209,9 +221,11 @@ fn evm_osaka_triple() -> TargetTriple {
 #[cfg(test)]
 mod tests {
     use sonatina_ir::{InstId, Module, isa::evm::Evm, module::FuncRef};
+    use sonatina_parser::parse_module;
     use sonatina_triple::{EvmVersion, OperatingSystem, TargetTriple};
 
     use super::{EvmCompile, ObjectCompileError, OptInstId, evm_osaka_triple};
+    use crate::object::SymbolId;
 
     fn module_for_evm(version: EvmVersion) -> Module {
         let triple = evm_osaka_triple();
@@ -244,5 +258,70 @@ mod tests {
 
         assert!(error.contains("undefined function"));
         assert_eq!(compile.optimize().ctx.triple, evm_osaka_triple());
+    }
+
+    #[test]
+    fn symbol_table_option_populates_embed_symbols_without_changing_bytes() {
+        let source = r#"
+target = "evm-ethereum-osaka"
+
+func public %runtime() {
+    block0:
+        evm_return 0.i256 0.i256;
+}
+
+func public %init() {
+    block0:
+        v0.i256 = sym_addr &runtime;
+        v1.i256 = sym_size &runtime;
+        mstore 0.i256 v0 i256;
+        mstore 32.i256 v1 i256;
+        evm_return 0.i256 64.i256;
+}
+
+object @Contract {
+  section init {
+    entry %init;
+    embed .runtime as &runtime;
+  }
+  section runtime {
+    entry %runtime;
+  }
+}
+"#;
+
+        let compile = |emit_symbol_table| {
+            EvmCompile::new(parse_module(source).expect("fixture parses").module)
+                .with_symbol_table(emit_symbol_table)
+                .with_observability(true)
+                .compile()
+                .expect("fixture compiles")
+        };
+        let without_symbols = compile(false);
+        let with_symbols = compile(true);
+        let without = &without_symbols[0];
+        let with = &with_symbols[0];
+
+        assert_eq!(without_symbols.len(), with_symbols.len());
+        assert_eq!(without.sections.len(), with.sections.len());
+        for ((without_name, without_section), (with_name, with_section)) in
+            without.sections.iter().zip(with.sections.iter())
+        {
+            assert_eq!(without_name, with_name);
+            assert_eq!(without_section.bytes, with_section.bytes);
+            assert!(without_section.symtab.is_empty());
+            assert!(with_section.observability.is_some());
+        }
+        let (_, init) = with
+            .sections
+            .iter()
+            .find(|(name, _)| name.0.as_str() == "init")
+            .expect("init section exists");
+        assert!(
+            init.symtab
+                .keys()
+                .any(|symbol| matches!(symbol, SymbolId::Embed(_))),
+            "symbol table must contain the required runtime embed symbol"
+        );
     }
 }

--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -25,6 +25,19 @@ pub enum OptLevel {
     O2,
 }
 
+/// An optimized-IR instruction id, the namespace a frontend stamps provenance
+/// against. Distinct from `MachineInstId` so a machine id cannot be handed to
+/// the stamping door by mistake. Use `.raw()` to cross to a bare `InstId`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct OptInstId(pub InstId);
+
+impl OptInstId {
+    pub fn raw(self) -> InstId {
+        self.0
+    }
+}
+
 pub struct EvmCompile {
     module: Module,
     opt_level: OptLevel,
@@ -72,10 +85,11 @@ impl EvmCompile {
     pub fn stamp_post_opt_provenance(
         &mut self,
         func: FuncRef,
-        inst: InstId,
+        inst: OptInstId,
         provenance: impl Into<String>,
     ) -> Result<(), String> {
         self.optimize();
+        let inst = inst.raw();
         if !self.module.funcs().contains(&func) {
             return Err(format!("cannot stamp undefined function {func:?}"));
         }
@@ -193,7 +207,11 @@ mod tests {
     fn post_opt_provenance_stamping_is_metadata_only() {
         let mut compile = EvmCompile::new(module_for_evm(EvmVersion::Osaka));
         let error = compile
-            .stamp_post_opt_provenance(FuncRef::from_u32(0), InstId(0), "post-opt:test")
+            .stamp_post_opt_provenance(
+                FuncRef::from_u32(0),
+                super::OptInstId(InstId(0)),
+                "post-opt:test",
+            )
             .expect_err("undefined functions must be rejected");
 
         assert!(error.contains("undefined function"));

--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -109,6 +109,30 @@ impl EvmCompile {
         Ok(())
     }
 
+    /// Stamp post-optimization provenance across every function in one pass.
+    ///
+    /// The closure returns `Some(provenance)` to stamp a live instruction or
+    /// `None` to leave it unstamped. Stamping many instructions this way runs
+    /// one function-list scan instead of the per-call rescan that
+    /// [`Self::stamp_post_opt_provenance`] pays.
+    pub fn stamp_all_post_opt_provenance(
+        &mut self,
+        mut f: impl FnMut(FuncRef, OptInstId) -> Option<String>,
+    ) {
+        self.optimize();
+        let funcs = self.module.funcs();
+        for func in funcs {
+            self.module.func_store.modify(func, |function| {
+                let insts: Vec<_> = function.dfg.inst_ids().collect();
+                for inst in insts {
+                    if let Some(provenance) = f(func, OptInstId(inst)) {
+                        function.set_inst_provenance(inst, provenance);
+                    }
+                }
+            });
+        }
+    }
+
     /// Optimize (if not already) and compile every object in the module.
     pub fn compile(mut self) -> Result<Vec<ObjectArtifact>, Vec<ObjectCompileError>> {
         self.optimize();

--- a/crates/codegen/src/isa/evm/emit/stack.rs
+++ b/crates/codegen/src/isa/evm/emit/stack.rs
@@ -239,6 +239,9 @@ pub(crate) fn prune_redundant_opcode_sequences(vcode: &mut VCode<OpCode>, block_
                     && is_plain_inst(vcode, &label_targets, eq)
                     && (vcode.insts[eq] as u8) == (OpCode::EQ as u8)
                 {
+                    if vcode.inst_ir[push] != vcode.inst_ir[eq] {
+                        vcode.inst_ir[eq] = None.into();
+                    }
                     vcode.insts[eq] = OpCode::ISZERO;
                     kept.push(eq);
                     changed = true;

--- a/crates/codegen/src/isa/evm/machine/lower.rs
+++ b/crates/codegen/src/isa/evm/machine/lower.rs
@@ -131,6 +131,7 @@ struct FuncLowerCtx<'a> {
     source_block_order: Vec<BlockId>,
     block_terminal_map: SecondaryMap<BlockId, Option<BlockId>>,
     current_block: Option<BlockId>,
+    active_source_inst: Option<sonatina_ir::InstId>,
     pending_phis: Vec<(sonatina_ir::InstId, sonatina_ir::InstId)>,
 }
 
@@ -158,6 +159,7 @@ fn lower_function(
         source_block_order,
         block_terminal_map: SecondaryMap::new(),
         current_block: None,
+        active_source_inst: None,
         pending_phis: Vec::new(),
     };
 
@@ -219,6 +221,7 @@ impl FuncLowerCtx<'_> {
                     &mut self.machine,
                     control_flow::Phi::new_unchecked(self.is, Vec::new()),
                 );
+                self.copy_frontend_origin_to_machine(source_inst, machine_inst);
                 let result_tys = self.machine_result_tys(source_inst)?;
                 let results = cursor.make_results(&mut self.machine, machine_inst, &result_tys);
                 cursor.attach_results(&mut self.machine, machine_inst, &results);
@@ -276,6 +279,13 @@ impl FuncLowerCtx<'_> {
             return Ok(());
         }
 
+        let previous = self.active_source_inst.replace(source_inst);
+        let result = self.lower_inst_active(source_inst);
+        self.active_source_inst = previous;
+        result
+    }
+
+    fn lower_inst_active(&mut self, source_inst: sonatina_ir::InstId) -> Result<(), String> {
         let data = self
             .source_is
             .resolve_inst(self.source.dfg.inst(source_inst));
@@ -934,11 +944,12 @@ impl FuncLowerCtx<'_> {
         inst: I,
     ) -> Result<(), String> {
         let result_tys = self.machine_result_tys(source_inst)?;
-        let machine_inst = self.append_inst_with_results_to(
+        let machine_inst = self.append_inst_with_results_raw(
             self.current_block.expect("insert needs current block"),
             inst,
             &result_tys,
         );
+        self.set_exact_lowering_provenance(source_inst, machine_inst);
         let results = self.machine.dfg.inst_results(machine_inst).to_vec();
         self.map_inst_results(source_inst, machine_inst, &results);
         Ok(())
@@ -953,6 +964,7 @@ impl FuncLowerCtx<'_> {
         let block = self.current_block.expect("insert needs current block");
         let mut cursor = InstInserter::at_location(CursorLocation::BlockBottom(block));
         let machine_inst = cursor.insert_inst_data_dyn(&mut self.machine, inst);
+        self.set_exact_lowering_provenance(source_inst, machine_inst);
         let results = cursor.make_results(&mut self.machine, machine_inst, &result_tys);
         cursor.attach_results(&mut self.machine, machine_inst, &results);
         self.map_inst_results(source_inst, machine_inst, &results);
@@ -965,12 +977,30 @@ impl FuncLowerCtx<'_> {
         inst: I,
     ) -> Result<(), String> {
         let block = self.current_block.expect("insert needs current block");
-        let machine_inst = self.append_inst_no_result_to(block, inst);
+        let machine_inst = self.append_inst_no_result_raw(block, inst);
+        self.set_exact_lowering_provenance(source_inst, machine_inst);
         self.map.insts[source_inst] = Some(machine_inst);
         Ok(())
     }
 
+    /// Glue path: machine instructions synthesized around the active source
+    /// instruction inherit its debug context.
     fn append_inst_with_results_to<I: Inst>(
+        &mut self,
+        block: BlockId,
+        inst: I,
+        tys: &[Type],
+    ) -> sonatina_ir::InstId {
+        let inst = self.append_inst_with_results_raw(block, inst, tys);
+        if let Some(source_inst) = self.active_source_inst {
+            self.copy_frontend_origin_to_machine(source_inst, inst);
+        }
+        inst
+    }
+
+    /// Exact path: the caller copies the debug bundle from its explicit
+    /// source instruction exactly once (via `set_exact_lowering_provenance`).
+    fn append_inst_with_results_raw<I: Inst>(
         &mut self,
         block: BlockId,
         inst: I,
@@ -988,8 +1018,38 @@ impl FuncLowerCtx<'_> {
         block: BlockId,
         inst: I,
     ) -> sonatina_ir::InstId {
+        let inst = self.append_inst_no_result_raw(block, inst);
+        if let Some(source_inst) = self.active_source_inst {
+            self.copy_frontend_origin_to_machine(source_inst, inst);
+        }
+        inst
+    }
+
+    fn append_inst_no_result_raw<I: Inst>(
+        &mut self,
+        block: BlockId,
+        inst: I,
+    ) -> sonatina_ir::InstId {
         let mut cursor = InstInserter::at_location(CursorLocation::BlockBottom(block));
         cursor.insert_inst_data(&mut self.machine, inst)
+    }
+
+    fn copy_frontend_origin_to_machine(
+        &mut self,
+        source_inst: sonatina_ir::InstId,
+        machine_inst: sonatina_ir::InstId,
+    ) {
+        self.machine
+            .import_inst_frontend_origin_from(self.source, source_inst, machine_inst);
+    }
+
+    fn set_exact_lowering_provenance(
+        &mut self,
+        source_inst: sonatina_ir::InstId,
+        machine_inst: sonatina_ir::InstId,
+    ) {
+        self.machine
+            .import_inst_attribution_from(self.source, source_inst, machine_inst);
     }
 
     fn map_inst_results(

--- a/crates/codegen/src/isa/evm/tests.rs
+++ b/crates/codegen/src/isa/evm/tests.rs
@@ -8,7 +8,7 @@ use crate::{
         lower::{LoweredFunction, SectionWorkModule},
         vcode::{Label, VCode, VCodeFixup},
     },
-    object::{CompileOptions, SymbolId, link::link_section},
+    object::{CompileOptions, PcAttribution, SymbolId, UnmappedReason, link::link_section},
     optim::pipeline::Pipeline,
     stackalloc::{
         Action, Actions, Allocator, StackifyAlloc, StackifyBuilder, StackifyEdgeSplitter,
@@ -18,11 +18,16 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec};
 use sonatina_ir::{
     BlockId, Function, Immediate, InstId, InstSetBase, InstSetExt, Module, ValueId,
-    cfg::ControlFlowGraph, inst::evm::inst_set::EvmInstKind, ir_writer::FuncWriter, isa::Isa,
-    module::ModuleCtx, object::SectionName,
+    cfg::ControlFlowGraph,
+    inst::evm::inst_set::EvmInstKind,
+    ir_writer::FuncWriter,
+    isa::Isa,
+    module::ModuleCtx,
+    object::{ObjectName, SectionName},
 };
 use sonatina_parser::parse_module;
 use sonatina_triple::{Architecture, EvmVersion, OperatingSystem, TargetTriple, Vendor};
+use std::sync::Arc;
 
 use self::{
     dyn_sp::DynSpInitKind,
@@ -3233,6 +3238,22 @@ block2:
 }
 
 #[test]
+fn prune_clears_ir_mapping_when_combining_different_attributions() {
+    let mut vcode = VCode::<OpCode>::default();
+    let block = BlockId(0);
+
+    let push = vcode.add_inst_to_block(OpCode::PUSH1, Some(InstId(1)), block);
+    vcode.inst_imm_bytes.insert((push, smallvec![0u8]));
+    let eq = vcode.add_inst_to_block(OpCode::EQ, Some(InstId(2)), block);
+
+    prune_redundant_opcode_sequences(&mut vcode, &[block]);
+
+    assert_eq!(vcode.block_insns(block).collect::<Vec<_>>(), vec![eq]);
+    assert_eq!(vcode.insts[eq] as u8, OpCode::ISZERO as u8);
+    assert_eq!(vcode.inst_ir[eq].expand(), None);
+}
+
+#[test]
 fn prune_removes_and_one_after_bool_producer() {
     let mut vcode = VCode::<OpCode>::default();
     let block = BlockId(0);
@@ -3346,6 +3367,202 @@ fn prune_keeps_iszero_iszero_before_non_labeled_jumpi() {
 }
 
 #[test]
+fn exact_and_glue_lowering_have_distinct_pc_attribution() {
+    let mut parsed = parse_module(
+        r#"
+target = "evm-ethereum-osaka"
+
+func public %runtime(v0.i256, v1.i256) {
+block0:
+    v2.i256 = add v0 v1;
+    v3.i1 = le v2 v1;
+    v4.i256 = zext v3 i256;
+    v5.i256 = add v2 v4;
+    mstore 0.i256 v5 i256;
+    evm_return 0.i256 32.i256;
+}
+
+object @Contract {
+  section runtime {
+    entry %runtime;
+  }
+}
+"#,
+    )
+    .expect("module parses");
+    let runtime = find_func(&parsed.module, "runtime");
+
+    parsed.module.func_store.modify(runtime, |function| {
+        let insts: Vec<_> = function
+            .layout
+            .iter_block()
+            .flat_map(|block| function.layout.iter_inst(block))
+            .collect();
+        let mut add_count = 0;
+        let mut le_count = 0;
+        for inst in insts {
+            match function.dfg.inst(inst).as_text() {
+                "add" if add_count == 0 => {
+                    function.set_inst_frontend_origin(inst, Arc::from("frontend:add"));
+                    add_count += 1;
+                }
+                "le" => {
+                    function.set_inst_frontend_origin(inst, Arc::from("frontend:le"));
+                    le_count += 1;
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(add_count, 1, "fixture should contain the exact add");
+        assert_eq!(le_count, 1, "fixture should contain the glue comparison");
+    });
+
+    Pipeline::speed().run(&mut parsed.module);
+    parsed.module.func_store.modify(runtime, |function| {
+        let insts: Vec<_> = function
+            .layout
+            .iter_block()
+            .flat_map(|block| function.layout.iter_inst(block))
+            .collect();
+        let mut stamped_add = false;
+        let mut stamped_le = false;
+        for inst in insts {
+            match function.inst_frontend_origin(inst) {
+                Some("frontend:add") => {
+                    function.set_inst_provenance(inst, "post-opt:add".to_string());
+                    stamped_add = true;
+                }
+                Some("frontend:le") => {
+                    function.set_inst_provenance(inst, "post-opt:le".to_string());
+                    stamped_le = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(stamped_add);
+        assert!(stamped_le);
+    });
+
+    let backend = test_backend().with_late_cleanup_profile(LateCleanupProfile::Off);
+    let prepared = backend
+        .prepare_section(work_module_with_entry(&parsed.module, &[runtime], runtime))
+        .expect("prepare should succeed");
+
+    let (exact_machine_insts, glue_machine_insts) =
+        prepared.module().func_store.view(runtime, |function| {
+            let mut exact = FxHashSet::default();
+            let mut glue = FxHashSet::default();
+            for inst in function
+                .layout
+                .iter_block()
+                .flat_map(|block| function.layout.iter_inst(block))
+            {
+                match function.inst_frontend_origin(inst) {
+                    Some("frontend:add") => {
+                        assert_eq!(function.inst_provenance(inst), Some("post-opt:add"));
+                        exact.insert(inst);
+                    }
+                    Some("frontend:le") => {
+                        assert_eq!(
+                            function.inst_provenance(inst),
+                            None,
+                            "one-to-many lowering glue must not inherit exact provenance"
+                        );
+                        glue.insert(inst);
+                    }
+                    _ => {}
+                }
+            }
+            (exact, glue)
+        });
+    assert!(
+        !exact_machine_insts.is_empty(),
+        "exact add lowering should retain origin and provenance"
+    );
+    assert!(
+        !glue_machine_insts.is_empty(),
+        "comparison glue should retain only frontend origin"
+    );
+
+    let artifact = link_section(
+        &backend,
+        &prepared,
+        &ObjectName("Contract".into()),
+        &[],
+        &[],
+        &SectionName("runtime".into()),
+        &CompileOptions {
+            fixup_policy: PushWidthPolicy::Push4,
+            emit_symtab: true,
+            emit_observability: true,
+            ..CompileOptions::default()
+        },
+    )
+    .expect("linking should succeed");
+    let observability = artifact
+        .observability
+        .as_ref()
+        .expect("runtime observability");
+
+    let exact_ranges: Vec<_> = observability
+        .pc_map
+        .iter()
+        .filter(|entry| {
+            entry
+                .attribution
+                .ir_inst()
+                .is_some_and(|inst| exact_machine_insts.contains(&inst))
+        })
+        .collect();
+    assert!(!exact_ranges.is_empty());
+    assert!(exact_ranges.iter().all(|entry| matches!(
+        &entry.attribution,
+        PcAttribution::Mapped {
+            post_opt_provenance,
+            ..
+        } if post_opt_provenance == "post-opt:add"
+    )));
+
+    let glue_ranges: Vec<_> = observability
+        .pc_map
+        .iter()
+        .filter(|entry| {
+            entry
+                .attribution
+                .ir_inst()
+                .is_some_and(|inst| glue_machine_insts.contains(&inst))
+        })
+        .collect();
+    assert!(!glue_ranges.is_empty());
+    assert!(glue_ranges.iter().all(|entry| matches!(
+        &entry.attribution,
+        PcAttribution::Unmapped {
+            reason: UnmappedReason::MissingProvenance,
+            ..
+        }
+    )));
+
+    let exact_bytes: u32 = exact_ranges
+        .iter()
+        .map(|entry| entry.pc_end - entry.pc_start)
+        .sum();
+    let glue_bytes: u32 = glue_ranges
+        .iter()
+        .map(|entry| entry.pc_end - entry.pc_start)
+        .sum();
+    assert_eq!(observability.mapped_code_bytes, exact_bytes);
+    assert!(glue_bytes > 0);
+    assert!(
+        observability.unmapped_reason_coverage.missing_provenance >= glue_bytes,
+        "glue bytes must be counted under missing_provenance"
+    );
+    assert_eq!(
+        observability.mapped_code_bytes + observability.unmapped_code_bytes,
+        observability.code_bytes
+    );
+}
+
+#[test]
 fn link_section_resolves_sym_fixups_in_late_outlined_helper() {
     let parsed = parse_module(
         r#"
@@ -3451,6 +3668,7 @@ block2:
     let artifact = link_section(
         &backend,
         &prepared,
+        &sonatina_ir::object::ObjectName("test".into()),
         &[],
         &[],
         &SectionName("runtime".into()),

--- a/crates/codegen/src/isa/evm/tests.rs
+++ b/crates/codegen/src/isa/evm/tests.rs
@@ -3510,8 +3510,8 @@ object @Contract {
         .filter(|entry| {
             entry
                 .attribution
-                .ir_inst()
-                .is_some_and(|inst| exact_machine_insts.contains(&inst))
+                .machine_inst()
+                .is_some_and(|inst| exact_machine_insts.contains(&inst.raw()))
         })
         .collect();
     assert!(!exact_ranges.is_empty());
@@ -3529,8 +3529,8 @@ object @Contract {
         .filter(|entry| {
             entry
                 .attribution
-                .ir_inst()
-                .is_some_and(|inst| glue_machine_insts.contains(&inst))
+                .machine_inst()
+                .is_some_and(|inst| glue_machine_insts.contains(&inst.raw()))
         })
         .collect();
     assert!(!glue_ranges.is_empty());

--- a/crates/codegen/src/isa/evm/tests.rs
+++ b/crates/codegen/src/isa/evm/tests.rs
@@ -3254,6 +3254,45 @@ fn prune_clears_ir_mapping_when_combining_different_attributions() {
 }
 
 #[test]
+fn prune_preserves_ir_mapping_when_combining_the_same_attribution() {
+    let mut vcode = VCode::<OpCode>::default();
+    let block = BlockId(0);
+    let owner = InstId(7);
+    let push = vcode.add_inst_to_block(OpCode::PUSH1, Some(owner), block);
+    vcode.inst_imm_bytes.insert((push, smallvec![0u8]));
+    let eq = vcode.add_inst_to_block(OpCode::EQ, Some(owner), block);
+
+    prune_redundant_opcode_sequences(&mut vcode, &[block]);
+
+    assert_eq!(vcode.block_insns(block).collect::<Vec<_>>(), vec![eq]);
+    assert_eq!(vcode.insts[eq] as u8, OpCode::ISZERO as u8);
+    assert_eq!(vcode.inst_ir[eq].expand(), Some(owner));
+}
+
+#[test]
+fn prune_preserves_surviving_owners_when_reordering_stack_operations() {
+    let mut vcode = VCode::<OpCode>::default();
+    let block = BlockId(0);
+    let addr = vcode.add_inst_to_block(OpCode::PUSH1, Some(InstId(1)), block);
+    vcode.inst_imm_bytes.insert((addr, smallvec![32u8]));
+    let load = vcode.add_inst_to_block(OpCode::MLOAD, Some(InstId(2)), block);
+    let imm = vcode.add_inst_to_block(OpCode::PUSH1, Some(InstId(3)), block);
+    vcode.inst_imm_bytes.insert((imm, smallvec![5u8]));
+    vcode.add_inst_to_block(OpCode::SWAP1, Some(InstId(4)), block);
+    let sub = vcode.add_inst_to_block(OpCode::SUB, Some(InstId(5)), block);
+
+    prune_redundant_opcode_sequences(&mut vcode, &[block]);
+
+    assert_eq!(
+        vcode.block_insns(block).collect::<Vec<_>>(),
+        vec![imm, addr, load, sub]
+    );
+    for (inst, owner) in [(addr, 1), (load, 2), (imm, 3), (sub, 5)] {
+        assert_eq!(vcode.inst_ir[inst].expand(), Some(InstId(owner)));
+    }
+}
+
+#[test]
 fn prune_removes_and_one_after_bool_producer() {
     let mut vcode = VCode::<OpCode>::default();
     let block = BlockId(0);

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -4,7 +4,7 @@ pub mod cfg_edit;
 pub mod cfg_scc;
 pub mod compile;
 
-pub use compile::{EvmCompile, OptLevel};
+pub use compile::{EvmCompile, OptInstId, OptLevel};
 pub mod critical_edge;
 pub mod domtree;
 pub mod isa;

--- a/crates/codegen/src/object/artifact.rs
+++ b/crates/codegen/src/object/artifact.rs
@@ -1,4 +1,4 @@
-use crate::machinst::vcode::VCodeInst;
+use crate::machinst::vcode::{SectionCodeUnitId, VCodeInst};
 use cranelift_entity::EntityRef;
 use indexmap::IndexMap;
 use rustc_hash::FxHashMap;
@@ -9,8 +9,38 @@ use sonatina_ir::{
 };
 use std::fmt::Write as _;
 
-pub const OBSERVABILITY_SCHEMA_VERSION: &str = "0.1.0";
-pub type FrontendProvenanceMap = FxHashMap<(FuncRef, InstId), String>;
+pub const OBSERVABILITY_SCHEMA_VERSION: &str = "0.3.0";
+pub type PostOptProvenanceMap = FxHashMap<(FuncRef, InstId), String>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PcMapUnit {
+    Function(FuncRef),
+    Synthetic {
+        object: ObjectName,
+        section: SectionName,
+        unit: SectionCodeUnitId,
+    },
+}
+
+impl PcMapUnit {
+    pub fn function(&self) -> Option<FuncRef> {
+        match self {
+            Self::Function(func) => Some(*func),
+            Self::Synthetic { .. } => None,
+        }
+    }
+
+    pub(crate) fn sort_key(&self) -> (u8, u32, &str, &str, u32) {
+        match self {
+            Self::Function(func) => (0, func.as_u32(), "", "", 0),
+            Self::Synthetic {
+                object,
+                section,
+                unit,
+            } => (1, 0, object.0.as_str(), section.0.as_str(), unit.0),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SymbolId {
@@ -28,6 +58,7 @@ pub struct SymbolDef {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnmappedReason {
+    MissingProvenance,
     NoIrInst,
     LabelOrFixupOnly,
     Synthetic,
@@ -37,6 +68,7 @@ pub enum UnmappedReason {
 impl UnmappedReason {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::MissingProvenance => "missing_provenance",
             Self::NoIrInst => "no_ir_inst",
             Self::LabelOrFixupOnly => "label_or_fixup_only",
             Self::Synthetic => "synthetic",
@@ -47,6 +79,7 @@ impl UnmappedReason {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct UnmappedReasonCoverage {
+    pub missing_provenance: u32,
     pub no_ir_inst: u32,
     pub label_or_fixup_only: u32,
     pub synthetic: u32,
@@ -56,6 +89,9 @@ pub struct UnmappedReasonCoverage {
 impl UnmappedReasonCoverage {
     pub fn add_bytes(&mut self, reason: UnmappedReason, bytes: u32) {
         match reason {
+            UnmappedReason::MissingProvenance => {
+                self.missing_provenance = self.missing_provenance.saturating_add(bytes);
+            }
             UnmappedReason::NoIrInst => {
                 self.no_ir_inst = self.no_ir_inst.saturating_add(bytes);
             }
@@ -72,10 +108,58 @@ impl UnmappedReasonCoverage {
     }
 
     pub fn total_bytes(self) -> u32 {
-        self.no_ir_inst
+        self.missing_provenance
+            .saturating_add(self.no_ir_inst)
             .saturating_add(self.label_or_fixup_only)
             .saturating_add(self.synthetic)
             .saturating_add(self.unknown)
+    }
+}
+
+/// The trace attribution of an emitted PC range.
+///
+/// A range is mapped only when its machine-IR instruction carries provenance
+/// stamped after optimization. Machine-IR identity alone is retained on the
+/// unmapped side for diagnostics, but never contributes to mapped coverage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PcAttribution {
+    Mapped {
+        ir_inst: InstId,
+        post_opt_provenance: String,
+    },
+    Unmapped {
+        ir_inst: Option<InstId>,
+        reason: UnmappedReason,
+    },
+}
+
+impl PcAttribution {
+    pub fn ir_inst(&self) -> Option<InstId> {
+        match self {
+            Self::Mapped { ir_inst, .. } => Some(*ir_inst),
+            Self::Unmapped { ir_inst, .. } => *ir_inst,
+        }
+    }
+
+    pub fn post_opt_provenance(&self) -> Option<&str> {
+        match self {
+            Self::Mapped {
+                post_opt_provenance,
+                ..
+            } => Some(post_opt_provenance),
+            Self::Unmapped { .. } => None,
+        }
+    }
+
+    pub fn unmapped_reason(&self) -> Option<UnmappedReason> {
+        match self {
+            Self::Mapped { .. } => None,
+            Self::Unmapped { reason, .. } => Some(*reason),
+        }
+    }
+
+    pub fn is_mapped(&self) -> bool {
+        matches!(self, Self::Mapped { .. })
     }
 }
 
@@ -83,13 +167,11 @@ impl UnmappedReasonCoverage {
 pub struct PcMapEntry {
     pub pc_start: u32,
     pub pc_end: u32,
-    pub func: FuncRef,
+    pub unit: PcMapUnit,
     pub func_name: String,
     pub block: BlockId,
     pub vcode_inst: VCodeInst,
-    pub ir_inst: Option<InstId>,
-    pub frontend_provenance: Option<String>,
-    pub unmapped_reason: Option<UnmappedReason>,
+    pub attribution: PcAttribution,
 }
 
 #[derive(Debug, Clone)]
@@ -107,6 +189,48 @@ pub struct SectionObservability {
 }
 
 impl SectionObservability {
+    fn recompute_coverage(&mut self) {
+        let mut mapped_code_bytes = 0_u32;
+        let mut unmapped_code_bytes = 0_u32;
+        let mut reasons = UnmappedReasonCoverage::default();
+        let mut cursor = 0_u32;
+
+        for entry in &self.pc_map {
+            if entry.pc_start > cursor {
+                let gap = entry.pc_start - cursor;
+                unmapped_code_bytes = unmapped_code_bytes.saturating_add(gap);
+                reasons.add_bytes(UnmappedReason::Unknown, gap);
+            }
+
+            let span = entry.pc_end.saturating_sub(entry.pc_start);
+            match &entry.attribution {
+                PcAttribution::Mapped { .. } => {
+                    mapped_code_bytes = mapped_code_bytes.saturating_add(span);
+                }
+                PcAttribution::Unmapped { reason, .. } => {
+                    unmapped_code_bytes = unmapped_code_bytes.saturating_add(span);
+                    reasons.add_bytes(*reason, span);
+                }
+            }
+            cursor = cursor.max(entry.pc_end);
+        }
+
+        if cursor < self.code_bytes {
+            let gap = self.code_bytes - cursor;
+            unmapped_code_bytes = unmapped_code_bytes.saturating_add(gap);
+            reasons.add_bytes(UnmappedReason::Unknown, gap);
+        }
+
+        debug_assert_eq!(
+            mapped_code_bytes.saturating_add(unmapped_code_bytes),
+            self.code_bytes
+        );
+        debug_assert_eq!(reasons.total_bytes(), unmapped_code_bytes);
+        self.mapped_code_bytes = mapped_code_bytes;
+        self.unmapped_code_bytes = unmapped_code_bytes;
+        self.unmapped_reason_coverage = reasons;
+    }
+
     pub fn to_text(&self) -> String {
         let mut out = String::new();
         writeln!(
@@ -129,7 +253,8 @@ impl SectionObservability {
         .expect("in-memory write should not fail");
         writeln!(
             &mut out,
-            "unmapped no_ir_inst={} label_or_fixup_only={} synthetic={} unknown={}",
+            "unmapped missing_provenance={} no_ir_inst={} label_or_fixup_only={} synthetic={} unknown={}",
+            self.unmapped_reason_coverage.missing_provenance,
             self.unmapped_reason_coverage.no_ir_inst,
             self.unmapped_reason_coverage.label_or_fixup_only,
             self.unmapped_reason_coverage.synthetic,
@@ -138,28 +263,22 @@ impl SectionObservability {
         .expect("in-memory write should not fail");
 
         let mut entries = self.pc_map.clone();
-        entries.sort_by_key(|e| {
-            (
-                e.pc_start,
-                e.pc_end,
-                e.func.index(),
-                e.block.index(),
-                e.vcode_inst.index(),
-            )
-        });
+        sort_pc_map_entries(&mut entries);
         for entry in entries {
             let reason = entry
-                .unmapped_reason
+                .attribution
+                .unmapped_reason()
                 .map(UnmappedReason::as_str)
                 .unwrap_or("-");
-            let frontend = entry.frontend_provenance.as_deref().unwrap_or("-");
+            let post_opt = entry.attribution.post_opt_provenance().unwrap_or("-");
             let ir = entry
-                .ir_inst
+                .attribution
+                .ir_inst()
                 .map(|ir| ir.0.to_string())
                 .unwrap_or("-".into());
             writeln!(
                 &mut out,
-                "pc [{}, {}) func={} block={} vcode={} ir={} reason={} frontend={}",
+                "pc [{}, {}) func={} block={} vcode={} ir={} reason={} post_opt={}",
                 entry.pc_start,
                 entry.pc_end,
                 entry.func_name,
@@ -167,7 +286,7 @@ impl SectionObservability {
                 entry.vcode_inst.index(),
                 ir,
                 reason,
-                frontend
+                post_opt
             )
             .expect("in-memory write should not fail");
         }
@@ -215,7 +334,8 @@ impl SectionObservability {
             .expect("in-memory write should not fail");
         write!(
             &mut out,
-            "\"no_ir_inst\":{},\"label_or_fixup_only\":{},\"synthetic\":{},\"unknown\":{}",
+            "\"missing_provenance\":{},\"no_ir_inst\":{},\"label_or_fixup_only\":{},\"synthetic\":{},\"unknown\":{}",
+            self.unmapped_reason_coverage.missing_provenance,
             self.unmapped_reason_coverage.no_ir_inst,
             self.unmapped_reason_coverage.label_or_fixup_only,
             self.unmapped_reason_coverage.synthetic,
@@ -226,15 +346,7 @@ impl SectionObservability {
 
         write!(&mut out, "\"pc_map\":[").expect("in-memory write should not fail");
         let mut entries = self.pc_map.clone();
-        entries.sort_by_key(|e| {
-            (
-                e.pc_start,
-                e.pc_end,
-                e.func.index(),
-                e.block.index(),
-                e.vcode_inst.index(),
-            )
-        });
+        sort_pc_map_entries(&mut entries);
         for (idx, entry) in entries.iter().enumerate() {
             if idx > 0 {
                 write!(&mut out, ",").expect("in-memory write should not fail");
@@ -242,13 +354,31 @@ impl SectionObservability {
             write!(&mut out, "{{").expect("in-memory write should not fail");
             write!(
                 &mut out,
-                "\"pc_start\":{},\"pc_end\":{},\"func\":{},\"block\":{},\"vcode_inst\":{}",
+                "\"pc_start\":{},\"pc_end\":{},\"block\":{},\"vcode_inst\":{}",
                 entry.pc_start,
                 entry.pc_end,
-                entry.func.index(),
                 entry.block.index(),
                 entry.vcode_inst.index()
             )
+            .expect("in-memory write should not fail");
+            match &entry.unit {
+                PcMapUnit::Function(func) => write!(
+                    &mut out,
+                    ",\"unit\":{{\"kind\":\"function\",\"func\":{}}}",
+                    func.index()
+                ),
+                PcMapUnit::Synthetic {
+                    object,
+                    section,
+                    unit,
+                } => write!(
+                    &mut out,
+                    ",\"unit\":{{\"kind\":\"synthetic\",\"object\":\"{}\",\"section\":\"{}\",\"unit\":{}}}",
+                    json_escape(&object.0),
+                    json_escape(&section.0),
+                    unit.0
+                ),
+            }
             .expect("in-memory write should not fail");
             write!(
                 &mut out,
@@ -257,31 +387,32 @@ impl SectionObservability {
             )
             .expect("in-memory write should not fail");
 
-            if let Some(ir_inst) = entry.ir_inst {
-                write!(&mut out, ",\"ir_inst\":{}", ir_inst.0)
-                    .expect("in-memory write should not fail");
-            } else {
-                write!(&mut out, ",\"ir_inst\":null").expect("in-memory write should not fail");
-            }
-
-            if let Some(reason) = entry.unmapped_reason {
-                write!(&mut out, ",\"reason\":\"{}\"", reason.as_str())
-                    .expect("in-memory write should not fail");
-            } else {
-                write!(&mut out, ",\"reason\":null").expect("in-memory write should not fail");
-            }
-
-            if let Some(frontend) = &entry.frontend_provenance {
-                write!(
+            match &entry.attribution {
+                PcAttribution::Mapped {
+                    ir_inst,
+                    post_opt_provenance,
+                } => write!(
                     &mut out,
-                    ",\"frontend_provenance\":\"{}\"",
-                    json_escape(frontend)
-                )
-                .expect("in-memory write should not fail");
-            } else {
-                write!(&mut out, ",\"frontend_provenance\":null")
+                    ",\"attribution\":{{\"status\":\"mapped\",\"ir_inst\":{},\"post_opt_provenance\":\"{}\"}}",
+                    ir_inst.0,
+                    json_escape(post_opt_provenance)
+                ),
+                PcAttribution::Unmapped { ir_inst, reason } => {
+                    write!(
+                        &mut out,
+                        ",\"attribution\":{{\"status\":\"unmapped\",\"ir_inst\":"
+                    )
                     .expect("in-memory write should not fail");
+                    if let Some(ir_inst) = ir_inst {
+                        write!(&mut out, "{}", ir_inst.0)
+                            .expect("in-memory write should not fail");
+                    } else {
+                        write!(&mut out, "null").expect("in-memory write should not fail");
+                    }
+                    write!(&mut out, ",\"reason\":\"{}\"}}", reason.as_str())
+                }
             }
+            .expect("in-memory write should not fail");
 
             write!(&mut out, "}}").expect("in-memory write should not fail");
         }
@@ -365,21 +496,45 @@ impl ObjectObservability {
         out
     }
 
-    /// Enrich pc-map entries with frontend provenance attached to `(FuncRef, InstId)`.
+    /// Enrich PC-map entries with provenance stamped after optimization.
     ///
-    /// This is additive and does not require mutating Sonatina IR instructions.
-    pub fn apply_frontend_provenance(&mut self, provenance: &FrontendProvenanceMap) {
+    /// Entries become mapped only when the supplied `(FuncRef, InstId)` key has
+    /// post-optimization provenance. Coverage and reason totals are recomputed.
+    pub fn apply_post_opt_provenance(&mut self, provenance: &PostOptProvenanceMap) {
         for section in self.sections.values_mut() {
             for entry in &mut section.pc_map {
-                let Some(ir_inst) = entry.ir_inst else {
+                let Some(ir_inst) = entry.attribution.ir_inst() else {
                     continue;
                 };
-                if let Some(value) = provenance.get(&(entry.func, ir_inst)) {
-                    entry.frontend_provenance = Some(value.clone());
+                if let Some(func) = entry.unit.function()
+                    && let Some(value) = provenance.get(&(func, ir_inst))
+                {
+                    entry.attribution = PcAttribution::Mapped {
+                        ir_inst,
+                        post_opt_provenance: value.clone(),
+                    };
                 }
             }
+            section.recompute_coverage();
         }
+
+        self.total_mapped_code_bytes = self.sections.values().fold(0_u32, |total, section| {
+            total.saturating_add(section.mapped_code_bytes)
+        });
+        self.total_unmapped_code_bytes = self.sections.values().fold(0_u32, |total, section| {
+            total.saturating_add(section.unmapped_code_bytes)
+        });
     }
+}
+
+fn sort_pc_map_entries(entries: &mut [PcMapEntry]) {
+    entries.sort_by(|a, b| {
+        (a.pc_start, a.pc_end)
+            .cmp(&(b.pc_start, b.pc_end))
+            .then_with(|| a.unit.sort_key().cmp(&b.unit.sort_key()))
+            .then_with(|| a.block.index().cmp(&b.block.index()))
+            .then_with(|| a.vcode_inst.index().cmp(&b.vcode_inst.index()))
+    });
 }
 
 #[derive(Debug, Clone)]

--- a/crates/codegen/src/object/artifact.rs
+++ b/crates/codegen/src/object/artifact.rs
@@ -11,6 +11,12 @@ use std::fmt::Write as _;
 
 pub const OBSERVABILITY_SCHEMA_VERSION: &str = "0.3.0";
 
+/// The owner of a PC-map range.
+///
+/// Function machine-instruction IDs are local to their function unit. A
+/// function unit and its [`MachineInstId`] must therefore be kept together
+/// when consuming an attribution. Synthetic units have no machine instruction
+/// owner and are always reported as unmapped.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PcMapUnit {
     Function(FuncRef),
@@ -121,7 +127,11 @@ impl UnmappedReasonCoverage {
 /// be looked up against each other by accident. Use `.raw()` at the point you
 /// deliberately cross back to a bare `InstId`. The inner field is pub on
 /// purpose: crossing namespaces requires writing the wrap explicitly, which is
-/// the reviewable act.
+/// the reviewable act. The numeric ID is local to the [`PcMapUnit::Function`]
+/// that owns the PC range, not globally unique across functions. Consumers
+/// must retain `(PcMapUnit, MachineInstId)` together with the enclosing object
+/// and section when consuming a PC map. IDs are not stable across separate
+/// compilations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct MachineInstId(pub InstId);
@@ -137,6 +147,11 @@ impl MachineInstId {
 /// A range is mapped only when its machine-IR instruction carries provenance
 /// stamped after optimization. Machine-IR identity alone is retained on the
 /// unmapped side for diagnostics, but never contributes to mapped coverage.
+/// The provenance string is a scalar anchor supplied through the public API
+/// after optimization and carried by codegen. It identifies one
+/// post-optimization instruction, but does not promise exhaustive
+/// transformation ancestry or source ownership for every input that
+/// contributed to the emitted range.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PcAttribution {
     Mapped {
@@ -179,6 +194,11 @@ impl PcAttribution {
     }
 }
 
+/// One emitted PC interval and its owning code unit.
+///
+/// For a function unit, [`Self::unit`] scopes the optional machine instruction
+/// ID in [`Self::attribution`]. Numeric machine IDs must not be joined across
+/// entries from different function units.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PcMapEntry {
     pub pc_start: u32,
@@ -190,6 +210,13 @@ pub struct PcMapEntry {
     pub attribution: PcAttribution,
 }
 
+/// Observability captured while linking one section.
+///
+/// This schema describes EVM object-section bytes and program-counter ranges;
+/// it is not a target-neutral provenance format. This is an owned snapshot of
+/// the section at compilation time. It is not a live view of the module and
+/// does not retain historical states if the module
+/// is mutated between optimization, stamping, and compilation.
 #[derive(Debug, Clone)]
 pub struct SectionObservability {
     pub schema_version: &'static str,

--- a/crates/codegen/src/object/artifact.rs
+++ b/crates/codegen/src/object/artifact.rs
@@ -115,6 +115,21 @@ impl UnmappedReasonCoverage {
     }
 }
 
+/// A machine-IR instruction id, recovered from the vcode `inst_ir` table.
+///
+/// It is a distinct type from an optimized-IR id so the two namespaces cannot
+/// be looked up against each other by accident. Use `.raw()` at the point you
+/// deliberately cross back to a bare `InstId`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct MachineInstId(pub InstId);
+
+impl MachineInstId {
+    pub fn raw(self) -> InstId {
+        self.0
+    }
+}
+
 /// The trace attribution of an emitted PC range.
 ///
 /// A range is mapped only when its machine-IR instruction carries provenance
@@ -123,20 +138,20 @@ impl UnmappedReasonCoverage {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PcAttribution {
     Mapped {
-        ir_inst: InstId,
+        machine_inst: MachineInstId,
         post_opt_provenance: String,
     },
     Unmapped {
-        ir_inst: Option<InstId>,
+        machine_inst: Option<MachineInstId>,
         reason: UnmappedReason,
     },
 }
 
 impl PcAttribution {
-    pub fn ir_inst(&self) -> Option<InstId> {
+    pub fn machine_inst(&self) -> Option<MachineInstId> {
         match self {
-            Self::Mapped { ir_inst, .. } => Some(*ir_inst),
-            Self::Unmapped { ir_inst, .. } => *ir_inst,
+            Self::Mapped { machine_inst, .. } => Some(*machine_inst),
+            Self::Unmapped { machine_inst, .. } => *machine_inst,
         }
     }
 
@@ -230,8 +245,8 @@ impl SectionObservability {
             let post_opt = entry.attribution.post_opt_provenance().unwrap_or("-");
             let ir = entry
                 .attribution
-                .ir_inst()
-                .map(|ir| ir.0.to_string())
+                .machine_inst()
+                .map(|ir| ir.raw().0.to_string())
                 .unwrap_or("-".into());
             writeln!(
                 &mut out,
@@ -346,22 +361,22 @@ impl SectionObservability {
 
             match &entry.attribution {
                 PcAttribution::Mapped {
-                    ir_inst,
+                    machine_inst,
                     post_opt_provenance,
                 } => write!(
                     &mut out,
-                    ",\"attribution\":{{\"status\":\"mapped\",\"ir_inst\":{},\"post_opt_provenance\":\"{}\"}}",
-                    ir_inst.0,
+                    ",\"attribution\":{{\"status\":\"mapped\",\"machine_inst\":{},\"post_opt_provenance\":\"{}\"}}",
+                    machine_inst.raw().0,
                     json_escape(post_opt_provenance)
                 ),
-                PcAttribution::Unmapped { ir_inst, reason } => {
+                PcAttribution::Unmapped { machine_inst, reason } => {
                     write!(
                         &mut out,
-                        ",\"attribution\":{{\"status\":\"unmapped\",\"ir_inst\":"
+                        ",\"attribution\":{{\"status\":\"unmapped\",\"machine_inst\":"
                     )
                     .expect("in-memory write should not fail");
-                    if let Some(ir_inst) = ir_inst {
-                        write!(&mut out, "{}", ir_inst.0)
+                    if let Some(machine_inst) = machine_inst {
+                        write!(&mut out, "{}", machine_inst.raw().0)
                             .expect("in-memory write should not fail");
                     } else {
                         write!(&mut out, "null").expect("in-memory write should not fail");

--- a/crates/codegen/src/object/artifact.rs
+++ b/crates/codegen/src/object/artifact.rs
@@ -10,7 +10,6 @@ use sonatina_ir::{
 use std::fmt::Write as _;
 
 pub const OBSERVABILITY_SCHEMA_VERSION: &str = "0.3.0";
-pub type PostOptProvenanceMap = FxHashMap<(FuncRef, InstId), String>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PcMapUnit {
@@ -189,48 +188,6 @@ pub struct SectionObservability {
 }
 
 impl SectionObservability {
-    fn recompute_coverage(&mut self) {
-        let mut mapped_code_bytes = 0_u32;
-        let mut unmapped_code_bytes = 0_u32;
-        let mut reasons = UnmappedReasonCoverage::default();
-        let mut cursor = 0_u32;
-
-        for entry in &self.pc_map {
-            if entry.pc_start > cursor {
-                let gap = entry.pc_start - cursor;
-                unmapped_code_bytes = unmapped_code_bytes.saturating_add(gap);
-                reasons.add_bytes(UnmappedReason::Unknown, gap);
-            }
-
-            let span = entry.pc_end.saturating_sub(entry.pc_start);
-            match &entry.attribution {
-                PcAttribution::Mapped { .. } => {
-                    mapped_code_bytes = mapped_code_bytes.saturating_add(span);
-                }
-                PcAttribution::Unmapped { reason, .. } => {
-                    unmapped_code_bytes = unmapped_code_bytes.saturating_add(span);
-                    reasons.add_bytes(*reason, span);
-                }
-            }
-            cursor = cursor.max(entry.pc_end);
-        }
-
-        if cursor < self.code_bytes {
-            let gap = self.code_bytes - cursor;
-            unmapped_code_bytes = unmapped_code_bytes.saturating_add(gap);
-            reasons.add_bytes(UnmappedReason::Unknown, gap);
-        }
-
-        debug_assert_eq!(
-            mapped_code_bytes.saturating_add(unmapped_code_bytes),
-            self.code_bytes
-        );
-        debug_assert_eq!(reasons.total_bytes(), unmapped_code_bytes);
-        self.mapped_code_bytes = mapped_code_bytes;
-        self.unmapped_code_bytes = unmapped_code_bytes;
-        self.unmapped_reason_coverage = reasons;
-    }
-
     pub fn to_text(&self) -> String {
         let mut out = String::new();
         writeln!(
@@ -494,36 +451,6 @@ impl ObjectObservability {
 
         write!(&mut out, "]}}").expect("in-memory write should not fail");
         out
-    }
-
-    /// Enrich PC-map entries with provenance stamped after optimization.
-    ///
-    /// Entries become mapped only when the supplied `(FuncRef, InstId)` key has
-    /// post-optimization provenance. Coverage and reason totals are recomputed.
-    pub fn apply_post_opt_provenance(&mut self, provenance: &PostOptProvenanceMap) {
-        for section in self.sections.values_mut() {
-            for entry in &mut section.pc_map {
-                let Some(ir_inst) = entry.attribution.ir_inst() else {
-                    continue;
-                };
-                if let Some(func) = entry.unit.function()
-                    && let Some(value) = provenance.get(&(func, ir_inst))
-                {
-                    entry.attribution = PcAttribution::Mapped {
-                        ir_inst,
-                        post_opt_provenance: value.clone(),
-                    };
-                }
-            }
-            section.recompute_coverage();
-        }
-
-        self.total_mapped_code_bytes = self.sections.values().fold(0_u32, |total, section| {
-            total.saturating_add(section.mapped_code_bytes)
-        });
-        self.total_unmapped_code_bytes = self.sections.values().fold(0_u32, |total, section| {
-            total.saturating_add(section.unmapped_code_bytes)
-        });
     }
 }
 

--- a/crates/codegen/src/object/artifact.rs
+++ b/crates/codegen/src/object/artifact.rs
@@ -119,7 +119,9 @@ impl UnmappedReasonCoverage {
 ///
 /// It is a distinct type from an optimized-IR id so the two namespaces cannot
 /// be looked up against each other by accident. Use `.raw()` at the point you
-/// deliberately cross back to a bare `InstId`.
+/// deliberately cross back to a bare `InstId`. The inner field is pub on
+/// purpose: crossing namespaces requires writing the wrap explicitly, which is
+/// the reviewable act.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct MachineInstId(pub InstId);

--- a/crates/codegen/src/object/artifact.rs
+++ b/crates/codegen/src/object/artifact.rs
@@ -58,7 +58,7 @@ pub struct SymbolDef {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnmappedReason {
     MissingProvenance,
-    NoIrInst,
+    NoMachineInst,
     LabelOrFixupOnly,
     Synthetic,
     Unknown,
@@ -68,7 +68,7 @@ impl UnmappedReason {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::MissingProvenance => "missing_provenance",
-            Self::NoIrInst => "no_ir_inst",
+            Self::NoMachineInst => "no_machine_inst",
             Self::LabelOrFixupOnly => "label_or_fixup_only",
             Self::Synthetic => "synthetic",
             Self::Unknown => "unknown",
@@ -79,7 +79,7 @@ impl UnmappedReason {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct UnmappedReasonCoverage {
     pub missing_provenance: u32,
-    pub no_ir_inst: u32,
+    pub no_machine_inst: u32,
     pub label_or_fixup_only: u32,
     pub synthetic: u32,
     pub unknown: u32,
@@ -91,8 +91,8 @@ impl UnmappedReasonCoverage {
             UnmappedReason::MissingProvenance => {
                 self.missing_provenance = self.missing_provenance.saturating_add(bytes);
             }
-            UnmappedReason::NoIrInst => {
-                self.no_ir_inst = self.no_ir_inst.saturating_add(bytes);
+            UnmappedReason::NoMachineInst => {
+                self.no_machine_inst = self.no_machine_inst.saturating_add(bytes);
             }
             UnmappedReason::LabelOrFixupOnly => {
                 self.label_or_fixup_only = self.label_or_fixup_only.saturating_add(bytes);
@@ -108,7 +108,7 @@ impl UnmappedReasonCoverage {
 
     pub fn total_bytes(self) -> u32 {
         self.missing_provenance
-            .saturating_add(self.no_ir_inst)
+            .saturating_add(self.no_machine_inst)
             .saturating_add(self.label_or_fixup_only)
             .saturating_add(self.synthetic)
             .saturating_add(self.unknown)
@@ -225,9 +225,9 @@ impl SectionObservability {
         .expect("in-memory write should not fail");
         writeln!(
             &mut out,
-            "unmapped missing_provenance={} no_ir_inst={} label_or_fixup_only={} synthetic={} unknown={}",
+            "unmapped missing_provenance={} no_machine_inst={} label_or_fixup_only={} synthetic={} unknown={}",
             self.unmapped_reason_coverage.missing_provenance,
-            self.unmapped_reason_coverage.no_ir_inst,
+            self.unmapped_reason_coverage.no_machine_inst,
             self.unmapped_reason_coverage.label_or_fixup_only,
             self.unmapped_reason_coverage.synthetic,
             self.unmapped_reason_coverage.unknown,
@@ -250,7 +250,7 @@ impl SectionObservability {
                 .unwrap_or("-".into());
             writeln!(
                 &mut out,
-                "pc [{}, {}) func={} block={} vcode={} ir={} reason={} post_opt={}",
+                "pc [{}, {}) func={} block={} vcode={} machine={} reason={} post_opt={}",
                 entry.pc_start,
                 entry.pc_end,
                 entry.func_name,
@@ -306,9 +306,9 @@ impl SectionObservability {
             .expect("in-memory write should not fail");
         write!(
             &mut out,
-            "\"missing_provenance\":{},\"no_ir_inst\":{},\"label_or_fixup_only\":{},\"synthetic\":{},\"unknown\":{}",
+            "\"missing_provenance\":{},\"no_machine_inst\":{},\"label_or_fixup_only\":{},\"synthetic\":{},\"unknown\":{}",
             self.unmapped_reason_coverage.missing_provenance,
-            self.unmapped_reason_coverage.no_ir_inst,
+            self.unmapped_reason_coverage.no_machine_inst,
             self.unmapped_reason_coverage.label_or_fixup_only,
             self.unmapped_reason_coverage.synthetic,
             self.unmapped_reason_coverage.unknown

--- a/crates/codegen/src/object/compile.rs
+++ b/crates/codegen/src/object/compile.rs
@@ -415,9 +415,26 @@ fn compile_section(
             section = %section_name.0
         )
         .entered();
-        link_section(backend, &prepared, &data, &embeds, section_name, opts).map_err(
-            |e| match e {
-                LinkSectionError::Backend { func, error } => {
+        link_section(
+            backend,
+            &prepared,
+            object_name,
+            &data,
+            &embeds,
+            section_name,
+            opts,
+        )
+        .map_err(|e| match e {
+            LinkSectionError::Backend { func, error } => {
+                vec![ObjectCompileError::BackendError {
+                    object: object_name.clone(),
+                    section: section_name.clone(),
+                    func,
+                    message: error,
+                }]
+            }
+            LinkSectionError::BackendFixup { owner, error } => match owner {
+                CodeUnitOwner::Function(func) => {
                     vec![ObjectCompileError::BackendError {
                         object: object_name.clone(),
                         section: section_name.clone(),
@@ -425,28 +442,18 @@ fn compile_section(
                         message: error,
                     }]
                 }
-                LinkSectionError::BackendFixup { owner, error } => match owner {
-                    CodeUnitOwner::Function(func) => {
-                        vec![ObjectCompileError::BackendError {
-                            object: object_name.clone(),
-                            section: section_name.clone(),
-                            func,
-                            message: error,
-                        }]
-                    }
-                    CodeUnitOwner::SectionUnit(_) => vec![ObjectCompileError::LinkError {
-                        object: object_name.clone(),
-                        section: section_name.clone(),
-                        message: format!("{owner}: {error}"),
-                    }],
-                },
-                LinkSectionError::Link(message) => vec![ObjectCompileError::LinkError {
+                CodeUnitOwner::SectionUnit(_) => vec![ObjectCompileError::LinkError {
                     object: object_name.clone(),
                     section: section_name.clone(),
-                    message,
+                    message: format!("{owner}: {error}"),
                 }],
             },
-        )?
+            LinkSectionError::Link(message) => vec![ObjectCompileError::LinkError {
+                object: object_name.clone(),
+                section: section_name.clone(),
+                message,
+            }],
+        })?
     };
 
     cache.insert(section_id, artifact);
@@ -501,7 +508,8 @@ mod tests {
     use crate::{
         isa::evm::{EvmBackend, PushWidthPolicy},
         object::{
-            CompileOptions, FrontendProvenanceMap, OBSERVABILITY_SCHEMA_VERSION, artifact::SymbolId,
+            CompileOptions, OBSERVABILITY_SCHEMA_VERSION, PcAttribution, PostOptProvenanceMap,
+            artifact::SymbolId,
         },
     };
     use sonatina_ir::{
@@ -881,16 +889,114 @@ object @Contract {
             .sections
             .values()
             .flat_map(|section| section.pc_map.iter())
-            .find_map(|entry| entry.ir_inst.map(|ir_inst| (entry.func, ir_inst)))
+            .find_map(|entry| Some((entry.unit.function()?, entry.attribution.ir_inst()?)))
             .expect("expected ir-backed pc-map entry");
-        let mut map = FrontendProvenanceMap::default();
-        map.insert(target, "mir_stmt:1".to_string());
-        enriched.apply_frontend_provenance(&map);
+        let target_bytes: u32 = enriched
+            .sections
+            .values()
+            .flat_map(|section| section.pc_map.iter())
+            .filter(|entry| {
+                entry.unit.function() == Some(target.0)
+                    && entry.attribution.ir_inst() == Some(target.1)
+            })
+            .map(|entry| entry.pc_end - entry.pc_start)
+            .sum();
+        assert!(target_bytes > 0);
+        let mapped_before = enriched.total_mapped_code_bytes;
+        let unmapped_before = enriched.total_unmapped_code_bytes;
+        let missing_before: u32 = enriched
+            .sections
+            .values()
+            .map(|section| section.unmapped_reason_coverage.missing_provenance)
+            .sum();
+        let mut map = PostOptProvenanceMap::default();
+        map.insert(target, "post-opt:mir_stmt:1".to_string());
+        enriched.apply_post_opt_provenance(&map);
+        assert_eq!(
+            enriched.total_mapped_code_bytes,
+            mapped_before + target_bytes
+        );
+        assert_eq!(
+            enriched.total_unmapped_code_bytes + target_bytes,
+            unmapped_before
+        );
+        let missing_after: u32 = enriched
+            .sections
+            .values()
+            .map(|section| section.unmapped_reason_coverage.missing_provenance)
+            .sum();
+        assert_eq!(missing_after + target_bytes, missing_before);
+        assert!(enriched.sections.values().all(|section| {
+            section.mapped_code_bytes + section.unmapped_code_bytes == section.code_bytes
+                && section.unmapped_reason_coverage.total_bytes() == section.unmapped_code_bytes
+        }));
         assert!(
             enriched
                 .to_json()
-                .contains("\"frontend_provenance\":\"mir_stmt:1\"")
+                .contains("\"post_opt_provenance\":\"post-opt:mir_stmt:1\"")
         );
+    }
+
+    #[test]
+    fn mandatory_evm_preparation_preserves_stamped_provenance() {
+        let parsed = parse_module(
+            r#"
+target = "evm-ethereum-osaka"
+
+global private const [i256; 2] $values = [11, 22];
+
+func public %runtime(v0.i256) -> i256 {
+    block0:
+        v1.constref<[i256; 2]> = const.ref $values;
+        v2.constref<i256> = const.index v1 v0;
+        v3.i256 = const.load v2;
+        return v3;
+}
+
+object @Contract {
+  section runtime {
+    entry %runtime;
+  }
+}
+"#,
+        )
+        .unwrap();
+        let func = parsed.module.funcs()[0];
+        parsed.module.func_store.modify(func, |function| {
+            let const_load = function
+                .layout
+                .iter_block()
+                .flat_map(|block| function.layout.iter_inst(block))
+                .find(|&inst| function.dfg.inst(inst).as_text() == "const.load")
+                .expect("fixture should contain const.load");
+            function.set_inst_provenance(const_load, "post-opt:const-load".to_string());
+        });
+
+        let artifact = compile_object(
+            &parsed.module,
+            &test_backend(),
+            "Contract",
+            &compile_opts(
+                PushWidthPolicy::Push4,
+                false,
+                true,
+                VerifierConfig::for_level(VerificationLevel::Standard),
+            ),
+        )
+        .unwrap();
+        let runtime = section(&artifact, "runtime");
+        let observability = runtime
+            .observability
+            .as_ref()
+            .expect("runtime observability");
+
+        assert!(observability.pc_map.iter().any(|entry| {
+            matches!(
+                &entry.attribution,
+                PcAttribution::Mapped { post_opt_provenance, .. }
+                    if post_opt_provenance == "post-opt:const-load"
+            )
+        }));
     }
 
     #[test]

--- a/crates/codegen/src/object/compile.rs
+++ b/crates/codegen/src/object/compile.rs
@@ -945,6 +945,76 @@ object @Contract {
     }
 
     #[test]
+    fn observability_json_uses_machine_inst_key() {
+        // Wire-shape guard: the attribution id serializes under "machine_inst",
+        // never the old "ir_inst" name, for both mapped and unmapped entries.
+        // This is the only test that fails if a writer silently renames the field.
+        let parsed = parse_module(
+            r#"
+target = "evm-ethereum-osaka"
+
+global private const [i256; 2] $values = [11, 22];
+
+func public %runtime(v0.i256) -> i256 {
+    block0:
+        v1.constref<[i256; 2]> = const.ref $values;
+        v2.constref<i256> = const.index v1 v0;
+        v3.i256 = const.load v2;
+        return v3;
+}
+
+object @Contract {
+  section runtime {
+    entry %runtime;
+  }
+}
+"#,
+        )
+        .unwrap();
+        let func = parsed.module.funcs()[0];
+        parsed.module.func_store.modify(func, |function| {
+            let const_load = function
+                .layout
+                .iter_block()
+                .flat_map(|block| function.layout.iter_inst(block))
+                .find(|&inst| function.dfg.inst(inst).as_text() == "const.load")
+                .expect("fixture should contain const.load");
+            function.set_inst_provenance(const_load, "post-opt:const-load".to_string());
+        });
+
+        let artifact = compile_object(
+            &parsed.module,
+            &test_backend(),
+            "Contract",
+            &compile_opts(
+                PushWidthPolicy::Push4,
+                false,
+                true,
+                VerifierConfig::for_level(VerificationLevel::Standard),
+            ),
+        )
+        .unwrap();
+        let json = section(&artifact, "runtime")
+            .observability
+            .as_ref()
+            .expect("runtime observability")
+            .to_json();
+
+        assert!(
+            !json.contains("\"ir_inst\""),
+            "attribution must not serialize the renamed ir_inst key: {json}"
+        );
+        assert!(
+            json.contains("\"status\":\"mapped\",\"machine_inst\":"),
+            "mapped entry must serialize machine_inst: {json}"
+        );
+        assert!(
+            json.contains("\"status\":\"unmapped\",\"machine_inst\":"),
+            "unmapped entry must serialize machine_inst: {json}"
+        );
+    }
+
+    #[test]
     fn compile_object_omits_observability_when_disabled() {
         let artifact = compile_fixture(
             r#"

--- a/crates/codegen/src/object/compile.rs
+++ b/crates/codegen/src/object/compile.rs
@@ -507,10 +507,7 @@ mod tests {
     use super::*;
     use crate::{
         isa::evm::{EvmBackend, PushWidthPolicy},
-        object::{
-            CompileOptions, OBSERVABILITY_SCHEMA_VERSION, PcAttribution, PostOptProvenanceMap,
-            artifact::SymbolId,
-        },
+        object::{CompileOptions, OBSERVABILITY_SCHEMA_VERSION, PcAttribution, artifact::SymbolId},
     };
     use sonatina_ir::{
         InstDowncastMut, Type, inst::arith::Add, ir_writer::ModuleWriter, isa::evm::Evm,
@@ -882,58 +879,6 @@ object @Contract {
         assert_eq!(
             runtime_obs.mapped_code_bytes + runtime_obs.unmapped_code_bytes,
             runtime_obs.code_bytes
-        );
-
-        let mut enriched = artifact.observability().expect("object observability");
-        let target = enriched
-            .sections
-            .values()
-            .flat_map(|section| section.pc_map.iter())
-            .find_map(|entry| Some((entry.unit.function()?, entry.attribution.ir_inst()?)))
-            .expect("expected ir-backed pc-map entry");
-        let target_bytes: u32 = enriched
-            .sections
-            .values()
-            .flat_map(|section| section.pc_map.iter())
-            .filter(|entry| {
-                entry.unit.function() == Some(target.0)
-                    && entry.attribution.ir_inst() == Some(target.1)
-            })
-            .map(|entry| entry.pc_end - entry.pc_start)
-            .sum();
-        assert!(target_bytes > 0);
-        let mapped_before = enriched.total_mapped_code_bytes;
-        let unmapped_before = enriched.total_unmapped_code_bytes;
-        let missing_before: u32 = enriched
-            .sections
-            .values()
-            .map(|section| section.unmapped_reason_coverage.missing_provenance)
-            .sum();
-        let mut map = PostOptProvenanceMap::default();
-        map.insert(target, "post-opt:mir_stmt:1".to_string());
-        enriched.apply_post_opt_provenance(&map);
-        assert_eq!(
-            enriched.total_mapped_code_bytes,
-            mapped_before + target_bytes
-        );
-        assert_eq!(
-            enriched.total_unmapped_code_bytes + target_bytes,
-            unmapped_before
-        );
-        let missing_after: u32 = enriched
-            .sections
-            .values()
-            .map(|section| section.unmapped_reason_coverage.missing_provenance)
-            .sum();
-        assert_eq!(missing_after + target_bytes, missing_before);
-        assert!(enriched.sections.values().all(|section| {
-            section.mapped_code_bytes + section.unmapped_code_bytes == section.code_bytes
-                && section.unmapped_reason_coverage.total_bytes() == section.unmapped_code_bytes
-        }));
-        assert!(
-            enriched
-                .to_json()
-                .contains("\"post_opt_provenance\":\"post-opt:mir_stmt:1\"")
         );
     }
 

--- a/crates/codegen/src/object/link.rs
+++ b/crates/codegen/src/object/link.rs
@@ -590,6 +590,11 @@ fn build_section_observability<Op>(
                 None
             };
 
+            let frontend_provenance = ir_inst.and_then(|iid| {
+                module.func_store.view(func, |function| {
+                    function.inst_provenance(iid).map(|s| s.to_string())
+                })
+            });
             pc_map.push(PcMapEntry {
                 pc_start,
                 pc_end,
@@ -598,13 +603,17 @@ fn build_section_observability<Op>(
                 block,
                 vcode_inst: insn,
                 ir_inst,
-                frontend_provenance: None,
+                frontend_provenance,
                 unmapped_reason,
             });
         }
     }
 
-    let synthetic_func_base = funcs
+    // Number synthetic units past every function of the MODULE, not just this
+    // section: a section-local base can collide with a real FuncRef that lives
+    // in another section, handing synthetic bytes a real function's identity.
+    let synthetic_func_base = module
+        .funcs()
         .iter()
         .map(|func| func.as_u32())
         .max()

--- a/crates/codegen/src/object/link.rs
+++ b/crates/codegen/src/object/link.rs
@@ -13,15 +13,15 @@ use sonatina_ir::{
     BlockId, GlobalVariableRef, Linkage, Module,
     inst::data::SymbolRef,
     module::FuncRef,
-    object::{EmbedSymbol, SectionName},
+    object::{EmbedSymbol, ObjectName, SectionName},
 };
 use tracing::{debug_span, info_span, trace_span};
 
 use super::{
     CompileOptions,
     artifact::{
-        OBSERVABILITY_SCHEMA_VERSION, PcMapEntry, SectionArtifact, SectionObservability, SymbolDef,
-        SymbolId, UnmappedReason, UnmappedReasonCoverage,
+        OBSERVABILITY_SCHEMA_VERSION, PcAttribution, PcMapEntry, PcMapUnit, SectionArtifact,
+        SectionObservability, SymbolDef, SymbolId, UnmappedReason, UnmappedReasonCoverage,
     },
 };
 
@@ -34,6 +34,7 @@ pub(crate) enum LinkSectionError {
 
 struct BuildSectionObservabilityInput<'a, Op> {
     module: &'a Module,
+    object: &'a ObjectName,
     layout: &'a ObjectLayout<Op>,
     funcs: &'a [FuncRef],
     symtab: &'a FxHashMap<SymbolId, SymbolDef>,
@@ -224,6 +225,7 @@ fn checked_u32(value: usize) -> Result<u32, String> {
 pub(crate) fn link_section(
     backend: &EvmBackend,
     prepared: &EvmPreparedSection,
+    object: &ObjectName,
     data: &[(GlobalVariableRef, Vec<u8>)],
     embeds: &[(EmbedSymbol, Vec<u8>)],
     section: &SectionName,
@@ -353,6 +355,7 @@ pub(crate) fn link_section(
                         debug_span!("sonatina.codegen.link_section.build_observability").entered();
                     build_section_observability(BuildSectionObservabilityInput {
                         module,
+                        object,
                         layout: &layout,
                         funcs: &layout_func_refs,
                         symtab: &symtab,
@@ -502,6 +505,7 @@ fn build_section_observability<Op>(
 ) -> Result<SectionObservability, String> {
     let BuildSectionObservabilityInput {
         module,
+        object,
         layout,
         funcs,
         symtab,
@@ -584,37 +588,40 @@ fn build_section_observability<Op>(
                     ));
                 }
             }
-            let unmapped_reason = if ir_inst.is_none() {
-                Some(classify_unmapped_reason(func_layout, insn, is_head))
-            } else {
-                None
+            let attribution = match ir_inst {
+                Some(ir_inst) => {
+                    let post_opt_provenance = module.func_store.view(func, |function| {
+                        function.inst_provenance(ir_inst).map(str::to_owned)
+                    });
+                    match post_opt_provenance {
+                        Some(post_opt_provenance) => PcAttribution::Mapped {
+                            ir_inst,
+                            post_opt_provenance,
+                        },
+                        None => PcAttribution::Unmapped {
+                            ir_inst: Some(ir_inst),
+                            reason: UnmappedReason::MissingProvenance,
+                        },
+                    }
+                }
+                None => PcAttribution::Unmapped {
+                    ir_inst: None,
+                    reason: classify_unmapped_reason(func_layout, insn, is_head),
+                },
             };
-
             pc_map.push(PcMapEntry {
                 pc_start,
                 pc_end,
-                func,
+                unit: PcMapUnit::Function(func),
                 func_name: func_name.clone(),
                 block,
                 vcode_inst: insn,
-                ir_inst,
-                frontend_provenance: None,
-                unmapped_reason,
+                attribution,
             });
         }
     }
 
-    let synthetic_func_base = funcs
-        .iter()
-        .map(|func| func.as_u32())
-        .max()
-        .map_or(0, |max| max.saturating_add(1));
-    for (idx, (unit_id, unit)) in layout.section_units().iter().enumerate() {
-        let func = FuncRef::from_u32(
-            synthetic_func_base
-                .checked_add(idx as u32)
-                .expect("synthetic observability func ref overflow"),
-        );
+    for (unit_id, unit) in layout.section_units().iter() {
         let func_name = unit.name().to_string();
         let layout = unit.layout();
         let func_end = layout.end();
@@ -642,25 +649,24 @@ fn build_section_observability<Op>(
             pc_map.push(PcMapEntry {
                 pc_start,
                 pc_end,
-                func,
+                unit: synthetic_pc_map_unit(object, section, *unit_id),
                 func_name: func_name.clone(),
                 block,
                 vcode_inst: insn,
-                ir_inst: None,
-                frontend_provenance: None,
-                unmapped_reason: Some(UnmappedReason::Synthetic),
+                attribution: PcAttribution::Unmapped {
+                    ir_inst: None,
+                    reason: UnmappedReason::Synthetic,
+                },
             });
         }
     }
 
-    pc_map.sort_by_key(|e| {
-        (
-            e.pc_start,
-            e.pc_end,
-            e.func.index(),
-            e.block.index(),
-            e.vcode_inst.index(),
-        )
+    pc_map.sort_by(|a, b| {
+        (a.pc_start, a.pc_end)
+            .cmp(&(b.pc_start, b.pc_end))
+            .then_with(|| a.unit.sort_key().cmp(&b.unit.sort_key()))
+            .then_with(|| a.block.index().cmp(&b.block.index()))
+            .then_with(|| a.vcode_inst.index().cmp(&b.vcode_inst.index()))
     });
 
     let mut mapped_code_bytes = 0_u32;
@@ -693,16 +699,18 @@ fn build_section_observability<Op>(
         }
 
         let span = entry.pc_end - entry.pc_start;
-        if entry.ir_inst.is_some() {
-            mapped_code_bytes = mapped_code_bytes
-                .checked_add(span)
-                .ok_or_else(|| "mapped code bytes overflow".to_string())?;
-        } else {
-            let reason = entry.unmapped_reason.unwrap_or(UnmappedReason::Unknown);
-            unmapped_code_bytes = unmapped_code_bytes
-                .checked_add(span)
-                .ok_or_else(|| "unmapped code bytes overflow".to_string())?;
-            unmapped_reason_coverage.add_bytes(reason, span);
+        match &entry.attribution {
+            PcAttribution::Mapped { .. } => {
+                mapped_code_bytes = mapped_code_bytes
+                    .checked_add(span)
+                    .ok_or_else(|| "mapped code bytes overflow".to_string())?;
+            }
+            PcAttribution::Unmapped { reason, .. } => {
+                unmapped_code_bytes = unmapped_code_bytes
+                    .checked_add(span)
+                    .ok_or_else(|| "unmapped code bytes overflow".to_string())?;
+                unmapped_reason_coverage.add_bytes(*reason, span);
+            }
         }
 
         cursor = cursor.max(entry.pc_end);
@@ -748,6 +756,18 @@ fn build_section_observability<Op>(
     })
 }
 
+fn synthetic_pc_map_unit(
+    object: &ObjectName,
+    section: &SectionName,
+    unit: crate::machinst::vcode::SectionCodeUnitId,
+) -> PcMapUnit {
+    PcMapUnit::Synthetic {
+        object: object.clone(),
+        section: section.clone(),
+        unit,
+    }
+}
+
 fn classify_unmapped_reason<Op>(
     func_layout: &crate::machinst::assemble::FuncLayout<Op>,
     insn: VCodeInst,
@@ -785,6 +805,30 @@ mod tests {
             vendor: Vendor::Ethereum,
             operating_system: OperatingSystem::Evm(EvmVersion::Osaka),
         }))
+    }
+
+    #[test]
+    fn synthetic_unit_identities_are_unique_across_objects_and_sections() {
+        let unit = SectionCodeUnitId(0);
+        let runtime_a = synthetic_pc_map_unit(
+            &sonatina_ir::object::ObjectName("A".into()),
+            &sonatina_ir::object::SectionName("runtime".into()),
+            unit,
+        );
+        let runtime_b = synthetic_pc_map_unit(
+            &sonatina_ir::object::ObjectName("B".into()),
+            &sonatina_ir::object::SectionName("runtime".into()),
+            unit,
+        );
+        let init_a = synthetic_pc_map_unit(
+            &sonatina_ir::object::ObjectName("A".into()),
+            &sonatina_ir::object::SectionName("init".into()),
+            unit,
+        );
+
+        assert_ne!(runtime_a, runtime_b);
+        assert_ne!(runtime_a, init_a);
+        assert_eq!(runtime_a.function(), None);
     }
 
     #[test]

--- a/crates/codegen/src/object/link.rs
+++ b/crates/codegen/src/object/link.rs
@@ -577,30 +577,30 @@ fn build_section_observability<Op>(
                 ));
             }
 
-            let ir_inst = func_layout.vcode().inst_ir[insn].expand();
-            if let Some(ir_inst) = ir_inst {
+            let machine_inst_id = func_layout.vcode().inst_ir[insn].expand();
+            if let Some(machine_inst_id) = machine_inst_id {
                 let valid = module
                     .func_store
-                    .view(func, |function| function.dfg.has_inst(ir_inst));
+                    .view(func, |function| function.dfg.has_inst(machine_inst_id));
                 if !valid {
                     return Err(format!(
-                        "invalid ir reference for func {:?}: vcode {:?} -> ir {:?}",
-                        func, insn, ir_inst
+                        "invalid machine-IR reference for func {:?}: vcode {:?} -> machine {:?}",
+                        func, insn, machine_inst_id
                     ));
                 }
             }
-            let attribution = match ir_inst {
-                Some(ir_inst) => {
+            let attribution = match machine_inst_id {
+                Some(machine_inst_id) => {
                     let post_opt_provenance = module.func_store.view(func, |function| {
-                        function.inst_provenance(ir_inst).map(str::to_owned)
+                        function.inst_provenance(machine_inst_id).map(str::to_owned)
                     });
                     match post_opt_provenance {
                         Some(post_opt_provenance) => PcAttribution::Mapped {
-                            machine_inst: MachineInstId(ir_inst),
+                            machine_inst: MachineInstId(machine_inst_id),
                             post_opt_provenance,
                         },
                         None => PcAttribution::Unmapped {
-                            machine_inst: Some(MachineInstId(ir_inst)),
+                            machine_inst: Some(MachineInstId(machine_inst_id)),
                             reason: UnmappedReason::MissingProvenance,
                         },
                     }

--- a/crates/codegen/src/object/link.rs
+++ b/crates/codegen/src/object/link.rs
@@ -20,8 +20,9 @@ use tracing::{debug_span, info_span, trace_span};
 use super::{
     CompileOptions,
     artifact::{
-        OBSERVABILITY_SCHEMA_VERSION, PcAttribution, PcMapEntry, PcMapUnit, SectionArtifact,
-        SectionObservability, SymbolDef, SymbolId, UnmappedReason, UnmappedReasonCoverage,
+        MachineInstId, OBSERVABILITY_SCHEMA_VERSION, PcAttribution, PcMapEntry, PcMapUnit,
+        SectionArtifact, SectionObservability, SymbolDef, SymbolId, UnmappedReason,
+        UnmappedReasonCoverage,
     },
 };
 
@@ -595,17 +596,17 @@ fn build_section_observability<Op>(
                     });
                     match post_opt_provenance {
                         Some(post_opt_provenance) => PcAttribution::Mapped {
-                            ir_inst,
+                            machine_inst: MachineInstId(ir_inst),
                             post_opt_provenance,
                         },
                         None => PcAttribution::Unmapped {
-                            ir_inst: Some(ir_inst),
+                            machine_inst: Some(MachineInstId(ir_inst)),
                             reason: UnmappedReason::MissingProvenance,
                         },
                     }
                 }
                 None => PcAttribution::Unmapped {
-                    ir_inst: None,
+                    machine_inst: None,
                     reason: classify_unmapped_reason(func_layout, insn, is_head),
                 },
             };
@@ -654,7 +655,7 @@ fn build_section_observability<Op>(
                 block,
                 vcode_inst: insn,
                 attribution: PcAttribution::Unmapped {
-                    ir_inst: None,
+                    machine_inst: None,
                     reason: UnmappedReason::Synthetic,
                 },
             });

--- a/crates/codegen/src/object/link.rs
+++ b/crates/codegen/src/object/link.rs
@@ -782,7 +782,7 @@ fn classify_unmapped_reason<Op>(
     } else if is_block_head {
         UnmappedReason::Synthetic
     } else {
-        UnmappedReason::NoIrInst
+        UnmappedReason::NoMachineInst
     }
 }
 

--- a/crates/codegen/src/object/mod.rs
+++ b/crates/codegen/src/object/mod.rs
@@ -8,8 +8,8 @@ pub mod resolve;
 use crate::isa::evm::PushWidthPolicy;
 pub use artifact::{
     OBSERVABILITY_SCHEMA_VERSION, ObjectArtifact, ObjectObservability, PcAttribution, PcMapEntry,
-    PcMapUnit, PostOptProvenanceMap, SectionArtifact, SectionObservability, SymbolDef, SymbolId,
-    UnmappedReason, UnmappedReasonCoverage,
+    PcMapUnit, SectionArtifact, SectionObservability, SymbolDef, SymbolId, UnmappedReason,
+    UnmappedReasonCoverage,
 };
 pub use compile::{compile_all_objects, compile_object};
 pub use data::encode_gv_initializer_to_bytes;

--- a/crates/codegen/src/object/mod.rs
+++ b/crates/codegen/src/object/mod.rs
@@ -7,9 +7,9 @@ pub mod resolve;
 
 use crate::isa::evm::PushWidthPolicy;
 pub use artifact::{
-    FrontendProvenanceMap, OBSERVABILITY_SCHEMA_VERSION, ObjectArtifact, ObjectObservability,
-    PcMapEntry, SectionArtifact, SectionObservability, SymbolDef, SymbolId, UnmappedReason,
-    UnmappedReasonCoverage,
+    OBSERVABILITY_SCHEMA_VERSION, ObjectArtifact, ObjectObservability, PcAttribution, PcMapEntry,
+    PcMapUnit, PostOptProvenanceMap, SectionArtifact, SectionObservability, SymbolDef, SymbolId,
+    UnmappedReason, UnmappedReasonCoverage,
 };
 pub use compile::{compile_all_objects, compile_object};
 pub use data::encode_gv_initializer_to_bytes;

--- a/crates/codegen/src/object/mod.rs
+++ b/crates/codegen/src/object/mod.rs
@@ -7,9 +7,9 @@ pub mod resolve;
 
 use crate::isa::evm::PushWidthPolicy;
 pub use artifact::{
-    OBSERVABILITY_SCHEMA_VERSION, ObjectArtifact, ObjectObservability, PcAttribution, PcMapEntry,
-    PcMapUnit, SectionArtifact, SectionObservability, SymbolDef, SymbolId, UnmappedReason,
-    UnmappedReasonCoverage,
+    MachineInstId, OBSERVABILITY_SCHEMA_VERSION, ObjectArtifact, ObjectObservability,
+    PcAttribution, PcMapEntry, PcMapUnit, SectionArtifact, SectionObservability, SymbolDef,
+    SymbolId, UnmappedReason, UnmappedReasonCoverage,
 };
 pub use compile::{compile_all_objects, compile_object};
 pub use data::encode_gv_initializer_to_bytes;

--- a/crates/codegen/src/optim/branch_canonicalize.rs
+++ b/crates/codegen/src/optim/branch_canonicalize.rs
@@ -90,13 +90,21 @@ impl BranchCanonicalize {
         let mut dead_cmp_inst = None;
         if let Some((cmp_inst, kind, lhs, rhs)) = compare_value(func, cond) {
             if let Some(zero_compare) =
-                zero_compare_branch_rewrite(func, term, kind, lhs, rhs, cond_ty)
+                zero_compare_branch_rewrite(func, term, cmp_inst, kind, lhs, rhs, cond_ty)
             {
                 cond = zero_compare.cond;
                 swap ^= zero_compare.swap;
                 dead_cmp_inst = Some(cmp_inst);
             } else if compare_cost(invert_compare(kind)) < compare_cost(kind) {
-                cond = insert_compare_before(func, term, invert_compare(kind), lhs, rhs, cond_ty);
+                cond = insert_compare_before(
+                    func,
+                    term,
+                    cmp_inst,
+                    invert_compare(kind),
+                    lhs,
+                    rhs,
+                    cond_ty,
+                );
                 swap = !swap;
                 dead_cmp_inst = Some(cmp_inst);
             }
@@ -202,6 +210,7 @@ fn compare_cost(kind: BinaryInstKind) -> u8 {
 fn zero_compare_branch_rewrite(
     func: &mut Function,
     term: InstId,
+    anchor: InstId,
     kind: BinaryInstKind,
     lhs: ValueId,
     rhs: ValueId,
@@ -245,7 +254,7 @@ fn zero_compare_branch_rewrite(
     };
 
     Some(ZeroComparePlan {
-        cond: insert_is_zero_before(func, term, arg, result_ty)?,
+        cond: insert_is_zero_before(func, term, anchor, arg, result_ty)?,
         swap,
     })
 }
@@ -265,6 +274,7 @@ fn i1_literal(func: &Function, value: ValueId) -> Option<bool> {
 fn insert_compare_before(
     func: &mut Function,
     before: InstId,
+    anchor: InstId,
     kind: BinaryInstKind,
     lhs: ValueId,
     rhs: ValueId,
@@ -291,12 +301,14 @@ fn insert_compare_before(
     });
     func.dfg.attach_result(inst, value);
     func.layout.insert_inst_before(inst, before);
+    func.propagate_inst_attribution(inst, anchor);
     value
 }
 
 fn insert_is_zero_before(
     func: &mut Function,
     before: InstId,
+    anchor: InstId,
     arg: ValueId,
     result_ty: Type,
 ) -> Option<ValueId> {
@@ -310,6 +322,7 @@ fn insert_is_zero_before(
     });
     func.dfg.attach_result(inst, value);
     func.layout.insert_inst_before(inst, before);
+    func.propagate_inst_attribution(inst, anchor);
     Some(value)
 }
 

--- a/crates/codegen/src/optim/checked_arith_elim.rs
+++ b/crates/codegen/src/optim/checked_arith_elim.rs
@@ -233,5 +233,6 @@ fn insert_plain_value(
     });
     func.dfg.attach_result(inst, value);
     func.layout.insert_inst_before(inst, before);
+    func.propagate_inst_attribution(inst, before);
     value
 }

--- a/crates/codegen/src/optim/constref_specialize.rs
+++ b/crates/codegen/src/optim/constref_specialize.rs
@@ -337,6 +337,7 @@ fn prepend_const_proj(
     });
     func.dfg.attach_result(inst, value);
     func.layout.insert_inst_after(inst, base.inst);
+    func.propagate_inst_attribution(inst, base.inst);
     (PrependedValue { inst, value }, field_ty)
 }
 
@@ -367,6 +368,7 @@ fn prepend_const_index(
     });
     func.dfg.attach_result(inst, value);
     func.layout.insert_inst_after(inst, base.inst);
+    func.propagate_inst_attribution(inst, base.inst);
     (PrependedValue { inst, value }, elem)
 }
 

--- a/crates/codegen/src/optim/inliner/full.rs
+++ b/crates/codegen/src/optim/inliner/full.rs
@@ -180,6 +180,9 @@ pub(super) fn try_inline_callsite_full(
 
             let (new_inst, new_results) =
                 editor.append_inst_with_results(new_block, cloned, result_tys.as_slice());
+            editor
+                .func_mut()
+                .import_inst_attribution_from(callee, old_inst, new_inst);
             inserted_insts += 1;
 
             assert_eq!(
@@ -217,7 +220,10 @@ pub(super) fn try_inline_callsite_full(
                 .unwrap_or_default();
 
             let jump = editor.func_mut().dfg.make_jump(cont_block);
-            editor.append_inst_with_result(new_block, Box::new(jump), None);
+            let (new_jump, _) = editor.append_inst_with_result(new_block, Box::new(jump), None);
+            editor
+                .func_mut()
+                .import_inst_attribution_from(callee, term_id, new_jump);
             inserted_insts += 1;
 
             returns.push(ReturnSite {
@@ -233,7 +239,10 @@ pub(super) fn try_inline_callsite_full(
                     .rewrite_inst_operands(term.as_mut(), false)
                     .expect("validated callee should be rewriteable");
             }
-            editor.append_inst_with_result(new_block, term, None);
+            let (new_term, _) = editor.append_inst_with_result(new_block, term, None);
+            editor
+                .func_mut()
+                .import_inst_attribution_from(callee, term_id, new_term);
             inserted_insts += 1;
         }
     }
@@ -297,6 +306,10 @@ pub(super) fn try_inline_callsite_full(
 
                     let phi = func.dfg.make_phi(args);
                     let phi_inst = func.dfg.make_inst(phi);
+                    // The return-merge phi carries the call's result; it
+                    // inherits the call instruction's attribution like every
+                    // other transplanted instruction.
+                    func.propagate_inst_attribution(phi_inst, call_inst);
                     func.layout.prepend_inst(phi_inst, cont_block);
 
                     let phi_value = func.dfg.make_value(Value::Inst {

--- a/crates/codegen/src/optim/inliner/trivial.rs
+++ b/crates/codegen/src/optim/inliner/trivial.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use sonatina_ir::{
-    Function, GlobalVariableRef, Immediate, Inst, InstDowncast, InstId, Module, Type, Value,
-    ValueId, inst::control_flow, module::FuncRef,
+    Function, GlobalVariableRef, Immediate, Inst, InstAttribution, InstDowncast, InstId, Module,
+    Type, Value, ValueId, inst::control_flow, module::FuncRef,
 };
 
 use crate::{
@@ -44,6 +44,7 @@ pub(super) enum InlinePlan {
 }
 
 struct TemplateInst {
+    attribution: InstAttribution,
     inst: Box<dyn Inst>,
     old_results: InstResultTemplates,
 }
@@ -65,6 +66,7 @@ struct TerminatorSplicePlan {
     callee_args: Vec<ValueId>,
     const_values: BTreeMap<ValueId, ValueTemplate>,
     body: Vec<TemplateInst>,
+    terminator_attribution: InstAttribution,
     terminator: Box<dyn Inst>,
 }
 
@@ -377,6 +379,7 @@ pub(super) fn materialize_plan(callee: &Function, summary: &InlinePlanSummary) -
                 callee_args: summary.callee_args.clone(),
                 const_values: summary.const_values.clone(),
                 body: materialize_body_templates(callee, &summary.body),
+                terminator_attribution: callee.inst_attribution(summary.term_inst_id),
                 terminator: callee.dfg.clone_inst(summary.term_inst_id),
             })
         }
@@ -389,6 +392,7 @@ fn materialize_body_templates(
 ) -> Vec<TemplateInst> {
     body.iter()
         .map(|summary| TemplateInst {
+            attribution: callee.inst_attribution(summary.inst_id),
             inst: callee.dfg.clone_inst(summary.inst_id),
             old_results: summary.old_results.clone(),
         })
@@ -508,25 +512,30 @@ fn apply_splice_single_block(
         return false;
     }
 
-    apply_splice_body(splice_plan.body, &mut value_map, |new_inst, result_tys| {
-        let new_inst_id = caller.dfg.make_inst_dyn(new_inst);
-        caller.layout.insert_inst_before(new_inst_id, call_inst_id);
-        let new_results: SmallVec<[ValueId; 2]> = result_tys
-            .iter()
-            .enumerate()
-            .map(|(result_idx, ty)| {
-                caller.dfg.make_value(Value::Inst {
-                    inst: new_inst_id,
-                    result_idx: result_idx.try_into().expect("too many instruction results"),
-                    ty: *ty,
+    apply_splice_body(
+        splice_plan.body,
+        &mut value_map,
+        |attribution, new_inst, result_tys| {
+            let new_inst_id = caller.dfg.make_inst_dyn(new_inst);
+            caller.layout.insert_inst_before(new_inst_id, call_inst_id);
+            let new_results: SmallVec<[ValueId; 2]> = result_tys
+                .iter()
+                .enumerate()
+                .map(|(result_idx, ty)| {
+                    caller.dfg.make_value(Value::Inst {
+                        inst: new_inst_id,
+                        result_idx: result_idx.try_into().expect("too many instruction results"),
+                        ty: *ty,
+                    })
                 })
-            })
-            .collect();
-        caller
-            .dfg
-            .attach_results(new_inst_id, new_results.as_slice());
-        new_results
-    });
+                .collect();
+            caller
+                .dfg
+                .attach_results(new_inst_id, new_results.as_slice());
+            caller.apply_inst_attribution(new_inst_id, attribution);
+            new_results
+        },
+    );
 
     for (&old_ret, &call_res) in splice_plan.ret_values.iter().zip(call_results.iter()) {
         let new_ret = *value_map
@@ -585,14 +594,25 @@ fn apply_splice_single_block_terminator(
 
     let mut editor = CfgEditor::new(caller, CleanupMode::Strict);
     let call_block = editor.truncate_block_from_inst(call_inst_id);
-    apply_splice_body(splice_plan.body, &mut value_map, |new_inst, result_tys| {
-        let (_, new_results) = editor.append_inst_with_results(call_block, new_inst, result_tys);
-        new_results
-    });
+    apply_splice_body(
+        splice_plan.body,
+        &mut value_map,
+        |attribution, new_inst, result_tys| {
+            let (new_inst_id, new_results) =
+                editor.append_inst_with_results(call_block, new_inst, result_tys);
+            editor
+                .func_mut()
+                .apply_inst_attribution(new_inst_id, attribution);
+            new_results
+        },
+    );
 
     let mut new_term = splice_plan.terminator;
     rewrite_inst_values_checked(new_term.as_mut(), &value_map);
-    editor.append_inst_with_results(call_block, new_term, &[]);
+    let (new_term_id, _) = editor.append_inst_with_results(call_block, new_term, &[]);
+    editor
+        .func_mut()
+        .apply_inst_attribution(new_term_id, &splice_plan.terminator_attribution);
     editor.recompute_cfg();
 
     stats.calls_spliced += 1;
@@ -622,7 +642,7 @@ fn build_splice_value_map(
 fn apply_splice_body(
     body: Vec<TemplateInst>,
     value_map: &mut FxHashMap<ValueId, ValueId>,
-    mut insert: impl FnMut(Box<dyn Inst>, &[Type]) -> SmallVec<[ValueId; 2]>,
+    mut insert: impl FnMut(&InstAttribution, Box<dyn Inst>, &[Type]) -> SmallVec<[ValueId; 2]>,
 ) {
     for template_inst in body {
         let mut new_inst = template_inst.inst;
@@ -632,7 +652,7 @@ fn apply_splice_body(
             .iter()
             .map(|(_, ty)| *ty)
             .collect();
-        let inserted_results = insert(new_inst, result_tys.as_slice());
+        let inserted_results = insert(&template_inst.attribution, new_inst, result_tys.as_slice());
         assert_eq!(
             inserted_results.len(),
             template_inst.old_results.len(),
@@ -785,4 +805,85 @@ fn rewrite_inst_values(inst: &mut dyn Inst, value_map: &FxHashMap<ValueId, Value
         }
     });
     all_mapped
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use smallvec::smallvec;
+    use sonatina_ir::{
+        Linkage, Signature, Type, builder::test_util::test_module_builder,
+        func_cursor::InstInserter, inst::arith::Add,
+    };
+
+    use super::*;
+    use crate::optim::inliner::Inliner;
+
+    #[test]
+    fn single_block_splice_preserves_frontend_origin() {
+        let mb = test_module_builder();
+        let callee_ref = mb
+            .declare_function(Signature::new_single(
+                "callee",
+                Linkage::Private,
+                &[],
+                Type::I32,
+            ))
+            .unwrap();
+        let caller_ref = mb
+            .declare_function(Signature::new_single(
+                "caller",
+                Linkage::Public,
+                &[],
+                Type::I32,
+            ))
+            .unwrap();
+
+        {
+            let mut callee = mb.func_builder::<InstInserter>(callee_ref);
+            let block = callee.append_block();
+            callee.switch_to_block(block);
+            let lhs = callee.make_imm_value(1i32);
+            let rhs = callee.make_imm_value(2i32);
+            let has_add = callee.inst_set().has_add().unwrap();
+            let result = callee.insert_inst(Add::new(has_add, lhs, rhs), Type::I32);
+            let add_inst = callee.func.dfg.value_inst(result).unwrap();
+            callee
+                .func
+                .set_inst_frontend_origin(add_inst, Arc::from("callee-origin://add"));
+            callee.insert_return(result);
+            callee.seal_all();
+            callee.finish();
+        }
+
+        {
+            let mut caller = mb.func_builder::<InstInserter>(caller_ref);
+            let block = caller.append_block();
+            caller.switch_to_block(block);
+            let result = caller.insert_call(callee_ref, smallvec![]).unwrap();
+            caller.insert_return(result);
+            caller.seal_all();
+            caller.finish();
+        }
+
+        let mut module = mb.build();
+        let mut inliner = Inliner::new(InlinerConfig::default());
+        let stats = inliner.run(&mut module);
+        assert_eq!(stats.calls_spliced, 1);
+
+        module.func_store.view(caller_ref, |caller| {
+            let inlined_add = caller
+                .layout
+                .iter_block()
+                .flat_map(|block| caller.layout.iter_inst(block))
+                .find(|&inst| caller.dfg.inst(inst).as_text() == "add")
+                .expect("callee add should be spliced into caller");
+
+            assert_eq!(
+                caller.inst_frontend_origin(inlined_add),
+                Some("callee-origin://add")
+            );
+        });
+    }
 }

--- a/crates/codegen/src/optim/multi_result_legalize.rs
+++ b/crates/codegen/src/optim/multi_result_legalize.rs
@@ -44,6 +44,7 @@ pub fn legalize_multi_result(func: &mut Function) -> bool {
                 .dfg
                 .make_inst(Add::new(is.has_add().unwrap(), lhs, rhs));
             func.layout.insert_inst_before(add_inst, inst);
+            func.propagate_inst_attribution(add_inst, inst);
             let add_result = func.dfg.make_value(Value::Inst {
                 inst: add_inst,
                 result_idx: 0,
@@ -55,6 +56,7 @@ pub fn legalize_multi_result(func: &mut Function) -> bool {
                 .dfg
                 .make_inst(Lt::new(is.has_lt().unwrap(), add_result, lhs));
             func.layout.insert_inst_before(lt_inst, inst);
+            func.propagate_inst_attribution(lt_inst, inst);
             let lt_result = func.dfg.make_value(Value::Inst {
                 inst: lt_inst,
                 result_idx: 0,

--- a/crates/codegen/src/transform/aggregate/abi.rs
+++ b/crates/codegen/src/transform/aggregate/abi.rs
@@ -290,8 +290,9 @@ impl AggregateExpandAbi {
             CursorLocation::At,
         );
         let mut cursor = InstInserter::at_location(loc);
-        let new_call = cursor.insert_inst_data(
+        let new_call = cursor.insert_inst_data_from(
             func,
+            inst,
             control_flow::Call::new(
                 func.inst_set()
                     .has_call()
@@ -497,8 +498,9 @@ fn insert_value_before_inst(
         CursorLocation::At,
     );
     let mut cursor = InstInserter::at_location(loc);
-    let insert_inst = cursor.insert_inst_data(
+    let insert_inst = cursor.insert_inst_data_from(
         func,
+        inst,
         data::InsertValue::new_unchecked(func.inst_set(), dest, idx_value, value),
     );
     let insert_value = func.dfg.make_value(Value::Inst {

--- a/crates/codegen/src/transform/aggregate/byval_object_abi.rs
+++ b/crates/codegen/src/transform/aggregate/byval_object_abi.rs
@@ -851,8 +851,9 @@ impl ObjectAggregateAbi {
                             total_leaves,
                         },
                     ) {
-                        cursor.insert_inst_data(
+                        cursor.insert_inst_data_from(
                             function,
+                            inst,
                             data::ObjStore::new_unchecked(function.inst_set(), out_arg, value),
                         );
                     }
@@ -1118,8 +1119,9 @@ impl ObjectAggregateAbi {
         for (&out_ty, &lowering) in plan.hidden_out_tys.iter().zip(&ret_lowerings) {
             match lowering {
                 RetLowering::Temp => {
-                    let alloc_inst = pre_call.insert_inst_data(
+                    let alloc_inst = pre_call.insert_inst_data_from(
                         function,
+                        inst,
                         data::ObjAlloc::new_unchecked(
                             function.inst_set(),
                             objref_element_ty(function.ctx(), out_ty)
@@ -1154,8 +1156,9 @@ impl ObjectAggregateAbi {
                             new_args.push(cached_copy);
                             continue;
                         }
-                        let alloc_inst = pre_call.insert_inst_data(
+                        let alloc_inst = pre_call.insert_inst_data_from(
                             function,
+                            inst,
                             data::ObjAlloc::new_unchecked(
                                 function.inst_set(),
                                 arg_plan.original_ty,
@@ -1164,8 +1167,9 @@ impl ObjectAggregateAbi {
                         let object = pre_call.make_result(function, alloc_inst, arg_plan.new_ty);
                         pre_call.attach_result(function, alloc_inst, object);
                         pre_call.set_location(CursorLocation::At(alloc_inst));
-                        let store_inst = pre_call.insert_inst_data(
+                        let store_inst = pre_call.insert_inst_data_from(
                             function,
+                            inst,
                             data::ObjStore::new_unchecked(function.inst_set(), object, arg),
                         );
                         pre_call.set_location(CursorLocation::At(store_inst));
@@ -1180,8 +1184,9 @@ impl ObjectAggregateAbi {
             }
         }
 
-        let new_call = pre_call.insert_inst_data(
+        let new_call = pre_call.insert_inst_data_from(
             function,
+            inst,
             control_flow::Call::new(
                 function
                     .inst_set()
@@ -1243,8 +1248,9 @@ impl ObjectAggregateAbi {
                         };
                         continue;
                     }
-                    let load_inst = post_call.insert_inst_data(
+                    let load_inst = post_call.insert_inst_data_from(
                         function,
+                        inst,
                         data::ObjLoad::new_unchecked(function.inst_set(), out_root),
                     );
                     let loaded = post_call.make_result(function, load_inst, ret_plan.original_ty);

--- a/crates/codegen/src/transform/aggregate/enum_lowering.rs
+++ b/crates/codegen/src/transform/aggregate/enum_lowering.rs
@@ -648,7 +648,7 @@ fn insert_result_inst(
     ty: Type,
 ) -> ValueId {
     let mut cursor = InstInserter::at_location(inst_insert_loc(function, before));
-    let inst = cursor.insert_inst_data_dyn(function, data);
+    let inst = cursor.insert_inst_data_dyn_from(function, before, data);
     let value = cursor.make_result(function, inst, ty);
     cursor.attach_result(function, inst, value);
     value
@@ -660,7 +660,7 @@ fn insert_no_result_inst(
     data: Box<dyn sonatina_ir::Inst>,
 ) {
     let mut cursor = InstInserter::at_location(inst_insert_loc(function, before));
-    let _ = cursor.insert_inst_data_dyn(function, data);
+    let _ = cursor.insert_inst_data_dyn_from(function, before, data);
 }
 
 fn inst_insert_loc(function: &Function, inst: sonatina_ir::InstId) -> CursorLocation {

--- a/crates/codegen/src/transform/aggregate/legalize.rs
+++ b/crates/codegen/src/transform/aggregate/legalize.rs
@@ -1924,6 +1924,7 @@ fn runtime_leaves_from_leaf_slice(leaves: &[shape::AggregateLeaf]) -> shape::Run
 
 struct BeforeCursor {
     cursor: InstInserter,
+    source: InstId,
 }
 
 impl BeforeCursor {
@@ -1936,11 +1937,14 @@ impl BeforeCursor {
         };
         Self {
             cursor: InstInserter::at_location(loc),
+            source: inst,
         }
     }
 
     fn insert_no_result<I: Inst>(&mut self, func: &mut Function, inst_data: I) -> InstId {
-        let inst = self.cursor.insert_inst_data(func, inst_data);
+        let inst = self
+            .cursor
+            .insert_inst_data_from(func, self.source, inst_data);
         self.cursor.set_location(CursorLocation::At(inst));
         inst
     }

--- a/crates/codegen/src/transform/aggregate/object.rs
+++ b/crates/codegen/src/transform/aggregate/object.rs
@@ -473,6 +473,7 @@ fn zext_before(func: &mut Function, before: InstId, value: ValueId, ty: Type) ->
     let inst = func
         .dfg
         .make_inst(cast::Zext::new_unchecked(func.inst_set(), value, ty));
+    func.propagate_inst_attribution(inst, before);
     func.layout.insert_inst_before(inst, before);
     let result = func.dfg.make_value(Value::Inst {
         inst,

--- a/crates/codegen/src/transform/aggregate/object_abi.rs
+++ b/crates/codegen/src/transform/aggregate/object_abi.rs
@@ -652,8 +652,9 @@ impl ObjectReturnOutParam {
             (function.arg_values[0], original_loc)
         } else {
             let mut cursor = InstInserter::at_location(original_loc);
-            let out_alloc = cursor.insert_inst_data(
+            let out_alloc = cursor.insert_inst_data_from(
                 function,
+                inst,
                 data::ObjAlloc::new_unchecked(function.inst_set(), callee_plan.out_elem_ty),
             );
             let out_arg = cursor.make_result(function, out_alloc, callee_plan.out_ty);
@@ -665,8 +666,9 @@ impl ObjectReturnOutParam {
         let new_args = std::iter::once(out_arg)
             .chain(call.args().iter().copied())
             .collect();
-        let new_call = cursor.insert_inst_data(
+        let new_call = cursor.insert_inst_data_from(
             function,
+            inst,
             control_flow::Call::new(
                 function
                     .inst_set()

--- a/crates/codegen/src/transform/aggregate/reconstruct.rs
+++ b/crates/codegen/src/transform/aggregate/reconstruct.rs
@@ -317,8 +317,9 @@ pub(crate) fn bitcast_before_inst(
         CursorLocation::At,
     );
     let mut cursor = InstInserter::at_location(loc);
-    let bitcast_inst = cursor.insert_inst_data(
+    let bitcast_inst = cursor.insert_inst_data_from(
         func,
+        inst,
         cast::Bitcast::new_unchecked(func.inst_set(), value, to_ty),
     );
     let cast_value = func.dfg.make_value(Value::Inst {
@@ -524,8 +525,9 @@ fn extract_value_before_inst(
         CursorLocation::At,
     );
     let mut cursor = InstInserter::at_location(loc);
-    let extract_inst = cursor.insert_inst_data(
+    let extract_inst = cursor.insert_inst_data_from(
         func,
+        inst,
         data::ExtractValue::new_unchecked(func.inst_set(), aggregate, idx_value),
     );
     let extract_value = func.dfg.make_value(Value::Inst {
@@ -543,8 +545,11 @@ fn enum_tag_before_inst(func: &mut Function, inst: InstId, value: ValueId, ty: T
         CursorLocation::At,
     );
     let mut cursor = InstInserter::at_location(loc);
-    let enum_tag_inst =
-        cursor.insert_inst_data(func, data::EnumTag::new_unchecked(func.inst_set(), value));
+    let enum_tag_inst = cursor.insert_inst_data_from(
+        func,
+        inst,
+        data::EnumTag::new_unchecked(func.inst_set(), value),
+    );
     let enum_tag_value = func.dfg.make_value(Value::Inst {
         inst: enum_tag_inst,
         result_idx: 0,
@@ -566,8 +571,9 @@ fn insert_enum_make_before_inst(
         CursorLocation::At,
     );
     let mut cursor = InstInserter::at_location(loc);
-    let enum_make_inst = cursor.insert_inst_data(
+    let enum_make_inst = cursor.insert_inst_data_from(
         func,
+        inst,
         data::EnumMake::new_unchecked(func.inst_set(), ty, variant, values),
     );
     let enum_make_value = func.dfg.make_value(Value::Inst {
@@ -595,8 +601,9 @@ fn insert_value_before_inst(
         CursorLocation::At,
     );
     let mut cursor = InstInserter::at_location(loc);
-    let insert_inst = cursor.insert_inst_data(
+    let insert_inst = cursor.insert_inst_data_from(
         func,
+        inst,
         data::InsertValue::new_unchecked(func.inst_set(), dest, idx_value, value),
     );
     let insert_value = func.dfg.make_value(Value::Inst {

--- a/crates/codegen/src/transform/evm/const_data.rs
+++ b/crates/codegen/src/transform/evm/const_data.rs
@@ -1324,6 +1324,7 @@ fn insert_before_results<I: sonatina_ir::Inst>(
     result_tys: &[Type],
 ) -> SmallVec<[ValueId; 2]> {
     let inst = func.dfg.make_inst(data);
+    func.propagate_inst_attribution(inst, before);
     func.layout.insert_inst_before(inst, before);
     result_tys
         .iter()
@@ -1355,6 +1356,7 @@ pub(super) fn insert_before_no_result<I: sonatina_ir::Inst>(
     data: I,
 ) {
     let inst = func.dfg.make_inst(data);
+    func.propagate_inst_attribution(inst, before);
     func.layout.insert_inst_before(inst, before);
 }
 

--- a/crates/codegen/src/transform/evm/const_data/tests.rs
+++ b/crates/codegen/src/transform/evm/const_data/tests.rs
@@ -824,7 +824,7 @@ func private %entry() -> i256 {
     let blob_bytes = lowered_blob_bytes(&parsed, "value");
     assert_eq!(blob_bytes.len(), 32 * 5);
 
-    let words: Vec<_> = blob_bytes.chunks_exact(32).collect();
+    let words: Vec<_> = blob_bytes.as_chunks::<32>().0.iter().collect();
     assert!(words[0][..31].iter().all(|&byte| byte == 0));
     assert_eq!(words[0][31], 1);
 

--- a/crates/codegen/src/transform/evm/legalize.rs
+++ b/crates/codegen/src/transform/evm/legalize.rs
@@ -569,6 +569,7 @@ impl<'a> FunctionLegalizer<'a> {
         widths: &[Option<ScalarWidth>],
     ) -> SmallVec<[ValueId; 2]> {
         let inst = self.func.dfg.make_inst(data);
+        self.func.propagate_inst_attribution(inst, before);
         self.func.layout.insert_inst_before(inst, before);
         let mut results = SmallVec::new();
         for (idx, &ty) in result_tys.iter().enumerate() {

--- a/crates/codegen/test_files/evm/const_array_dynamic_affine_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_affine_load.snap
@@ -18,32 +18,32 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=24 code=24 data=0 embed=0 mapped=23 unmapped=1
+object schema=0.3.0
+totals section_bytes=24 code=24 data=0 embed=0 mapped=0 unmapped=24
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=24 code=24 data=0 embed=0
-coverage mapped=23 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_affine block=0 vcode=6 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_affine block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_affine block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 21) func=load_affine block=0 vcode=2 ir=1 reason=- frontend=-
-pc [21, 22) func=load_affine block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 23) func=load_affine block=0 vcode=4 ir=2 reason=- frontend=-
-pc [23, 24) func=load_affine block=0 vcode=5 ir=2 reason=- frontend=-
+coverage mapped=0 unmapped=24
+unmapped missing_provenance=23 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_affine block=0 vcode=6 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_affine block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_affine block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_affine block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_affine block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_affine block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_affine block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21200 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=60

--- a/crates/codegen/test_files/evm/const_array_dynamic_affine_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_affine_load.snap
@@ -24,26 +24,26 @@ totals section_bytes=24 code=24 data=0 embed=0 mapped=0 unmapped=24
 section runtime schema=0.3.0
 bytes total=24 code=24 data=0 embed=0
 coverage mapped=0 unmapped=24
-unmapped missing_provenance=23 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_affine block=0 vcode=6 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_affine block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_affine block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 21) func=load_affine block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_affine block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_affine block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [23, 24) func=load_affine block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
+unmapped missing_provenance=23 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_affine block=0 vcode=6 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_affine block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_affine block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_affine block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_affine block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_affine block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_affine block=0 vcode=5 machine=2 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21200 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=60

--- a/crates/codegen/test_files/evm/const_array_dynamic_dense_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_dense_load.snap
@@ -24,33 +24,33 @@ totals section_bytes=192 code=32 data=160 embed=0 mapped=0 unmapped=32
 section runtime schema=0.3.0
 bytes total=192 code=32 data=160 embed=0
 coverage mapped=0 unmapped=32
-unmapped missing_provenance=31 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_dense block=0 vcode=13 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_dense block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_dense block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
-pc [19, 21) func=load_dense block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_dense block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_dense block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [23, 25) func=load_dense block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
-pc [25, 26) func=load_dense block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
-pc [26, 27) func=load_dense block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [27, 28) func=load_dense block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [28, 29) func=load_dense block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [29, 30) func=load_dense block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [30, 31) func=load_dense block=0 vcode=11 ir=5 reason=missing_provenance post_opt=-
-pc [31, 32) func=load_dense block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
+unmapped missing_provenance=31 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_dense block=0 vcode=13 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_dense block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_dense block=0 vcode=1 machine=1 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_dense block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_dense block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_dense block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [23, 25) func=load_dense block=0 vcode=5 machine=3 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_dense block=0 vcode=6 machine=3 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_dense block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [27, 28) func=load_dense block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [28, 29) func=load_dense block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_dense block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_dense block=0 vcode=11 machine=5 reason=missing_provenance post_opt=-
+pc [31, 32) func=load_dense block=0 vcode=12 machine=5 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21222 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=82

--- a/crates/codegen/test_files/evm/const_array_dynamic_dense_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_dense_load.snap
@@ -18,39 +18,39 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=192 code=32 data=160 embed=0 mapped=31 unmapped=1
+object schema=0.3.0
+totals section_bytes=192 code=32 data=160 embed=0 mapped=0 unmapped=32
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=192 code=32 data=160 embed=0
-coverage mapped=31 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_dense block=0 vcode=13 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_dense block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_dense block=0 vcode=1 ir=1 reason=- frontend=-
-pc [19, 21) func=load_dense block=0 vcode=2 ir=1 reason=- frontend=-
-pc [21, 22) func=load_dense block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 23) func=load_dense block=0 vcode=4 ir=2 reason=- frontend=-
-pc [23, 25) func=load_dense block=0 vcode=5 ir=3 reason=- frontend=-
-pc [25, 26) func=load_dense block=0 vcode=6 ir=3 reason=- frontend=-
-pc [26, 27) func=load_dense block=0 vcode=7 ir=3 reason=- frontend=-
-pc [27, 28) func=load_dense block=0 vcode=8 ir=3 reason=- frontend=-
-pc [28, 29) func=load_dense block=0 vcode=9 ir=4 reason=- frontend=-
-pc [29, 30) func=load_dense block=0 vcode=10 ir=4 reason=- frontend=-
-pc [30, 31) func=load_dense block=0 vcode=11 ir=5 reason=- frontend=-
-pc [31, 32) func=load_dense block=0 vcode=12 ir=5 reason=- frontend=-
+coverage mapped=0 unmapped=32
+unmapped missing_provenance=31 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_dense block=0 vcode=13 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_dense block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_dense block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_dense block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_dense block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_dense block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [23, 25) func=load_dense block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_dense block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_dense block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [27, 28) func=load_dense block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [28, 29) func=load_dense block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_dense block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_dense block=0 vcode=11 ir=5 reason=missing_provenance post_opt=-
+pc [31, 32) func=load_dense block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21222 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=82

--- a/crates/codegen/test_files/evm/const_array_dynamic_i16_packed_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_i16_packed_load.snap
@@ -18,37 +18,37 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=38 code=38 data=0 embed=0 mapped=37 unmapped=1
+object schema=0.3.0
+totals section_bytes=38 code=38 data=0 embed=0 mapped=0 unmapped=38
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=38 code=38 data=0 embed=0
-coverage mapped=37 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=- frontend=-
-pc [15, 16) func=load_half block=0 vcode=11 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_half block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_half block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 21) func=load_half block=0 vcode=2 ir=1 reason=- frontend=-
-pc [21, 22) func=load_half block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 30) func=load_half block=0 vcode=4 ir=2 reason=- frontend=-
-pc [30, 31) func=load_half block=0 vcode=5 ir=2 reason=- frontend=-
-pc [31, 32) func=load_half block=0 vcode=6 ir=2 reason=- frontend=-
-pc [32, 35) func=load_half block=0 vcode=7 ir=3 reason=- frontend=-
-pc [35, 36) func=load_half block=0 vcode=8 ir=3 reason=- frontend=-
-pc [36, 37) func=load_half block=0 vcode=9 ir=4 reason=- frontend=-
-pc [37, 38) func=load_half block=0 vcode=10 ir=4 reason=- frontend=-
+coverage mapped=0 unmapped=38
+unmapped missing_provenance=37 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_half block=0 vcode=11 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_half block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_half block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_half block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_half block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 30) func=load_half block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_half block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
+pc [31, 32) func=load_half block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [32, 35) func=load_half block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [35, 36) func=load_half block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [36, 37) func=load_half block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [37, 38) func=load_half block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21215 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=75

--- a/crates/codegen/test_files/evm/const_array_dynamic_i16_packed_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_i16_packed_load.snap
@@ -24,31 +24,31 @@ totals section_bytes=38 code=38 data=0 embed=0 mapped=0 unmapped=38
 section runtime schema=0.3.0
 bytes total=38 code=38 data=0 embed=0
 coverage mapped=0 unmapped=38
-unmapped missing_provenance=37 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_half block=0 vcode=11 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_half block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_half block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 21) func=load_half block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_half block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 30) func=load_half block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [30, 31) func=load_half block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
-pc [31, 32) func=load_half block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [32, 35) func=load_half block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [35, 36) func=load_half block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [36, 37) func=load_half block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [37, 38) func=load_half block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+unmapped missing_provenance=37 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=4 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_half block=0 vcode=11 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_half block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_half block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_half block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_half block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 30) func=load_half block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_half block=0 vcode=5 machine=2 reason=missing_provenance post_opt=-
+pc [31, 32) func=load_half block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [32, 35) func=load_half block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [35, 36) func=load_half block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [36, 37) func=load_half block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [37, 38) func=load_half block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21215 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=75

--- a/crates/codegen/test_files/evm/const_array_dynamic_i1_bitset_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_i1_bitset_load.snap
@@ -18,35 +18,35 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=27 code=27 data=0 embed=0 mapped=26 unmapped=1
+object schema=0.3.0
+totals section_bytes=27 code=27 data=0 embed=0 mapped=0 unmapped=27
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=27 code=27 data=0 embed=0
-coverage mapped=26 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_bit block=0 vcode=9 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_bit block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_bit block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 20) func=load_bit block=0 vcode=2 ir=0 reason=- frontend=-
-pc [20, 22) func=load_bit block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 23) func=load_bit block=0 vcode=4 ir=1 reason=- frontend=-
-pc [23, 24) func=load_bit block=0 vcode=5 ir=2 reason=- frontend=-
-pc [24, 25) func=load_bit block=0 vcode=6 ir=3 reason=- frontend=-
-pc [25, 26) func=load_bit block=0 vcode=7 ir=4 reason=- frontend=-
-pc [26, 27) func=load_bit block=0 vcode=8 ir=4 reason=- frontend=-
+coverage mapped=0 unmapped=27
+unmapped missing_provenance=26 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_bit block=0 vcode=9 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_bit block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_bit block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_bit block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [20, 22) func=load_bit block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_bit block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_bit block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
+pc [24, 25) func=load_bit block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_bit block=0 vcode=7 ir=4 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_bit block=0 vcode=8 ir=4 reason=missing_provenance post_opt=-
 
 evm:
   case index_3: calldata_len=32 success reason=Return gas_used=21209 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=69

--- a/crates/codegen/test_files/evm/const_array_dynamic_i1_bitset_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_i1_bitset_load.snap
@@ -24,29 +24,29 @@ totals section_bytes=27 code=27 data=0 embed=0 mapped=0 unmapped=27
 section runtime schema=0.3.0
 bytes total=27 code=27 data=0 embed=0
 coverage mapped=0 unmapped=27
-unmapped missing_provenance=26 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_bit block=0 vcode=9 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_bit block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_bit block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 20) func=load_bit block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [20, 22) func=load_bit block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_bit block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [23, 24) func=load_bit block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
-pc [24, 25) func=load_bit block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
-pc [25, 26) func=load_bit block=0 vcode=7 ir=4 reason=missing_provenance post_opt=-
-pc [26, 27) func=load_bit block=0 vcode=8 ir=4 reason=missing_provenance post_opt=-
+unmapped missing_provenance=26 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_bit block=0 vcode=9 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_bit block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_bit block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_bit block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [20, 22) func=load_bit block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_bit block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_bit block=0 vcode=5 machine=2 reason=missing_provenance post_opt=-
+pc [24, 25) func=load_bit block=0 vcode=6 machine=3 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_bit block=0 vcode=7 machine=4 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_bit block=0 vcode=8 machine=4 reason=missing_provenance post_opt=-
 
 evm:
   case index_3: calldata_len=32 success reason=Return gas_used=21209 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=69

--- a/crates/codegen/test_files/evm/const_array_dynamic_i64_packed_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_i64_packed_load.snap
@@ -24,34 +24,34 @@ totals section_bytes=58 code=58 data=0 embed=0 mapped=0 unmapped=58
 section runtime schema=0.3.0
 bytes total=58 code=58 data=0 embed=0
 coverage mapped=0 unmapped=58
-unmapped missing_provenance=57 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_word block=0 vcode=14 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_word block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_word block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 21) func=load_word block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_word block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 48) func=load_word block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [48, 49) func=load_word block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
-pc [49, 50) func=load_word block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [50, 51) func=load_word block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [51, 52) func=load_word block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [52, 54) func=load_word block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [54, 55) func=load_word block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [55, 56) func=load_word block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [56, 57) func=load_word block=0 vcode=12 ir=4 reason=missing_provenance post_opt=-
-pc [57, 58) func=load_word block=0 vcode=13 ir=4 reason=missing_provenance post_opt=-
+unmapped missing_provenance=57 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=4 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_word block=0 vcode=14 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_word block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_word block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_word block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_word block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 48) func=load_word block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [48, 49) func=load_word block=0 vcode=5 machine=2 reason=missing_provenance post_opt=-
+pc [49, 50) func=load_word block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [50, 51) func=load_word block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [51, 52) func=load_word block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [52, 54) func=load_word block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [54, 55) func=load_word block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [55, 56) func=load_word block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [56, 57) func=load_word block=0 vcode=12 machine=4 reason=missing_provenance post_opt=-
+pc [57, 58) func=load_word block=0 vcode=13 machine=4 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21223 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=83

--- a/crates/codegen/test_files/evm/const_array_dynamic_i64_packed_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_i64_packed_load.snap
@@ -18,40 +18,40 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=58 code=58 data=0 embed=0 mapped=57 unmapped=1
+object schema=0.3.0
+totals section_bytes=58 code=58 data=0 embed=0 mapped=0 unmapped=58
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=58 code=58 data=0 embed=0
-coverage mapped=57 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=- frontend=-
-pc [15, 16) func=load_word block=0 vcode=14 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_word block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_word block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 21) func=load_word block=0 vcode=2 ir=1 reason=- frontend=-
-pc [21, 22) func=load_word block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 48) func=load_word block=0 vcode=4 ir=2 reason=- frontend=-
-pc [48, 49) func=load_word block=0 vcode=5 ir=2 reason=- frontend=-
-pc [49, 50) func=load_word block=0 vcode=6 ir=2 reason=- frontend=-
-pc [50, 51) func=load_word block=0 vcode=7 ir=3 reason=- frontend=-
-pc [51, 52) func=load_word block=0 vcode=8 ir=3 reason=- frontend=-
-pc [52, 54) func=load_word block=0 vcode=9 ir=3 reason=- frontend=-
-pc [54, 55) func=load_word block=0 vcode=10 ir=3 reason=- frontend=-
-pc [55, 56) func=load_word block=0 vcode=11 ir=3 reason=- frontend=-
-pc [56, 57) func=load_word block=0 vcode=12 ir=4 reason=- frontend=-
-pc [57, 58) func=load_word block=0 vcode=13 ir=4 reason=- frontend=-
+coverage mapped=0 unmapped=58
+unmapped missing_provenance=57 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_word block=0 vcode=14 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_word block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_word block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_word block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_word block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 48) func=load_word block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [48, 49) func=load_word block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
+pc [49, 50) func=load_word block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [50, 51) func=load_word block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [51, 52) func=load_word block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [52, 54) func=load_word block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [54, 55) func=load_word block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [55, 56) func=load_word block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [56, 57) func=load_word block=0 vcode=12 ir=4 reason=missing_provenance post_opt=-
+pc [57, 58) func=load_word block=0 vcode=13 ir=4 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21223 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=83

--- a/crates/codegen/test_files/evm/const_array_dynamic_i8_packed_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_i8_packed_load.snap
@@ -18,35 +18,35 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=31 code=31 data=0 embed=0 mapped=30 unmapped=1
+object schema=0.3.0
+totals section_bytes=31 code=31 data=0 embed=0 mapped=0 unmapped=31
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=31 code=31 data=0 embed=0
-coverage mapped=30 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=- frontend=-
-pc [15, 16) func=load_byte block=0 vcode=9 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_byte block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_byte block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 24) func=load_byte block=0 vcode=2 ir=1 reason=- frontend=-
-pc [24, 25) func=load_byte block=0 vcode=3 ir=1 reason=- frontend=-
-pc [25, 26) func=load_byte block=0 vcode=4 ir=1 reason=- frontend=-
-pc [26, 28) func=load_byte block=0 vcode=5 ir=2 reason=- frontend=-
-pc [28, 29) func=load_byte block=0 vcode=6 ir=2 reason=- frontend=-
-pc [29, 30) func=load_byte block=0 vcode=7 ir=3 reason=- frontend=-
-pc [30, 31) func=load_byte block=0 vcode=8 ir=3 reason=- frontend=-
+coverage mapped=0 unmapped=31
+unmapped missing_provenance=30 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_byte block=0 vcode=9 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_byte block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_byte block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 24) func=load_byte block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [24, 25) func=load_byte block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_byte block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [26, 28) func=load_byte block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
+pc [28, 29) func=load_byte block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_byte block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_byte block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21209 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=69

--- a/crates/codegen/test_files/evm/const_array_dynamic_i8_packed_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_i8_packed_load.snap
@@ -24,29 +24,29 @@ totals section_bytes=31 code=31 data=0 embed=0 mapped=0 unmapped=31
 section runtime schema=0.3.0
 bytes total=31 code=31 data=0 embed=0
 coverage mapped=0 unmapped=31
-unmapped missing_provenance=30 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_byte block=0 vcode=9 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_byte block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_byte block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 24) func=load_byte block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [24, 25) func=load_byte block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [25, 26) func=load_byte block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [26, 28) func=load_byte block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
-pc [28, 29) func=load_byte block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [29, 30) func=load_byte block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [30, 31) func=load_byte block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+unmapped missing_provenance=30 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=4 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_byte block=0 vcode=9 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_byte block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_byte block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 24) func=load_byte block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [24, 25) func=load_byte block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_byte block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [26, 28) func=load_byte block=0 vcode=5 machine=2 reason=missing_provenance post_opt=-
+pc [28, 29) func=load_byte block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_byte block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_byte block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21209 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=69

--- a/crates/codegen/test_files/evm/const_array_dynamic_load_duplicates_data.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_load_duplicates_data.snap
@@ -18,39 +18,39 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=192 code=32 data=160 embed=0 mapped=31 unmapped=1
+object schema=0.3.0
+totals section_bytes=192 code=32 data=160 embed=0 mapped=0 unmapped=32
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=192 code=32 data=160 embed=0
-coverage mapped=31 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_value block=0 vcode=13 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_value block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_value block=0 vcode=1 ir=1 reason=- frontend=-
-pc [19, 21) func=load_value block=0 vcode=2 ir=1 reason=- frontend=-
-pc [21, 22) func=load_value block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 23) func=load_value block=0 vcode=4 ir=2 reason=- frontend=-
-pc [23, 25) func=load_value block=0 vcode=5 ir=3 reason=- frontend=-
-pc [25, 26) func=load_value block=0 vcode=6 ir=3 reason=- frontend=-
-pc [26, 27) func=load_value block=0 vcode=7 ir=3 reason=- frontend=-
-pc [27, 28) func=load_value block=0 vcode=8 ir=3 reason=- frontend=-
-pc [28, 29) func=load_value block=0 vcode=9 ir=4 reason=- frontend=-
-pc [29, 30) func=load_value block=0 vcode=10 ir=4 reason=- frontend=-
-pc [30, 31) func=load_value block=0 vcode=11 ir=5 reason=- frontend=-
-pc [31, 32) func=load_value block=0 vcode=12 ir=5 reason=- frontend=-
+coverage mapped=0 unmapped=32
+unmapped missing_provenance=31 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_value block=0 vcode=13 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_value block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_value block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_value block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_value block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_value block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [23, 25) func=load_value block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_value block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_value block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [27, 28) func=load_value block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [28, 29) func=load_value block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_value block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_value block=0 vcode=11 ir=5 reason=missing_provenance post_opt=-
+pc [31, 32) func=load_value block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21222 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=82

--- a/crates/codegen/test_files/evm/const_array_dynamic_load_duplicates_data.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_load_duplicates_data.snap
@@ -24,33 +24,33 @@ totals section_bytes=192 code=32 data=160 embed=0 mapped=0 unmapped=32
 section runtime schema=0.3.0
 bytes total=192 code=32 data=160 embed=0
 coverage mapped=0 unmapped=32
-unmapped missing_provenance=31 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_value block=0 vcode=13 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_value block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_value block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
-pc [19, 21) func=load_value block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_value block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_value block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [23, 25) func=load_value block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
-pc [25, 26) func=load_value block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
-pc [26, 27) func=load_value block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [27, 28) func=load_value block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [28, 29) func=load_value block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [29, 30) func=load_value block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [30, 31) func=load_value block=0 vcode=11 ir=5 reason=missing_provenance post_opt=-
-pc [31, 32) func=load_value block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
+unmapped missing_provenance=31 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_value block=0 vcode=13 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_value block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_value block=0 vcode=1 machine=1 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_value block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_value block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_value block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [23, 25) func=load_value block=0 vcode=5 machine=3 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_value block=0 vcode=6 machine=3 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_value block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [27, 28) func=load_value block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [28, 29) func=load_value block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_value block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_value block=0 vcode=11 machine=5 reason=missing_provenance post_opt=-
+pc [31, 32) func=load_value block=0 vcode=12 machine=5 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21222 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=82

--- a/crates/codegen/test_files/evm/const_array_dynamic_periodic_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_periodic_load.snap
@@ -24,38 +24,38 @@ totals section_bytes=40 code=40 data=0 embed=0 mapped=0 unmapped=40
 section runtime schema=0.3.0
 bytes total=40 code=40 data=0 embed=0
 coverage mapped=0 unmapped=40
-unmapped missing_provenance=39 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_periodic block=0 vcode=18 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_periodic block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_periodic block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 20) func=load_periodic block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [20, 22) func=load_periodic block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_periodic block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [23, 24) func=load_periodic block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [24, 26) func=load_periodic block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [26, 27) func=load_periodic block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [27, 29) func=load_periodic block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [29, 30) func=load_periodic block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [30, 31) func=load_periodic block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [31, 33) func=load_periodic block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
-pc [33, 34) func=load_periodic block=0 vcode=12 ir=4 reason=missing_provenance post_opt=-
-pc [34, 36) func=load_periodic block=0 vcode=13 ir=5 reason=missing_provenance post_opt=-
-pc [36, 37) func=load_periodic block=0 vcode=14 ir=5 reason=missing_provenance post_opt=-
-pc [37, 38) func=load_periodic block=0 vcode=15 ir=6 reason=missing_provenance post_opt=-
-pc [38, 39) func=load_periodic block=0 vcode=16 ir=7 reason=missing_provenance post_opt=-
-pc [39, 40) func=load_periodic block=0 vcode=17 ir=7 reason=missing_provenance post_opt=-
+unmapped missing_provenance=39 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_periodic block=0 vcode=18 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_periodic block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_periodic block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_periodic block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [20, 22) func=load_periodic block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_periodic block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_periodic block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [24, 26) func=load_periodic block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_periodic block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [27, 29) func=load_periodic block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_periodic block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_periodic block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [31, 33) func=load_periodic block=0 vcode=11 machine=4 reason=missing_provenance post_opt=-
+pc [33, 34) func=load_periodic block=0 vcode=12 machine=4 reason=missing_provenance post_opt=-
+pc [34, 36) func=load_periodic block=0 vcode=13 machine=5 reason=missing_provenance post_opt=-
+pc [36, 37) func=load_periodic block=0 vcode=14 machine=5 reason=missing_provenance post_opt=-
+pc [37, 38) func=load_periodic block=0 vcode=15 machine=6 reason=missing_provenance post_opt=-
+pc [38, 39) func=load_periodic block=0 vcode=16 machine=7 reason=missing_provenance post_opt=-
+pc [39, 40) func=load_periodic block=0 vcode=17 machine=7 reason=missing_provenance post_opt=-
 
 evm:
   case index_4: calldata_len=32 success reason=Return gas_used=21238 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=98

--- a/crates/codegen/test_files/evm/const_array_dynamic_periodic_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_periodic_load.snap
@@ -18,44 +18,44 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=40 code=40 data=0 embed=0 mapped=39 unmapped=1
+object schema=0.3.0
+totals section_bytes=40 code=40 data=0 embed=0 mapped=0 unmapped=40
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=40 code=40 data=0 embed=0
-coverage mapped=39 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_periodic block=0 vcode=18 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_periodic block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_periodic block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 20) func=load_periodic block=0 vcode=2 ir=0 reason=- frontend=-
-pc [20, 22) func=load_periodic block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 23) func=load_periodic block=0 vcode=4 ir=1 reason=- frontend=-
-pc [23, 24) func=load_periodic block=0 vcode=5 ir=1 reason=- frontend=-
-pc [24, 26) func=load_periodic block=0 vcode=6 ir=2 reason=- frontend=-
-pc [26, 27) func=load_periodic block=0 vcode=7 ir=2 reason=- frontend=-
-pc [27, 29) func=load_periodic block=0 vcode=8 ir=3 reason=- frontend=-
-pc [29, 30) func=load_periodic block=0 vcode=9 ir=3 reason=- frontend=-
-pc [30, 31) func=load_periodic block=0 vcode=10 ir=4 reason=- frontend=-
-pc [31, 33) func=load_periodic block=0 vcode=11 ir=4 reason=- frontend=-
-pc [33, 34) func=load_periodic block=0 vcode=12 ir=4 reason=- frontend=-
-pc [34, 36) func=load_periodic block=0 vcode=13 ir=5 reason=- frontend=-
-pc [36, 37) func=load_periodic block=0 vcode=14 ir=5 reason=- frontend=-
-pc [37, 38) func=load_periodic block=0 vcode=15 ir=6 reason=- frontend=-
-pc [38, 39) func=load_periodic block=0 vcode=16 ir=7 reason=- frontend=-
-pc [39, 40) func=load_periodic block=0 vcode=17 ir=7 reason=- frontend=-
+coverage mapped=0 unmapped=40
+unmapped missing_provenance=39 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_periodic block=0 vcode=18 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_periodic block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_periodic block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_periodic block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [20, 22) func=load_periodic block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_periodic block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_periodic block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [24, 26) func=load_periodic block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_periodic block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [27, 29) func=load_periodic block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_periodic block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_periodic block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [31, 33) func=load_periodic block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
+pc [33, 34) func=load_periodic block=0 vcode=12 ir=4 reason=missing_provenance post_opt=-
+pc [34, 36) func=load_periodic block=0 vcode=13 ir=5 reason=missing_provenance post_opt=-
+pc [36, 37) func=load_periodic block=0 vcode=14 ir=5 reason=missing_provenance post_opt=-
+pc [37, 38) func=load_periodic block=0 vcode=15 ir=6 reason=missing_provenance post_opt=-
+pc [38, 39) func=load_periodic block=0 vcode=16 ir=7 reason=missing_provenance post_opt=-
+pc [39, 40) func=load_periodic block=0 vcode=17 ir=7 reason=missing_provenance post_opt=-
 
 evm:
   case index_4: calldata_len=32 success reason=Return gas_used=21238 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=98

--- a/crates/codegen/test_files/evm/const_array_dynamic_power2_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_power2_load.snap
@@ -18,31 +18,31 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=22 code=22 data=0 embed=0 mapped=21 unmapped=1
+object schema=0.3.0
+totals section_bytes=22 code=22 data=0 embed=0 mapped=0 unmapped=22
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=22 code=22 data=0 embed=0
-coverage mapped=21 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_power block=0 vcode=5 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_power block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_power block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 20) func=load_power block=0 vcode=2 ir=0 reason=- frontend=-
-pc [20, 21) func=load_power block=0 vcode=3 ir=1 reason=- frontend=-
-pc [21, 22) func=load_power block=0 vcode=4 ir=1 reason=- frontend=-
+coverage mapped=0 unmapped=22
+unmapped missing_provenance=21 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_power block=0 vcode=5 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_power block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_power block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_power block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [20, 21) func=load_power block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_power block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
 
 evm:
   case index_3: calldata_len=32 success reason=Return gas_used=21197 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=57

--- a/crates/codegen/test_files/evm/const_array_dynamic_power2_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_power2_load.snap
@@ -24,25 +24,25 @@ totals section_bytes=22 code=22 data=0 embed=0 mapped=0 unmapped=22
 section runtime schema=0.3.0
 bytes total=22 code=22 data=0 embed=0
 coverage mapped=0 unmapped=22
-unmapped missing_provenance=21 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_power block=0 vcode=5 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_power block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_power block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 20) func=load_power block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [20, 21) func=load_power block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_power block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+unmapped missing_provenance=21 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_power block=0 vcode=5 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_power block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_power block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_power block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [20, 21) func=load_power block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_power block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
 
 evm:
   case index_3: calldata_len=32 success reason=Return gas_used=21197 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=57

--- a/crates/codegen/test_files/evm/const_array_dynamic_small_inline_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_small_inline_load.snap
@@ -18,41 +18,41 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=36 code=36 data=0 embed=0 mapped=35 unmapped=1
+object schema=0.3.0
+totals section_bytes=36 code=36 data=0 embed=0 mapped=0 unmapped=36
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=36 code=36 data=0 embed=0
-coverage mapped=35 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_small block=0 vcode=15 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_small block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_small block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 20) func=load_small block=0 vcode=2 ir=0 reason=- frontend=-
-pc [20, 22) func=load_small block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 23) func=load_small block=0 vcode=4 ir=1 reason=- frontend=-
-pc [23, 25) func=load_small block=0 vcode=5 ir=2 reason=- frontend=-
-pc [25, 26) func=load_small block=0 vcode=6 ir=2 reason=- frontend=-
-pc [26, 27) func=load_small block=0 vcode=7 ir=3 reason=- frontend=-
-pc [27, 29) func=load_small block=0 vcode=8 ir=3 reason=- frontend=-
-pc [29, 30) func=load_small block=0 vcode=9 ir=3 reason=- frontend=-
-pc [30, 32) func=load_small block=0 vcode=10 ir=4 reason=- frontend=-
-pc [32, 33) func=load_small block=0 vcode=11 ir=4 reason=- frontend=-
-pc [33, 34) func=load_small block=0 vcode=12 ir=5 reason=- frontend=-
-pc [34, 35) func=load_small block=0 vcode=13 ir=6 reason=- frontend=-
-pc [35, 36) func=load_small block=0 vcode=14 ir=6 reason=- frontend=-
+coverage mapped=0 unmapped=36
+unmapped missing_provenance=35 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_small block=0 vcode=15 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_small block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_small block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_small block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [20, 22) func=load_small block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_small block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [23, 25) func=load_small block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_small block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_small block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [27, 29) func=load_small block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_small block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [30, 32) func=load_small block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [32, 33) func=load_small block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
+pc [33, 34) func=load_small block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
+pc [34, 35) func=load_small block=0 vcode=13 ir=6 reason=missing_provenance post_opt=-
+pc [35, 36) func=load_small block=0 vcode=14 ir=6 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21227 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=87

--- a/crates/codegen/test_files/evm/const_array_dynamic_small_inline_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_small_inline_load.snap
@@ -24,35 +24,35 @@ totals section_bytes=36 code=36 data=0 embed=0 mapped=0 unmapped=36
 section runtime schema=0.3.0
 bytes total=36 code=36 data=0 embed=0
 coverage mapped=0 unmapped=36
-unmapped missing_provenance=35 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_small block=0 vcode=15 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_small block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_small block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 20) func=load_small block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [20, 22) func=load_small block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_small block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [23, 25) func=load_small block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
-pc [25, 26) func=load_small block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [26, 27) func=load_small block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [27, 29) func=load_small block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [29, 30) func=load_small block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [30, 32) func=load_small block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [32, 33) func=load_small block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
-pc [33, 34) func=load_small block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
-pc [34, 35) func=load_small block=0 vcode=13 ir=6 reason=missing_provenance post_opt=-
-pc [35, 36) func=load_small block=0 vcode=14 ir=6 reason=missing_provenance post_opt=-
+unmapped missing_provenance=35 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_small block=0 vcode=15 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_small block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_small block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_small block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [20, 22) func=load_small block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_small block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [23, 25) func=load_small block=0 vcode=5 machine=2 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_small block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_small block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [27, 29) func=load_small block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_small block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [30, 32) func=load_small block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [32, 33) func=load_small block=0 vcode=11 machine=4 reason=missing_provenance post_opt=-
+pc [33, 34) func=load_small block=0 vcode=12 machine=5 reason=missing_provenance post_opt=-
+pc [34, 35) func=load_small block=0 vcode=13 machine=6 reason=missing_provenance post_opt=-
+pc [35, 36) func=load_small block=0 vcode=14 machine=6 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21227 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=87

--- a/crates/codegen/test_files/evm/const_array_dynamic_sparse_exception_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_sparse_exception_load.snap
@@ -24,26 +24,26 @@ totals section_bytes=24 code=24 data=0 embed=0 mapped=0 unmapped=24
 section runtime schema=0.3.0
 bytes total=24 code=24 data=0 embed=0
 coverage mapped=0 unmapped=24
-unmapped missing_provenance=23 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_sparse block=0 vcode=6 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_sparse block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_sparse block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 21) func=load_sparse block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_sparse block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_sparse block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [23, 24) func=load_sparse block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
+unmapped missing_provenance=23 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_sparse block=0 vcode=6 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_sparse block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_sparse block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_sparse block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_sparse block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_sparse block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_sparse block=0 vcode=5 machine=2 reason=missing_provenance post_opt=-
 
 evm:
   case exception: calldata_len=32 success reason=Return gas_used=21202 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=62

--- a/crates/codegen/test_files/evm/const_array_dynamic_sparse_exception_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_sparse_exception_load.snap
@@ -18,32 +18,32 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=24 code=24 data=0 embed=0 mapped=23 unmapped=1
+object schema=0.3.0
+totals section_bytes=24 code=24 data=0 embed=0 mapped=0 unmapped=24
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=24 code=24 data=0 embed=0
-coverage mapped=23 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_sparse block=0 vcode=6 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_sparse block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_sparse block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 21) func=load_sparse block=0 vcode=2 ir=1 reason=- frontend=-
-pc [21, 22) func=load_sparse block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 23) func=load_sparse block=0 vcode=4 ir=2 reason=- frontend=-
-pc [23, 24) func=load_sparse block=0 vcode=5 ir=2 reason=- frontend=-
+coverage mapped=0 unmapped=24
+unmapped missing_provenance=23 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_sparse block=0 vcode=6 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_sparse block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_sparse block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_sparse block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_sparse block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_sparse block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_sparse block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
 
 evm:
   case exception: calldata_len=32 success reason=Return gas_used=21202 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=62

--- a/crates/codegen/test_files/evm/const_array_dynamic_splat_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_splat_load.snap
@@ -18,30 +18,30 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=21 code=21 data=0 embed=0 mapped=20 unmapped=1
+object schema=0.3.0
+totals section_bytes=21 code=21 data=0 embed=0 mapped=0 unmapped=21
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=21 code=21 data=0 embed=0
-coverage mapped=20 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_seven block=0 vcode=4 ir=- reason=synthetic frontend=-
-pc [16, 17) func=load_seven block=0 vcode=0 ir=0 reason=- frontend=-
-pc [17, 19) func=load_seven block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 20) func=load_seven block=0 vcode=2 ir=0 reason=- frontend=-
-pc [20, 21) func=load_seven block=0 vcode=3 ir=0 reason=- frontend=-
+coverage mapped=0 unmapped=21
+unmapped missing_provenance=20 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_seven block=0 vcode=4 ir=- reason=synthetic post_opt=-
+pc [16, 17) func=load_seven block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [17, 19) func=load_seven block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_seven block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [20, 21) func=load_seven block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21193 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=53

--- a/crates/codegen/test_files/evm/const_array_dynamic_splat_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_splat_load.snap
@@ -24,24 +24,24 @@ totals section_bytes=21 code=21 data=0 embed=0 mapped=0 unmapped=21
 section runtime schema=0.3.0
 bytes total=21 code=21 data=0 embed=0
 coverage mapped=0 unmapped=21
-unmapped missing_provenance=20 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_seven block=0 vcode=4 ir=- reason=synthetic post_opt=-
-pc [16, 17) func=load_seven block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [17, 19) func=load_seven block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 20) func=load_seven block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [20, 21) func=load_seven block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
+unmapped missing_provenance=20 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_seven block=0 vcode=4 machine=- reason=synthetic post_opt=-
+pc [16, 17) func=load_seven block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [17, 19) func=load_seven block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_seven block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [20, 21) func=load_seven block=0 vcode=3 machine=0 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21193 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=53

--- a/crates/codegen/test_files/evm/const_array_dynamic_subpath_dense_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_subpath_dense_load.snap
@@ -24,33 +24,33 @@ totals section_bytes=192 code=32 data=160 embed=0 mapped=0 unmapped=32
 section runtime schema=0.3.0
 bytes total=192 code=32 data=160 embed=0
 coverage mapped=0 unmapped=32
-unmapped missing_provenance=31 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_dense_subpath block=0 vcode=13 ir=- reason=synthetic post_opt=-
-pc [16, 18) func=load_dense_subpath block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_dense_subpath block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
-pc [19, 21) func=load_dense_subpath block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_dense_subpath block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_dense_subpath block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [23, 25) func=load_dense_subpath block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
-pc [25, 26) func=load_dense_subpath block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
-pc [26, 27) func=load_dense_subpath block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [27, 28) func=load_dense_subpath block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [28, 29) func=load_dense_subpath block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [29, 30) func=load_dense_subpath block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [30, 31) func=load_dense_subpath block=0 vcode=11 ir=5 reason=missing_provenance post_opt=-
-pc [31, 32) func=load_dense_subpath block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
+unmapped missing_provenance=31 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_dense_subpath block=0 vcode=13 machine=- reason=synthetic post_opt=-
+pc [16, 18) func=load_dense_subpath block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_dense_subpath block=0 vcode=1 machine=1 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_dense_subpath block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_dense_subpath block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_dense_subpath block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [23, 25) func=load_dense_subpath block=0 vcode=5 machine=3 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_dense_subpath block=0 vcode=6 machine=3 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_dense_subpath block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [27, 28) func=load_dense_subpath block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [28, 29) func=load_dense_subpath block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_dense_subpath block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_dense_subpath block=0 vcode=11 machine=5 reason=missing_provenance post_opt=-
+pc [31, 32) func=load_dense_subpath block=0 vcode=12 machine=5 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21222 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=82

--- a/crates/codegen/test_files/evm/const_array_dynamic_subpath_dense_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_subpath_dense_load.snap
@@ -18,39 +18,39 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=192 code=32 data=160 embed=0 mapped=31 unmapped=1
+object schema=0.3.0
+totals section_bytes=192 code=32 data=160 embed=0 mapped=0 unmapped=32
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=192 code=32 data=160 embed=0
-coverage mapped=31 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_dense_subpath block=0 vcode=13 ir=- reason=synthetic frontend=-
-pc [16, 18) func=load_dense_subpath block=0 vcode=0 ir=0 reason=- frontend=-
-pc [18, 19) func=load_dense_subpath block=0 vcode=1 ir=1 reason=- frontend=-
-pc [19, 21) func=load_dense_subpath block=0 vcode=2 ir=1 reason=- frontend=-
-pc [21, 22) func=load_dense_subpath block=0 vcode=3 ir=1 reason=- frontend=-
-pc [22, 23) func=load_dense_subpath block=0 vcode=4 ir=2 reason=- frontend=-
-pc [23, 25) func=load_dense_subpath block=0 vcode=5 ir=3 reason=- frontend=-
-pc [25, 26) func=load_dense_subpath block=0 vcode=6 ir=3 reason=- frontend=-
-pc [26, 27) func=load_dense_subpath block=0 vcode=7 ir=3 reason=- frontend=-
-pc [27, 28) func=load_dense_subpath block=0 vcode=8 ir=3 reason=- frontend=-
-pc [28, 29) func=load_dense_subpath block=0 vcode=9 ir=4 reason=- frontend=-
-pc [29, 30) func=load_dense_subpath block=0 vcode=10 ir=4 reason=- frontend=-
-pc [30, 31) func=load_dense_subpath block=0 vcode=11 ir=5 reason=- frontend=-
-pc [31, 32) func=load_dense_subpath block=0 vcode=12 ir=5 reason=- frontend=-
+coverage mapped=0 unmapped=32
+unmapped missing_provenance=31 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_dense_subpath block=0 vcode=13 ir=- reason=synthetic post_opt=-
+pc [16, 18) func=load_dense_subpath block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_dense_subpath block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_dense_subpath block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_dense_subpath block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_dense_subpath block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [23, 25) func=load_dense_subpath block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_dense_subpath block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_dense_subpath block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [27, 28) func=load_dense_subpath block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [28, 29) func=load_dense_subpath block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_dense_subpath block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [30, 31) func=load_dense_subpath block=0 vcode=11 ir=5 reason=missing_provenance post_opt=-
+pc [31, 32) func=load_dense_subpath block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21222 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=82

--- a/crates/codegen/test_files/evm/const_array_dynamic_zero_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_zero_load.snap
@@ -18,30 +18,30 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=20 code=20 data=0 embed=0 mapped=19 unmapped=1
+object schema=0.3.0
+totals section_bytes=20 code=20 data=0 embed=0 mapped=0 unmapped=20
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=20 code=20 data=0 embed=0
-coverage mapped=19 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load_zero block=0 vcode=4 ir=- reason=synthetic frontend=-
-pc [16, 17) func=load_zero block=0 vcode=0 ir=0 reason=- frontend=-
-pc [17, 18) func=load_zero block=0 vcode=1 ir=0 reason=- frontend=-
-pc [18, 19) func=load_zero block=0 vcode=2 ir=0 reason=- frontend=-
-pc [19, 20) func=load_zero block=0 vcode=3 ir=0 reason=- frontend=-
+coverage mapped=0 unmapped=20
+unmapped missing_provenance=19 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_zero block=0 vcode=4 ir=- reason=synthetic post_opt=-
+pc [16, 17) func=load_zero block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [17, 18) func=load_zero block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_zero block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_zero block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
 
 evm:
   case index_3: calldata_len=32 success reason=Return gas_used=21192 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=52

--- a/crates/codegen/test_files/evm/const_array_dynamic_zero_load.snap
+++ b/crates/codegen/test_files/evm/const_array_dynamic_zero_load.snap
@@ -24,24 +24,24 @@ totals section_bytes=20 code=20 data=0 embed=0 mapped=0 unmapped=20
 section runtime schema=0.3.0
 bytes total=20 code=20 data=0 embed=0
 coverage mapped=0 unmapped=20
-unmapped missing_provenance=19 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_zero block=0 vcode=4 ir=- reason=synthetic post_opt=-
-pc [16, 17) func=load_zero block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [17, 18) func=load_zero block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_zero block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [19, 20) func=load_zero block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
+unmapped missing_provenance=19 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_zero block=0 vcode=4 machine=- reason=synthetic post_opt=-
+pc [16, 17) func=load_zero block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [17, 18) func=load_zero block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_zero block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_zero block=0 vcode=3 machine=0 reason=missing_provenance post_opt=-
 
 evm:
   case index_3: calldata_len=32 success reason=Return gas_used=21192 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=52

--- a/crates/codegen/test_files/evm/const_obj_init_mixed_hybrid.snap
+++ b/crates/codegen/test_files/evm/const_obj_init_mixed_hybrid.snap
@@ -22,35 +22,35 @@ totals section_bytes=198 code=38 data=160 embed=0 mapped=0 unmapped=38
 section runtime schema=0.3.0
 bytes total=198 code=38 data=160 embed=0
 coverage mapped=0 unmapped=38
-unmapped missing_provenance=38 no_ir_inst=0 label_or_fixup_only=0 synthetic=0 unknown=0
-pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [2, 3) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [3, 4) func=entry block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=2 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=3 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
-pc [8, 10) func=entry block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=8 ir=5 reason=missing_provenance post_opt=-
-pc [13, 15) func=entry block=0 vcode=9 ir=6 reason=missing_provenance post_opt=-
-pc [15, 16) func=entry block=0 vcode=10 ir=6 reason=missing_provenance post_opt=-
-pc [16, 18) func=entry block=0 vcode=11 ir=6 reason=missing_provenance post_opt=-
-pc [18, 19) func=entry block=0 vcode=12 ir=6 reason=missing_provenance post_opt=-
-pc [19, 20) func=entry block=0 vcode=13 ir=7 reason=missing_provenance post_opt=-
-pc [20, 21) func=entry block=0 vcode=14 ir=7 reason=missing_provenance post_opt=-
-pc [21, 23) func=entry block=0 vcode=15 ir=12 reason=missing_provenance post_opt=-
-pc [23, 24) func=entry block=0 vcode=16 ir=12 reason=missing_provenance post_opt=-
-pc [24, 27) func=entry block=0 vcode=17 ir=17 reason=missing_provenance post_opt=-
-pc [27, 28) func=entry block=0 vcode=18 ir=17 reason=missing_provenance post_opt=-
-pc [28, 29) func=entry block=0 vcode=19 ir=18 reason=missing_provenance post_opt=-
-pc [29, 30) func=entry block=0 vcode=20 ir=18 reason=missing_provenance post_opt=-
-pc [30, 31) func=entry block=0 vcode=21 ir=18 reason=missing_provenance post_opt=-
-pc [31, 32) func=entry block=0 vcode=22 ir=19 reason=missing_provenance post_opt=-
-pc [32, 33) func=entry block=0 vcode=23 ir=20 reason=missing_provenance post_opt=-
-pc [33, 34) func=entry block=0 vcode=24 ir=20 reason=missing_provenance post_opt=-
-pc [34, 36) func=entry block=0 vcode=25 ir=21 reason=missing_provenance post_opt=-
-pc [36, 37) func=entry block=0 vcode=26 ir=21 reason=missing_provenance post_opt=-
-pc [37, 38) func=entry block=0 vcode=27 ir=21 reason=missing_provenance post_opt=-
+unmapped missing_provenance=38 no_machine_inst=0 label_or_fixup_only=0 synthetic=0 unknown=0
+pc [0, 2) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [2, 3) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [3, 4) func=entry block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=2 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=3 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=3 reason=missing_provenance post_opt=-
+pc [8, 10) func=entry block=0 vcode=6 machine=3 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=8 machine=5 reason=missing_provenance post_opt=-
+pc [13, 15) func=entry block=0 vcode=9 machine=6 reason=missing_provenance post_opt=-
+pc [15, 16) func=entry block=0 vcode=10 machine=6 reason=missing_provenance post_opt=-
+pc [16, 18) func=entry block=0 vcode=11 machine=6 reason=missing_provenance post_opt=-
+pc [18, 19) func=entry block=0 vcode=12 machine=6 reason=missing_provenance post_opt=-
+pc [19, 20) func=entry block=0 vcode=13 machine=7 reason=missing_provenance post_opt=-
+pc [20, 21) func=entry block=0 vcode=14 machine=7 reason=missing_provenance post_opt=-
+pc [21, 23) func=entry block=0 vcode=15 machine=12 reason=missing_provenance post_opt=-
+pc [23, 24) func=entry block=0 vcode=16 machine=12 reason=missing_provenance post_opt=-
+pc [24, 27) func=entry block=0 vcode=17 machine=17 reason=missing_provenance post_opt=-
+pc [27, 28) func=entry block=0 vcode=18 machine=17 reason=missing_provenance post_opt=-
+pc [28, 29) func=entry block=0 vcode=19 machine=18 reason=missing_provenance post_opt=-
+pc [29, 30) func=entry block=0 vcode=20 machine=18 reason=missing_provenance post_opt=-
+pc [30, 31) func=entry block=0 vcode=21 machine=18 reason=missing_provenance post_opt=-
+pc [31, 32) func=entry block=0 vcode=22 machine=19 reason=missing_provenance post_opt=-
+pc [32, 33) func=entry block=0 vcode=23 machine=20 reason=missing_provenance post_opt=-
+pc [33, 34) func=entry block=0 vcode=24 machine=20 reason=missing_provenance post_opt=-
+pc [34, 36) func=entry block=0 vcode=25 machine=21 reason=missing_provenance post_opt=-
+pc [36, 37) func=entry block=0 vcode=26 machine=21 reason=missing_provenance post_opt=-
+pc [37, 38) func=entry block=0 vcode=27 machine=21 reason=missing_provenance post_opt=-
 
 evm:
   case ok: calldata_len=0 success reason=Return gas_used=21139 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=139

--- a/crates/codegen/test_files/evm/const_obj_init_mixed_hybrid.snap
+++ b/crates/codegen/test_files/evm/const_obj_init_mixed_hybrid.snap
@@ -16,41 +16,41 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=198 code=38 data=160 embed=0 mapped=38 unmapped=0
+object schema=0.3.0
+totals section_bytes=198 code=38 data=160 embed=0 mapped=0 unmapped=38
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=198 code=38 data=160 embed=0
-coverage mapped=38 unmapped=0
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=0 unknown=0
-pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [2, 3) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [3, 4) func=entry block=0 vcode=2 ir=0 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=2 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=3 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=3 reason=- frontend=-
-pc [8, 10) func=entry block=0 vcode=6 ir=3 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=7 ir=3 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=8 ir=5 reason=- frontend=-
-pc [13, 15) func=entry block=0 vcode=9 ir=6 reason=- frontend=-
-pc [15, 16) func=entry block=0 vcode=10 ir=6 reason=- frontend=-
-pc [16, 18) func=entry block=0 vcode=11 ir=6 reason=- frontend=-
-pc [18, 19) func=entry block=0 vcode=12 ir=6 reason=- frontend=-
-pc [19, 20) func=entry block=0 vcode=13 ir=7 reason=- frontend=-
-pc [20, 21) func=entry block=0 vcode=14 ir=7 reason=- frontend=-
-pc [21, 23) func=entry block=0 vcode=15 ir=12 reason=- frontend=-
-pc [23, 24) func=entry block=0 vcode=16 ir=12 reason=- frontend=-
-pc [24, 27) func=entry block=0 vcode=17 ir=17 reason=- frontend=-
-pc [27, 28) func=entry block=0 vcode=18 ir=17 reason=- frontend=-
-pc [28, 29) func=entry block=0 vcode=19 ir=18 reason=- frontend=-
-pc [29, 30) func=entry block=0 vcode=20 ir=18 reason=- frontend=-
-pc [30, 31) func=entry block=0 vcode=21 ir=18 reason=- frontend=-
-pc [31, 32) func=entry block=0 vcode=22 ir=19 reason=- frontend=-
-pc [32, 33) func=entry block=0 vcode=23 ir=20 reason=- frontend=-
-pc [33, 34) func=entry block=0 vcode=24 ir=20 reason=- frontend=-
-pc [34, 36) func=entry block=0 vcode=25 ir=21 reason=- frontend=-
-pc [36, 37) func=entry block=0 vcode=26 ir=21 reason=- frontend=-
-pc [37, 38) func=entry block=0 vcode=27 ir=21 reason=- frontend=-
+coverage mapped=0 unmapped=38
+unmapped missing_provenance=38 no_ir_inst=0 label_or_fixup_only=0 synthetic=0 unknown=0
+pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [2, 3) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [3, 4) func=entry block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=2 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=3 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
+pc [8, 10) func=entry block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=8 ir=5 reason=missing_provenance post_opt=-
+pc [13, 15) func=entry block=0 vcode=9 ir=6 reason=missing_provenance post_opt=-
+pc [15, 16) func=entry block=0 vcode=10 ir=6 reason=missing_provenance post_opt=-
+pc [16, 18) func=entry block=0 vcode=11 ir=6 reason=missing_provenance post_opt=-
+pc [18, 19) func=entry block=0 vcode=12 ir=6 reason=missing_provenance post_opt=-
+pc [19, 20) func=entry block=0 vcode=13 ir=7 reason=missing_provenance post_opt=-
+pc [20, 21) func=entry block=0 vcode=14 ir=7 reason=missing_provenance post_opt=-
+pc [21, 23) func=entry block=0 vcode=15 ir=12 reason=missing_provenance post_opt=-
+pc [23, 24) func=entry block=0 vcode=16 ir=12 reason=missing_provenance post_opt=-
+pc [24, 27) func=entry block=0 vcode=17 ir=17 reason=missing_provenance post_opt=-
+pc [27, 28) func=entry block=0 vcode=18 ir=17 reason=missing_provenance post_opt=-
+pc [28, 29) func=entry block=0 vcode=19 ir=18 reason=missing_provenance post_opt=-
+pc [29, 30) func=entry block=0 vcode=20 ir=18 reason=missing_provenance post_opt=-
+pc [30, 31) func=entry block=0 vcode=21 ir=18 reason=missing_provenance post_opt=-
+pc [31, 32) func=entry block=0 vcode=22 ir=19 reason=missing_provenance post_opt=-
+pc [32, 33) func=entry block=0 vcode=23 ir=20 reason=missing_provenance post_opt=-
+pc [33, 34) func=entry block=0 vcode=24 ir=20 reason=missing_provenance post_opt=-
+pc [34, 36) func=entry block=0 vcode=25 ir=21 reason=missing_provenance post_opt=-
+pc [36, 37) func=entry block=0 vcode=26 ir=21 reason=missing_provenance post_opt=-
+pc [37, 38) func=entry block=0 vcode=27 ir=21 reason=missing_provenance post_opt=-
 
 evm:
   case ok: calldata_len=0 success reason=Return gas_used=21139 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=139

--- a/crates/codegen/test_files/evm/const_obj_init_splat_fill.snap
+++ b/crates/codegen/test_files/evm/const_obj_init_splat_fill.snap
@@ -24,36 +24,36 @@ totals section_bytes=38 code=38 data=0 embed=0 mapped=0 unmapped=38
 section runtime schema=0.3.0
 bytes total=38 code=38 data=0 embed=0
 coverage mapped=0 unmapped=38
-unmapped missing_provenance=37 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
-pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [12, 13) func=load_splat_object block=0 vcode=19 ir=- reason=synthetic post_opt=-
-pc [13, 15) func=load_splat_object block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [15, 16) func=load_splat_object block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [16, 17) func=load_splat_object block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [17, 19) func=load_splat_object block=0 vcode=3 ir=2 reason=missing_provenance post_opt=-
-pc [19, 20) func=load_splat_object block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [20, 21) func=load_splat_object block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_splat_object block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [22, 24) func=load_splat_object block=0 vcode=7 ir=4 reason=missing_provenance post_opt=-
-pc [24, 25) func=load_splat_object block=0 vcode=8 ir=4 reason=missing_provenance post_opt=-
-pc [25, 26) func=load_splat_object block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [26, 27) func=load_splat_object block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [27, 29) func=load_splat_object block=0 vcode=11 ir=6 reason=missing_provenance post_opt=-
-pc [29, 30) func=load_splat_object block=0 vcode=12 ir=6 reason=missing_provenance post_opt=-
-pc [30, 32) func=load_splat_object block=0 vcode=13 ir=6 reason=missing_provenance post_opt=-
-pc [32, 33) func=load_splat_object block=0 vcode=14 ir=6 reason=missing_provenance post_opt=-
-pc [33, 35) func=load_splat_object block=0 vcode=15 ir=10 reason=missing_provenance post_opt=-
-pc [35, 36) func=load_splat_object block=0 vcode=16 ir=10 reason=missing_provenance post_opt=-
-pc [36, 37) func=load_splat_object block=0 vcode=17 ir=11 reason=missing_provenance post_opt=-
-pc [37, 38) func=load_splat_object block=0 vcode=18 ir=11 reason=missing_provenance post_opt=-
+unmapped missing_provenance=37 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 2) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [5, 6) func=entry block=0 vcode=3 machine=0 reason=missing_provenance post_opt=-
+pc [6, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 10) func=entry block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [11, 12) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [12, 13) func=load_splat_object block=0 vcode=19 machine=- reason=synthetic post_opt=-
+pc [13, 15) func=load_splat_object block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_splat_object block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [16, 17) func=load_splat_object block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [17, 19) func=load_splat_object block=0 vcode=3 machine=2 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_splat_object block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [20, 21) func=load_splat_object block=0 vcode=5 machine=2 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_splat_object block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [22, 24) func=load_splat_object block=0 vcode=7 machine=4 reason=missing_provenance post_opt=-
+pc [24, 25) func=load_splat_object block=0 vcode=8 machine=4 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_splat_object block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_splat_object block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [27, 29) func=load_splat_object block=0 vcode=11 machine=6 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_splat_object block=0 vcode=12 machine=6 reason=missing_provenance post_opt=-
+pc [30, 32) func=load_splat_object block=0 vcode=13 machine=6 reason=missing_provenance post_opt=-
+pc [32, 33) func=load_splat_object block=0 vcode=14 machine=6 reason=missing_provenance post_opt=-
+pc [33, 35) func=load_splat_object block=0 vcode=15 machine=10 reason=missing_provenance post_opt=-
+pc [35, 36) func=load_splat_object block=0 vcode=16 machine=10 reason=missing_provenance post_opt=-
+pc [36, 37) func=load_splat_object block=0 vcode=17 machine=11 reason=missing_provenance post_opt=-
+pc [37, 38) func=load_splat_object block=0 vcode=18 machine=11 reason=missing_provenance post_opt=-
 
 evm:
   case index_4: calldata_len=0 success reason=Return gas_used=21111 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=111

--- a/crates/codegen/test_files/evm/const_obj_init_splat_fill.snap
+++ b/crates/codegen/test_files/evm/const_obj_init_splat_fill.snap
@@ -18,42 +18,42 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=38 code=38 data=0 embed=0 mapped=37 unmapped=1
+object schema=0.3.0
+totals section_bytes=38 code=38 data=0 embed=0 mapped=0 unmapped=38
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=38 code=38 data=0 embed=0
-coverage mapped=37 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=- frontend=-
-pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=- frontend=-
-pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [12, 13) func=load_splat_object block=0 vcode=19 ir=- reason=synthetic frontend=-
-pc [13, 15) func=load_splat_object block=0 vcode=0 ir=0 reason=- frontend=-
-pc [15, 16) func=load_splat_object block=0 vcode=1 ir=0 reason=- frontend=-
-pc [16, 17) func=load_splat_object block=0 vcode=2 ir=0 reason=- frontend=-
-pc [17, 19) func=load_splat_object block=0 vcode=3 ir=2 reason=- frontend=-
-pc [19, 20) func=load_splat_object block=0 vcode=4 ir=2 reason=- frontend=-
-pc [20, 21) func=load_splat_object block=0 vcode=5 ir=2 reason=- frontend=-
-pc [21, 22) func=load_splat_object block=0 vcode=6 ir=2 reason=- frontend=-
-pc [22, 24) func=load_splat_object block=0 vcode=7 ir=4 reason=- frontend=-
-pc [24, 25) func=load_splat_object block=0 vcode=8 ir=4 reason=- frontend=-
-pc [25, 26) func=load_splat_object block=0 vcode=9 ir=4 reason=- frontend=-
-pc [26, 27) func=load_splat_object block=0 vcode=10 ir=4 reason=- frontend=-
-pc [27, 29) func=load_splat_object block=0 vcode=11 ir=6 reason=- frontend=-
-pc [29, 30) func=load_splat_object block=0 vcode=12 ir=6 reason=- frontend=-
-pc [30, 32) func=load_splat_object block=0 vcode=13 ir=6 reason=- frontend=-
-pc [32, 33) func=load_splat_object block=0 vcode=14 ir=6 reason=- frontend=-
-pc [33, 35) func=load_splat_object block=0 vcode=15 ir=10 reason=- frontend=-
-pc [35, 36) func=load_splat_object block=0 vcode=16 ir=10 reason=- frontend=-
-pc [36, 37) func=load_splat_object block=0 vcode=17 ir=11 reason=- frontend=-
-pc [37, 38) func=load_splat_object block=0 vcode=18 ir=11 reason=- frontend=-
+coverage mapped=0 unmapped=38
+unmapped missing_provenance=37 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
+pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [12, 13) func=load_splat_object block=0 vcode=19 ir=- reason=synthetic post_opt=-
+pc [13, 15) func=load_splat_object block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [15, 16) func=load_splat_object block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [16, 17) func=load_splat_object block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [17, 19) func=load_splat_object block=0 vcode=3 ir=2 reason=missing_provenance post_opt=-
+pc [19, 20) func=load_splat_object block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [20, 21) func=load_splat_object block=0 vcode=5 ir=2 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_splat_object block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [22, 24) func=load_splat_object block=0 vcode=7 ir=4 reason=missing_provenance post_opt=-
+pc [24, 25) func=load_splat_object block=0 vcode=8 ir=4 reason=missing_provenance post_opt=-
+pc [25, 26) func=load_splat_object block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [26, 27) func=load_splat_object block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [27, 29) func=load_splat_object block=0 vcode=11 ir=6 reason=missing_provenance post_opt=-
+pc [29, 30) func=load_splat_object block=0 vcode=12 ir=6 reason=missing_provenance post_opt=-
+pc [30, 32) func=load_splat_object block=0 vcode=13 ir=6 reason=missing_provenance post_opt=-
+pc [32, 33) func=load_splat_object block=0 vcode=14 ir=6 reason=missing_provenance post_opt=-
+pc [33, 35) func=load_splat_object block=0 vcode=15 ir=10 reason=missing_provenance post_opt=-
+pc [35, 36) func=load_splat_object block=0 vcode=16 ir=10 reason=missing_provenance post_opt=-
+pc [36, 37) func=load_splat_object block=0 vcode=17 ir=11 reason=missing_provenance post_opt=-
+pc [37, 38) func=load_splat_object block=0 vcode=18 ir=11 reason=missing_provenance post_opt=-
 
 evm:
   case index_4: calldata_len=0 success reason=Return gas_used=21111 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=111

--- a/crates/codegen/test_files/evm/const_obj_init_zero_fill.snap
+++ b/crates/codegen/test_files/evm/const_obj_init_zero_fill.snap
@@ -18,32 +18,32 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=24 code=24 data=0 embed=0 mapped=23 unmapped=1
+object schema=0.3.0
+totals section_bytes=24 code=24 data=0 embed=0 mapped=0 unmapped=24
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=24 code=24 data=0 embed=0
-coverage mapped=23 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=- frontend=-
-pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=- frontend=-
-pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [12, 13) func=load_zero_object block=0 vcode=9 ir=- reason=synthetic frontend=-
-pc [13, 14) func=load_zero_object block=0 vcode=0 ir=0 reason=- frontend=-
-pc [14, 16) func=load_zero_object block=0 vcode=1 ir=1 reason=- frontend=-
-pc [16, 17) func=load_zero_object block=0 vcode=2 ir=1 reason=- frontend=-
-pc [17, 18) func=load_zero_object block=0 vcode=3 ir=1 reason=- frontend=-
-pc [18, 19) func=load_zero_object block=0 vcode=4 ir=1 reason=- frontend=-
-pc [19, 21) func=load_zero_object block=0 vcode=5 ir=5 reason=- frontend=-
-pc [21, 22) func=load_zero_object block=0 vcode=6 ir=5 reason=- frontend=-
-pc [22, 23) func=load_zero_object block=0 vcode=7 ir=6 reason=- frontend=-
-pc [23, 24) func=load_zero_object block=0 vcode=8 ir=6 reason=- frontend=-
+coverage mapped=0 unmapped=24
+unmapped missing_provenance=23 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
+pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [12, 13) func=load_zero_object block=0 vcode=9 ir=- reason=synthetic post_opt=-
+pc [13, 14) func=load_zero_object block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [14, 16) func=load_zero_object block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
+pc [16, 17) func=load_zero_object block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [17, 18) func=load_zero_object block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_zero_object block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_zero_object block=0 vcode=5 ir=5 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_zero_object block=0 vcode=6 ir=5 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_zero_object block=0 vcode=7 ir=6 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_zero_object block=0 vcode=8 ir=6 reason=missing_provenance post_opt=-
 
 evm:
   case index_4: calldata_len=0 success reason=Return gas_used=21086 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=86

--- a/crates/codegen/test_files/evm/const_obj_init_zero_fill.snap
+++ b/crates/codegen/test_files/evm/const_obj_init_zero_fill.snap
@@ -24,26 +24,26 @@ totals section_bytes=24 code=24 data=0 embed=0 mapped=0 unmapped=24
 section runtime schema=0.3.0
 bytes total=24 code=24 data=0 embed=0
 coverage mapped=0 unmapped=24
-unmapped missing_provenance=23 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
-pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [12, 13) func=load_zero_object block=0 vcode=9 ir=- reason=synthetic post_opt=-
-pc [13, 14) func=load_zero_object block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [14, 16) func=load_zero_object block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
-pc [16, 17) func=load_zero_object block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [17, 18) func=load_zero_object block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [18, 19) func=load_zero_object block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [19, 21) func=load_zero_object block=0 vcode=5 ir=5 reason=missing_provenance post_opt=-
-pc [21, 22) func=load_zero_object block=0 vcode=6 ir=5 reason=missing_provenance post_opt=-
-pc [22, 23) func=load_zero_object block=0 vcode=7 ir=6 reason=missing_provenance post_opt=-
-pc [23, 24) func=load_zero_object block=0 vcode=8 ir=6 reason=missing_provenance post_opt=-
+unmapped missing_provenance=23 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 2) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [5, 6) func=entry block=0 vcode=3 machine=0 reason=missing_provenance post_opt=-
+pc [6, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 10) func=entry block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [11, 12) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [12, 13) func=load_zero_object block=0 vcode=9 machine=- reason=synthetic post_opt=-
+pc [13, 14) func=load_zero_object block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [14, 16) func=load_zero_object block=0 vcode=1 machine=1 reason=missing_provenance post_opt=-
+pc [16, 17) func=load_zero_object block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [17, 18) func=load_zero_object block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [18, 19) func=load_zero_object block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [19, 21) func=load_zero_object block=0 vcode=5 machine=5 reason=missing_provenance post_opt=-
+pc [21, 22) func=load_zero_object block=0 vcode=6 machine=5 reason=missing_provenance post_opt=-
+pc [22, 23) func=load_zero_object block=0 vcode=7 machine=6 reason=missing_provenance post_opt=-
+pc [23, 24) func=load_zero_object block=0 vcode=8 machine=6 reason=missing_provenance post_opt=-
 
 evm:
   case index_4: calldata_len=0 success reason=Return gas_used=21086 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=86

--- a/crates/codegen/test_files/evm/const_word_blob_dedup_same_layout.snap
+++ b/crates/codegen/test_files/evm/const_word_blob_dedup_same_layout.snap
@@ -26,48 +26,48 @@ totals section_bytes=211 code=51 data=160 embed=0 mapped=0 unmapped=51
 section runtime schema=0.3.0
 bytes total=211 code=51 data=160 embed=0
 coverage mapped=0 unmapped=51
-unmapped missing_provenance=49 no_ir_inst=0 label_or_fixup_only=0 synthetic=2 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 11) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=9 ir=2 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=10 ir=2 reason=missing_provenance post_opt=-
-pc [15, 17) func=entry block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
-pc [17, 18) func=entry block=0 vcode=12 ir=4 reason=missing_provenance post_opt=-
-pc [18, 19) func=entry block=0 vcode=13 ir=4 reason=missing_provenance post_opt=-
-pc [19, 20) func=entry block=0 vcode=14 ir=4 reason=missing_provenance post_opt=-
-pc [20, 21) func=entry block=0 vcode=15 ir=5 reason=missing_provenance post_opt=-
-pc [21, 22) func=entry block=0 vcode=16 ir=5 reason=missing_provenance post_opt=-
-pc [22, 23) func=entry block=0 vcode=17 ir=6 reason=missing_provenance post_opt=-
-pc [23, 24) func=entry block=0 vcode=18 ir=7 reason=missing_provenance post_opt=-
-pc [24, 25) func=entry block=0 vcode=19 ir=7 reason=missing_provenance post_opt=-
-pc [25, 27) func=entry block=0 vcode=20 ir=8 reason=missing_provenance post_opt=-
-pc [27, 28) func=entry block=0 vcode=21 ir=8 reason=missing_provenance post_opt=-
-pc [28, 29) func=entry block=0 vcode=22 ir=8 reason=missing_provenance post_opt=-
-pc [29, 30) func=addr_row block=0 vcode=3 ir=- reason=synthetic post_opt=-
-pc [30, 32) func=addr_row block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [32, 33) func=addr_row block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
-pc [33, 34) func=addr_row block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [34, 35) func=load_arr block=0 vcode=13 ir=- reason=synthetic post_opt=-
-pc [35, 37) func=load_arr block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [37, 38) func=load_arr block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
-pc [38, 40) func=load_arr block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [40, 41) func=load_arr block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [41, 42) func=load_arr block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
-pc [42, 44) func=load_arr block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
-pc [44, 45) func=load_arr block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
-pc [45, 46) func=load_arr block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
-pc [46, 47) func=load_arr block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
-pc [47, 48) func=load_arr block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
-pc [48, 49) func=load_arr block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
-pc [49, 50) func=load_arr block=0 vcode=11 ir=5 reason=missing_provenance post_opt=-
-pc [50, 51) func=load_arr block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
+unmapped missing_provenance=49 no_machine_inst=0 label_or_fixup_only=0 synthetic=2 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 11) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=9 machine=2 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=10 machine=2 reason=missing_provenance post_opt=-
+pc [15, 17) func=entry block=0 vcode=11 machine=4 reason=missing_provenance post_opt=-
+pc [17, 18) func=entry block=0 vcode=12 machine=4 reason=missing_provenance post_opt=-
+pc [18, 19) func=entry block=0 vcode=13 machine=4 reason=missing_provenance post_opt=-
+pc [19, 20) func=entry block=0 vcode=14 machine=4 reason=missing_provenance post_opt=-
+pc [20, 21) func=entry block=0 vcode=15 machine=5 reason=missing_provenance post_opt=-
+pc [21, 22) func=entry block=0 vcode=16 machine=5 reason=missing_provenance post_opt=-
+pc [22, 23) func=entry block=0 vcode=17 machine=6 reason=missing_provenance post_opt=-
+pc [23, 24) func=entry block=0 vcode=18 machine=7 reason=missing_provenance post_opt=-
+pc [24, 25) func=entry block=0 vcode=19 machine=7 reason=missing_provenance post_opt=-
+pc [25, 27) func=entry block=0 vcode=20 machine=8 reason=missing_provenance post_opt=-
+pc [27, 28) func=entry block=0 vcode=21 machine=8 reason=missing_provenance post_opt=-
+pc [28, 29) func=entry block=0 vcode=22 machine=8 reason=missing_provenance post_opt=-
+pc [29, 30) func=addr_row block=0 vcode=3 machine=- reason=synthetic post_opt=-
+pc [30, 32) func=addr_row block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [32, 33) func=addr_row block=0 vcode=1 machine=1 reason=missing_provenance post_opt=-
+pc [33, 34) func=addr_row block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [34, 35) func=load_arr block=0 vcode=13 machine=- reason=synthetic post_opt=-
+pc [35, 37) func=load_arr block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [37, 38) func=load_arr block=0 vcode=1 machine=1 reason=missing_provenance post_opt=-
+pc [38, 40) func=load_arr block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [40, 41) func=load_arr block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [41, 42) func=load_arr block=0 vcode=4 machine=2 reason=missing_provenance post_opt=-
+pc [42, 44) func=load_arr block=0 vcode=5 machine=3 reason=missing_provenance post_opt=-
+pc [44, 45) func=load_arr block=0 vcode=6 machine=3 reason=missing_provenance post_opt=-
+pc [45, 46) func=load_arr block=0 vcode=7 machine=3 reason=missing_provenance post_opt=-
+pc [46, 47) func=load_arr block=0 vcode=8 machine=3 reason=missing_provenance post_opt=-
+pc [47, 48) func=load_arr block=0 vcode=9 machine=4 reason=missing_provenance post_opt=-
+pc [48, 49) func=load_arr block=0 vcode=10 machine=4 reason=missing_provenance post_opt=-
+pc [49, 50) func=load_arr block=0 vcode=11 machine=5 reason=missing_provenance post_opt=-
+pc [50, 51) func=load_arr block=0 vcode=12 machine=5 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21274 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=134

--- a/crates/codegen/test_files/evm/const_word_blob_dedup_same_layout.snap
+++ b/crates/codegen/test_files/evm/const_word_blob_dedup_same_layout.snap
@@ -20,54 +20,54 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=211 code=51 data=160 embed=0 mapped=49 unmapped=2
+object schema=0.3.0
+totals section_bytes=211 code=51 data=160 embed=0 mapped=0 unmapped=51
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=211 code=51 data=160 embed=0
-coverage mapped=49 unmapped=2
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=2 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 11) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=9 ir=2 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=10 ir=2 reason=- frontend=-
-pc [15, 17) func=entry block=0 vcode=11 ir=4 reason=- frontend=-
-pc [17, 18) func=entry block=0 vcode=12 ir=4 reason=- frontend=-
-pc [18, 19) func=entry block=0 vcode=13 ir=4 reason=- frontend=-
-pc [19, 20) func=entry block=0 vcode=14 ir=4 reason=- frontend=-
-pc [20, 21) func=entry block=0 vcode=15 ir=5 reason=- frontend=-
-pc [21, 22) func=entry block=0 vcode=16 ir=5 reason=- frontend=-
-pc [22, 23) func=entry block=0 vcode=17 ir=6 reason=- frontend=-
-pc [23, 24) func=entry block=0 vcode=18 ir=7 reason=- frontend=-
-pc [24, 25) func=entry block=0 vcode=19 ir=7 reason=- frontend=-
-pc [25, 27) func=entry block=0 vcode=20 ir=8 reason=- frontend=-
-pc [27, 28) func=entry block=0 vcode=21 ir=8 reason=- frontend=-
-pc [28, 29) func=entry block=0 vcode=22 ir=8 reason=- frontend=-
-pc [29, 30) func=addr_row block=0 vcode=3 ir=- reason=synthetic frontend=-
-pc [30, 32) func=addr_row block=0 vcode=0 ir=0 reason=- frontend=-
-pc [32, 33) func=addr_row block=0 vcode=1 ir=1 reason=- frontend=-
-pc [33, 34) func=addr_row block=0 vcode=2 ir=1 reason=- frontend=-
-pc [34, 35) func=load_arr block=0 vcode=13 ir=- reason=synthetic frontend=-
-pc [35, 37) func=load_arr block=0 vcode=0 ir=0 reason=- frontend=-
-pc [37, 38) func=load_arr block=0 vcode=1 ir=1 reason=- frontend=-
-pc [38, 40) func=load_arr block=0 vcode=2 ir=1 reason=- frontend=-
-pc [40, 41) func=load_arr block=0 vcode=3 ir=1 reason=- frontend=-
-pc [41, 42) func=load_arr block=0 vcode=4 ir=2 reason=- frontend=-
-pc [42, 44) func=load_arr block=0 vcode=5 ir=3 reason=- frontend=-
-pc [44, 45) func=load_arr block=0 vcode=6 ir=3 reason=- frontend=-
-pc [45, 46) func=load_arr block=0 vcode=7 ir=3 reason=- frontend=-
-pc [46, 47) func=load_arr block=0 vcode=8 ir=3 reason=- frontend=-
-pc [47, 48) func=load_arr block=0 vcode=9 ir=4 reason=- frontend=-
-pc [48, 49) func=load_arr block=0 vcode=10 ir=4 reason=- frontend=-
-pc [49, 50) func=load_arr block=0 vcode=11 ir=5 reason=- frontend=-
-pc [50, 51) func=load_arr block=0 vcode=12 ir=5 reason=- frontend=-
+coverage mapped=0 unmapped=51
+unmapped missing_provenance=49 no_ir_inst=0 label_or_fixup_only=0 synthetic=2 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 11) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=9 ir=2 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=10 ir=2 reason=missing_provenance post_opt=-
+pc [15, 17) func=entry block=0 vcode=11 ir=4 reason=missing_provenance post_opt=-
+pc [17, 18) func=entry block=0 vcode=12 ir=4 reason=missing_provenance post_opt=-
+pc [18, 19) func=entry block=0 vcode=13 ir=4 reason=missing_provenance post_opt=-
+pc [19, 20) func=entry block=0 vcode=14 ir=4 reason=missing_provenance post_opt=-
+pc [20, 21) func=entry block=0 vcode=15 ir=5 reason=missing_provenance post_opt=-
+pc [21, 22) func=entry block=0 vcode=16 ir=5 reason=missing_provenance post_opt=-
+pc [22, 23) func=entry block=0 vcode=17 ir=6 reason=missing_provenance post_opt=-
+pc [23, 24) func=entry block=0 vcode=18 ir=7 reason=missing_provenance post_opt=-
+pc [24, 25) func=entry block=0 vcode=19 ir=7 reason=missing_provenance post_opt=-
+pc [25, 27) func=entry block=0 vcode=20 ir=8 reason=missing_provenance post_opt=-
+pc [27, 28) func=entry block=0 vcode=21 ir=8 reason=missing_provenance post_opt=-
+pc [28, 29) func=entry block=0 vcode=22 ir=8 reason=missing_provenance post_opt=-
+pc [29, 30) func=addr_row block=0 vcode=3 ir=- reason=synthetic post_opt=-
+pc [30, 32) func=addr_row block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [32, 33) func=addr_row block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
+pc [33, 34) func=addr_row block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [34, 35) func=load_arr block=0 vcode=13 ir=- reason=synthetic post_opt=-
+pc [35, 37) func=load_arr block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [37, 38) func=load_arr block=0 vcode=1 ir=1 reason=missing_provenance post_opt=-
+pc [38, 40) func=load_arr block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [40, 41) func=load_arr block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [41, 42) func=load_arr block=0 vcode=4 ir=2 reason=missing_provenance post_opt=-
+pc [42, 44) func=load_arr block=0 vcode=5 ir=3 reason=missing_provenance post_opt=-
+pc [44, 45) func=load_arr block=0 vcode=6 ir=3 reason=missing_provenance post_opt=-
+pc [45, 46) func=load_arr block=0 vcode=7 ir=3 reason=missing_provenance post_opt=-
+pc [46, 47) func=load_arr block=0 vcode=8 ir=3 reason=missing_provenance post_opt=-
+pc [47, 48) func=load_arr block=0 vcode=9 ir=4 reason=missing_provenance post_opt=-
+pc [48, 49) func=load_arr block=0 vcode=10 ir=4 reason=missing_provenance post_opt=-
+pc [49, 50) func=load_arr block=0 vcode=11 ir=5 reason=missing_provenance post_opt=-
+pc [50, 51) func=load_arr block=0 vcode=12 ir=5 reason=missing_provenance post_opt=-
 
 evm:
   case index_2: calldata_len=32 success reason=Return gas_used=21274 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=134

--- a/crates/codegen/test_files/evm/constref_specialization_dynamic_splat.snap
+++ b/crates/codegen/test_files/evm/constref_specialization_dynamic_splat.snap
@@ -20,30 +20,30 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=21 code=21 data=0 embed=0 mapped=20 unmapped=1
+object schema=0.3.0
+totals section_bytes=21 code=21 data=0 embed=0 mapped=0 unmapped=21
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=21 code=21 data=0 embed=0
-coverage mapped=20 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load__constref_a0_g0 block=0 vcode=4 ir=- reason=synthetic frontend=-
-pc [16, 17) func=load__constref_a0_g0 block=0 vcode=0 ir=0 reason=- frontend=-
-pc [17, 19) func=load__constref_a0_g0 block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 20) func=load__constref_a0_g0 block=0 vcode=2 ir=0 reason=- frontend=-
-pc [20, 21) func=load__constref_a0_g0 block=0 vcode=3 ir=0 reason=- frontend=-
+coverage mapped=0 unmapped=21
+unmapped missing_provenance=20 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load__constref_a0_g0 block=0 vcode=4 ir=- reason=synthetic post_opt=-
+pc [16, 17) func=load__constref_a0_g0 block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [17, 19) func=load__constref_a0_g0 block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load__constref_a0_g0 block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [20, 21) func=load__constref_a0_g0 block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
 
 evm:
   case index_3: calldata_len=32 success reason=Return gas_used=21193 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=53

--- a/crates/codegen/test_files/evm/constref_specialization_dynamic_splat.snap
+++ b/crates/codegen/test_files/evm/constref_specialization_dynamic_splat.snap
@@ -26,24 +26,24 @@ totals section_bytes=21 code=21 data=0 embed=0 mapped=0 unmapped=21
 section runtime schema=0.3.0
 bytes total=21 code=21 data=0 embed=0
 coverage mapped=0 unmapped=21
-unmapped missing_provenance=20 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load__constref_a0_g0 block=0 vcode=4 ir=- reason=synthetic post_opt=-
-pc [16, 17) func=load__constref_a0_g0 block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [17, 19) func=load__constref_a0_g0 block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 20) func=load__constref_a0_g0 block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [20, 21) func=load__constref_a0_g0 block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
+unmapped missing_provenance=20 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load__constref_a0_g0 block=0 vcode=4 machine=- reason=synthetic post_opt=-
+pc [16, 17) func=load__constref_a0_g0 block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [17, 19) func=load__constref_a0_g0 block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load__constref_a0_g0 block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [20, 21) func=load__constref_a0_g0 block=0 vcode=3 machine=0 reason=missing_provenance post_opt=-
 
 evm:
   case index_3: calldata_len=32 success reason=Return gas_used=21193 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=53

--- a/crates/codegen/test_files/evm/constref_specialization_static_subpath_splat.snap
+++ b/crates/codegen/test_files/evm/constref_specialization_static_subpath_splat.snap
@@ -20,30 +20,30 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=21 code=21 data=0 embed=0 mapped=20 unmapped=1
+object schema=0.3.0
+totals section_bytes=21 code=21 data=0 embed=0 mapped=0 unmapped=21
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=21 code=21 data=0 embed=0
-coverage mapped=20 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=- frontend=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=- frontend=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=- frontend=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=- frontend=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=- frontend=-
-pc [15, 16) func=load__constref_a0_g0i1 block=0 vcode=4 ir=- reason=synthetic frontend=-
-pc [16, 17) func=load__constref_a0_g0i1 block=0 vcode=0 ir=0 reason=- frontend=-
-pc [17, 19) func=load__constref_a0_g0i1 block=0 vcode=1 ir=0 reason=- frontend=-
-pc [19, 20) func=load__constref_a0_g0i1 block=0 vcode=2 ir=0 reason=- frontend=-
-pc [20, 21) func=load__constref_a0_g0i1 block=0 vcode=3 ir=0 reason=- frontend=-
+coverage mapped=0 unmapped=21
+unmapped missing_provenance=20 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load__constref_a0_g0i1 block=0 vcode=4 ir=- reason=synthetic post_opt=-
+pc [16, 17) func=load__constref_a0_g0i1 block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [17, 19) func=load__constref_a0_g0i1 block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load__constref_a0_g0i1 block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [20, 21) func=load__constref_a0_g0i1 block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
 
 evm:
   case index_0: calldata_len=32 success reason=Return gas_used=21181 gas_refunded=0 logs=0 output=call len=32 tx_gas=21128 runtime_gas=53

--- a/crates/codegen/test_files/evm/constref_specialization_static_subpath_splat.snap
+++ b/crates/codegen/test_files/evm/constref_specialization_static_subpath_splat.snap
@@ -26,24 +26,24 @@ totals section_bytes=21 code=21 data=0 embed=0 mapped=0 unmapped=21
 section runtime schema=0.3.0
 bytes total=21 code=21 data=0 embed=0
 coverage mapped=0 unmapped=21
-unmapped missing_provenance=20 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 1) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [1, 2) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=2 ir=1 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=3 ir=1 reason=missing_provenance post_opt=-
-pc [5, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 9) func=entry block=0 vcode=6 ir=1 reason=missing_provenance post_opt=-
-pc [9, 10) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [11, 13) func=entry block=0 vcode=9 ir=3 reason=missing_provenance post_opt=-
-pc [13, 14) func=entry block=0 vcode=10 ir=3 reason=missing_provenance post_opt=-
-pc [14, 15) func=entry block=0 vcode=11 ir=3 reason=missing_provenance post_opt=-
-pc [15, 16) func=load__constref_a0_g0i1 block=0 vcode=4 ir=- reason=synthetic post_opt=-
-pc [16, 17) func=load__constref_a0_g0i1 block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [17, 19) func=load__constref_a0_g0i1 block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [19, 20) func=load__constref_a0_g0i1 block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [20, 21) func=load__constref_a0_g0i1 block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
+unmapped missing_provenance=20 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 1) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [1, 2) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=2 machine=1 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=3 machine=1 reason=missing_provenance post_opt=-
+pc [5, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 9) func=entry block=0 vcode=6 machine=1 reason=missing_provenance post_opt=-
+pc [9, 10) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [11, 13) func=entry block=0 vcode=9 machine=3 reason=missing_provenance post_opt=-
+pc [13, 14) func=entry block=0 vcode=10 machine=3 reason=missing_provenance post_opt=-
+pc [14, 15) func=entry block=0 vcode=11 machine=3 reason=missing_provenance post_opt=-
+pc [15, 16) func=load__constref_a0_g0i1 block=0 vcode=4 machine=- reason=synthetic post_opt=-
+pc [16, 17) func=load__constref_a0_g0i1 block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [17, 19) func=load__constref_a0_g0i1 block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [19, 20) func=load__constref_a0_g0i1 block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [20, 21) func=load__constref_a0_g0i1 block=0 vcode=3 machine=0 reason=missing_provenance post_opt=-
 
 evm:
   case index_0: calldata_len=32 success reason=Return gas_used=21181 gas_refunded=0 logs=0 output=call len=32 tx_gas=21128 runtime_gas=53

--- a/crates/codegen/test_files/evm/observability_basic.snap
+++ b/crates/codegen/test_files/evm/observability_basic.snap
@@ -24,20 +24,20 @@ totals section_bytes=17 code=17 data=0 embed=0 mapped=0 unmapped=17
 section runtime schema=0.3.0
 bytes total=17 code=17 data=0 embed=0
 coverage mapped=0 unmapped=17
-unmapped missing_provenance=16 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
-pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
-pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
-pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
-pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
-pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
-pc [12, 13) func=main block=0 vcode=3 ir=- reason=synthetic post_opt=-
-pc [13, 15) func=main block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
-pc [15, 16) func=main block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
-pc [16, 17) func=main block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+unmapped missing_provenance=16 no_machine_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 2) func=entry block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
+pc [5, 6) func=entry block=0 vcode=3 machine=0 reason=missing_provenance post_opt=-
+pc [6, 7) func=entry block=0 vcode=4 machine=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 machine=1 reason=missing_provenance post_opt=-
+pc [8, 10) func=entry block=0 vcode=6 machine=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=7 machine=2 reason=missing_provenance post_opt=-
+pc [11, 12) func=entry block=0 vcode=8 machine=2 reason=missing_provenance post_opt=-
+pc [12, 13) func=main block=0 vcode=3 machine=- reason=synthetic post_opt=-
+pc [13, 15) func=main block=0 vcode=0 machine=0 reason=missing_provenance post_opt=-
+pc [15, 16) func=main block=0 vcode=1 machine=0 reason=missing_provenance post_opt=-
+pc [16, 17) func=main block=0 vcode=2 machine=0 reason=missing_provenance post_opt=-
 
 evm:
   case ok: calldata_len=0 success reason=Return gas_used=21043 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=43

--- a/crates/codegen/test_files/evm/observability_basic.snap
+++ b/crates/codegen/test_files/evm/observability_basic.snap
@@ -18,26 +18,26 @@ functions:
 
 --------------- OBSERVABILITY ---------------
 
-object schema=0.1.0
-totals section_bytes=17 code=17 data=0 embed=0 mapped=16 unmapped=1
+object schema=0.3.0
+totals section_bytes=17 code=17 data=0 embed=0 mapped=0 unmapped=17
 
-section runtime schema=0.1.0
+section runtime schema=0.3.0
 bytes total=17 code=17 data=0 embed=0
-coverage mapped=16 unmapped=1
-unmapped no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
-pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=- frontend=-
-pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=- frontend=-
-pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=- frontend=-
-pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=- frontend=-
-pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=- frontend=-
-pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=- frontend=-
-pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=- frontend=-
-pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=- frontend=-
-pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=- frontend=-
-pc [12, 13) func=main block=0 vcode=3 ir=- reason=synthetic frontend=-
-pc [13, 15) func=main block=0 vcode=0 ir=0 reason=- frontend=-
-pc [15, 16) func=main block=0 vcode=1 ir=0 reason=- frontend=-
-pc [16, 17) func=main block=0 vcode=2 ir=0 reason=- frontend=-
+coverage mapped=0 unmapped=17
+unmapped missing_provenance=16 no_ir_inst=0 label_or_fixup_only=0 synthetic=1 unknown=0
+pc [0, 2) func=entry block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [2, 4) func=entry block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [4, 5) func=entry block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
+pc [5, 6) func=entry block=0 vcode=3 ir=0 reason=missing_provenance post_opt=-
+pc [6, 7) func=entry block=0 vcode=4 ir=1 reason=missing_provenance post_opt=-
+pc [7, 8) func=entry block=0 vcode=5 ir=1 reason=missing_provenance post_opt=-
+pc [8, 10) func=entry block=0 vcode=6 ir=2 reason=missing_provenance post_opt=-
+pc [10, 11) func=entry block=0 vcode=7 ir=2 reason=missing_provenance post_opt=-
+pc [11, 12) func=entry block=0 vcode=8 ir=2 reason=missing_provenance post_opt=-
+pc [12, 13) func=main block=0 vcode=3 ir=- reason=synthetic post_opt=-
+pc [13, 15) func=main block=0 vcode=0 ir=0 reason=missing_provenance post_opt=-
+pc [15, 16) func=main block=0 vcode=1 ir=0 reason=missing_provenance post_opt=-
+pc [16, 17) func=main block=0 vcode=2 ir=0 reason=missing_provenance post_opt=-
 
 evm:
   case ok: calldata_len=0 success reason=Return gas_used=21043 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=43

--- a/crates/codegen/tests/attribution_conformance.rs
+++ b/crates/codegen/tests/attribution_conformance.rs
@@ -194,7 +194,11 @@ fn unique_needle_pc(bytes: &[u8], needle: &[u8]) -> u32 {
         .filter(|(_, w)| *w == needle)
         .map(|(i, _)| i)
         .collect();
-    assert_eq!(hits.len(), 1, "marker byte pattern must be unique: {hits:?}");
+    assert_eq!(
+        hits.len(),
+        1,
+        "marker byte pattern must be unique: {hits:?}"
+    );
     hits[0] as u32
 }
 
@@ -291,7 +295,11 @@ fn compile_fully_stamped(
     // stamp encoding its own id.
     compile.stamp_all_post_opt_provenance(|func, inst| Some(stamp_string(func, inst)));
 
-    (compile.compile().expect("compile succeeds"), expected, stamped)
+    (
+        compile.compile().expect("compile succeeds"),
+        expected,
+        stamped,
+    )
 }
 
 /// Stamp every optimized inst and compile, no marker expectation (for fixtures
@@ -307,6 +315,14 @@ fn stamp_all_and_compile(source: &str, opt: OptLevel) -> Vec<ObjectArtifact> {
 
 // ---- the suite -----------------------------------------------------------
 
+/// Markers expected to lose their stamp at a given opt level, by mandatory-prep
+/// pass (R1#1). Empty at this commit: every marker maps at every level. When a
+/// prep change legitimately drops one, register it here with the cause, which
+/// keeps the loss a reviewed diff instead of sanctioned silence.
+fn expected_marker_losses(_opt: OptLevel) -> Vec<u32> {
+    Vec::new()
+}
+
 #[test]
 fn exact_mapping_is_content_correct_and_conserved_at_all_opt_levels() {
     for opt in [OptLevel::O0, OptLevel::O2, OptLevel::Os] {
@@ -318,6 +334,7 @@ fn exact_mapping_is_content_correct_and_conserved_at_all_opt_levels() {
         // outcome, with inter-entry and trailing gaps counted unmapped.
         assert_conserved(obs);
 
+        let mut lost_markers: Vec<u32> = Vec::new();
         for &marker in &MARKERS {
             let pc = unique_needle_pc(&runtime.bytes, &push3_needle(marker));
             let entry = entry_covering(obs, pc);
@@ -328,7 +345,8 @@ fn exact_mapping_is_content_correct_and_conserved_at_all_opt_levels() {
                 // marker. This is the assertion the three shipped id-pun rounds
                 // would fail, and that any reintroduced positional/id join fails.
                 PcAttribution::Mapped {
-                    post_opt_provenance, ..
+                    post_opt_provenance,
+                    ..
                 } => {
                     assert_eq!(
                         post_opt_provenance, &expected[&marker],
@@ -344,10 +362,24 @@ fn exact_mapping_is_content_correct_and_conserved_at_all_opt_levels() {
                         UnmappedReason::MissingProvenance,
                         "marker lost with an unexpected reason"
                     );
-                    eprintln!("KNOWN-LOSS opt={opt:?} marker={marker:#x}: prep dropped the stamp");
+                    lost_markers.push(marker);
                 }
             }
         }
+
+        // Completeness floor (HARD): the expected-loss register is empty, so at
+        // this commit every marker maps at every opt level. A marker landing in
+        // the KNOWN-LOSS arm above is a provenance-carry regression until it is
+        // registered in expected_marker_losses together with the mandatory-prep
+        // pass that legitimately causes it (R1#1). This turns the suite into the
+        // measured R1#1 sensor rather than a sanctioned silence.
+        assert_eq!(
+            lost_markers,
+            expected_marker_losses(opt),
+            "opt={opt:?}: markers lost their stamps; if a mandatory-prep change \
+             caused this legitimately, register the loss with a reason instead \
+             of weakening this assert"
+        );
 
         // Fixture validity (HARD): replay the exact join the removed
         // post-hoc-provenance code did. It keyed the optimized provenance map by
@@ -369,12 +401,12 @@ fn exact_mapping_is_content_correct_and_conserved_at_all_opt_levels() {
             let Some(m) = e.attribution.machine_inst() else {
                 continue;
             };
-            let pun_answer: Option<String> =
-                if stamped.contains(&(func.as_u32(), m.raw().as_u32())) {
-                    Some(stamp_string(func, OptInstId(m.raw())))
-                } else {
-                    None
-                };
+            let pun_answer: Option<String> = if stamped.contains(&(func.as_u32(), m.raw().as_u32()))
+            {
+                Some(stamp_string(func, OptInstId(m.raw())))
+            } else {
+                None
+            };
             let actual_answer: Option<String> =
                 e.attribution.post_opt_provenance().map(str::to_string);
             if pun_answer != actual_answer {
@@ -466,8 +498,7 @@ fn synthetic_units_are_unique_across_sections() {
     // The property: object+section fully disambiguates those colliding ids, so
     // every (section, raw-unit) pair maps to its own distinct identity and no
     // identity is shared across sections.
-    let distinct_section_unit_pairs: usize =
-        sections_by_raw_unit.values().map(|s| s.len()).sum();
+    let distinct_section_unit_pairs: usize = sections_by_raw_unit.values().map(|s| s.len()).sum();
     assert_eq!(
         identities.len(),
         distinct_section_unit_pairs,

--- a/crates/codegen/tests/attribution_conformance.rs
+++ b/crates/codegen/tests/attribution_conformance.rs
@@ -1,0 +1,476 @@
+//! Attribution conformance: drives sonatina-codegen exactly as an external
+//! frontend does (the `EvmCompile` public door only) and checks properties,
+//! not anecdotes: byte conservation, no-wrong-mapping (a content oracle that
+//! does not trust ids), and honest loss.
+//!
+//! The content oracle is the point. Both the machine-IR and optimized-IR inst
+//! arenas are dense from zero, so their numeric ids collide by construction.
+//! A pc range is attributed correctly only if the provenance string stamped on
+//! it decodes to the optimized instruction that actually owns that range,
+//! independent of any positional/id join. The three shipped "post-hoc
+//! provenance" rounds all did a positional join and would fail the hard arm
+//! below; so would any future reintroduction in the linker or elsewhere.
+
+use sonatina_codegen::{
+    EvmCompile, OptInstId, OptLevel,
+    object::{
+        ObjectArtifact, PcAttribution, PcMapEntry, PcMapUnit, SectionArtifact,
+        SectionObservability, UnmappedReason,
+    },
+};
+use sonatina_ir::{
+    I256, Immediate, Type,
+    inst::{arith::Add, downcast},
+    module::FuncRef,
+};
+use sonatina_parser::parse_module;
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+// 0xA1B2C3, 0xA1B2C4, 0xA1B2C5: each a genuine 3-byte constant (PUSH3), each
+// used exactly once so it cannot be folded, hoisted, or deduplicated.
+const MARKERS: [u32; 3] = [10_597_059, 10_597_060, 10_597_061];
+
+// A one-to-many glue op (`le` + `zext`) precedes the marked adds. Its lowering
+// carries no provenance (one-to-many glue is unmapped by design), yet the glue
+// range still records the machine inst id of `le`/`zext`, whose optimized ids
+// are also stamped. That is the cross-arena collision the removed post-hoc join
+// mis-resolved: it keyed the optimized provenance map by that machine id and so
+// would stamp the glue range with `le`/`zext`'s source. The correct pipeline
+// leaves it unmapped; `exact_mapping_...` replays the join and requires the two
+// to disagree. v3 is dynamic and each constant is used once, so no pass folds
+// the marked adds.
+const FIXTURE: &str = r#"
+target = "evm-ethereum-osaka"
+
+func public %runtime(v0.i256, v1.i256) {
+    block0:
+        v2.i1 = le v0 v1;
+        v3.i256 = zext v2 i256;
+        v4.i256 = add v3 10597059.i256;
+        mstore 0.i256 v4 i256;
+        v5.i256 = add v3 10597060.i256;
+        mstore 32.i256 v5 i256;
+        v6.i256 = add v3 10597061.i256;
+        mstore 64.i256 v6 i256;
+        evm_return 0.i256 96.i256;
+}
+
+object @Contract {
+  section runtime {
+    entry %runtime;
+  }
+}
+"#;
+
+// Two sections, each with two private helpers that end in byte-identical
+// terminal blocks (current-section sym_addr/sym_size + mstore + evm_return).
+// Under any non-Off late-cleanup profile the duplicate terminal is outlined
+// into one shared section unit, minted as `PcMapUnit::Synthetic`. Distinct
+// section names keep the two synthetic identities apart. Shape lifted from the
+// in-crate outline test `link_section_resolves_sym_fixups_in_late_outlined_helper`
+// (isa/evm/tests.rs).
+const FIXTURE_B: &str = r#"
+target = "evm-ethereum-osaka"
+
+func inline(never) private %a1(v0.i1) {
+block0:
+    br v0 block1 block2;
+block1:
+    jump block3;
+block2:
+    evm_invalid;
+block3:
+    v1.i256 = sym_addr .;
+    v2.i256 = sym_size .;
+    mstore 0.i256 v1 i256;
+    mstore 32.i256 v2 i256;
+    evm_return 0.i256 64.i256;
+}
+
+func inline(never) private %b1(v0.i1) {
+block0:
+    br v0 block1 block2;
+block1:
+    jump block3;
+block2:
+    evm_invalid;
+block3:
+    v3.i256 = sym_addr .;
+    v4.i256 = sym_size .;
+    mstore 0.i256 v3 i256;
+    mstore 32.i256 v4 i256;
+    evm_return 0.i256 64.i256;
+}
+
+func public %main1(v0.i1) {
+block0:
+    br v0 block1 block2;
+block1:
+    call %a1 1.i1;
+    return;
+block2:
+    call %b1 1.i1;
+    return;
+}
+
+func inline(never) private %a2(v0.i1) {
+block0:
+    br v0 block1 block2;
+block1:
+    jump block3;
+block2:
+    evm_invalid;
+block3:
+    v1.i256 = sym_addr .;
+    v2.i256 = sym_size .;
+    mstore 0.i256 v1 i256;
+    mstore 32.i256 v2 i256;
+    evm_return 0.i256 64.i256;
+}
+
+func inline(never) private %b2(v0.i1) {
+block0:
+    br v0 block1 block2;
+block1:
+    jump block3;
+block2:
+    evm_invalid;
+block3:
+    v3.i256 = sym_addr .;
+    v4.i256 = sym_size .;
+    mstore 0.i256 v3 i256;
+    mstore 32.i256 v4 i256;
+    evm_return 0.i256 64.i256;
+}
+
+func public %main2(v0.i1) {
+block0:
+    br v0 block1 block2;
+block1:
+    call %a2 1.i1;
+    return;
+block2:
+    call %b2 1.i1;
+    return;
+}
+
+object @Contract {
+  section init {
+    entry %main1;
+  }
+  section runtime {
+    entry %main2;
+  }
+}
+"#;
+
+// ---- helpers -------------------------------------------------------------
+
+// A stamp encodes its own (func, optimized-inst) identity, so decoding it later
+// recovers which optimized instruction a range claims to come from.
+fn stamp_string(func: FuncRef, inst: OptInstId) -> String {
+    format!("conformance:{}:{}", func.as_u32(), inst.raw().as_u32())
+}
+
+fn section<'a>(artifact: &'a ObjectArtifact, name: &str) -> &'a SectionArtifact {
+    artifact
+        .sections
+        .iter()
+        .find(|(n, _)| n.0.as_str() == name)
+        .map(|(_, s)| s)
+        .expect("section missing")
+}
+
+fn push3_needle(marker: u32) -> [u8; 4] {
+    let b = marker.to_be_bytes();
+    [0x62, b[1], b[2], b[3]]
+}
+
+/// Exactly one occurrence, or the fixture is invalid for the oracle.
+fn unique_needle_pc(bytes: &[u8], needle: &[u8]) -> u32 {
+    let hits: Vec<usize> = bytes
+        .windows(needle.len())
+        .enumerate()
+        .filter(|(_, w)| *w == needle)
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(hits.len(), 1, "marker byte pattern must be unique: {hits:?}");
+    hits[0] as u32
+}
+
+fn entry_covering(obs: &SectionObservability, pc: u32) -> &PcMapEntry {
+    obs.pc_map
+        .iter()
+        .find(|e| e.pc_start <= pc && pc < e.pc_end)
+        .expect("pc not covered by any pc-map entry")
+}
+
+/// The link-path byte equation (object/link.rs), observed as an outcome of the
+/// public pipeline: re-derive totals from the entries, count inter-entry and
+/// trailing gaps as unmapped (as the backend does), and require balance.
+fn assert_conserved(obs: &SectionObservability) {
+    let mut entries: Vec<&PcMapEntry> = obs.pc_map.iter().collect();
+    entries.sort_by_key(|e| (e.pc_start, e.pc_end));
+    let (mut mapped, mut unmapped, mut cursor) = (0u32, 0u32, 0u32);
+    for e in entries {
+        assert!(
+            e.pc_start >= cursor,
+            "overlapping pc-map entries at {}",
+            e.pc_start
+        );
+        unmapped += e.pc_start - cursor; // inter-entry gap
+        let span = e.pc_end - e.pc_start;
+        match &e.attribution {
+            PcAttribution::Mapped { .. } => mapped += span,
+            PcAttribution::Unmapped { .. } => unmapped += span,
+        }
+        cursor = e.pc_end;
+    }
+    unmapped += obs.code_bytes.saturating_sub(cursor); // trailing gap
+    assert_eq!(mapped, obs.mapped_code_bytes, "mapped byte total");
+    assert_eq!(unmapped, obs.unmapped_code_bytes, "unmapped byte total");
+    assert_eq!(
+        mapped + unmapped,
+        obs.code_bytes,
+        "mapped + unmapped must equal code_bytes"
+    );
+}
+
+/// The full set of optimized instructions the frontend stamps, keyed by
+/// (func-as-u32, inst-as-u32). This is exactly the domain the removed post-hoc
+/// join looked instructions up in, so it is what we replay the join against.
+type StampedSet = HashSet<(u32, u32)>;
+
+/// Full frontend pattern through the public door. Returns the artifacts, the
+/// expected marker->stamp map (built by reading the *optimized* module: which
+/// optimized add owns which marker constant, never from position), and the set
+/// of every stamped optimized inst id.
+fn compile_fully_stamped(
+    source: &str,
+    opt: OptLevel,
+) -> (Vec<ObjectArtifact>, BTreeMap<u32, String>, StampedSet) {
+    let parsed = parse_module(source).expect("fixture parses");
+    let mut compile = EvmCompile::new(parsed.module)
+        .with_opt_level(opt)
+        .with_observability(true);
+
+    // Content-derived expectations plus the full stamped-id domain.
+    let mut expected: BTreeMap<u32, String> = BTreeMap::new();
+    let mut stamped: StampedSet = HashSet::new();
+    {
+        let module = compile.optimize();
+        for func in module.funcs() {
+            module.func_store.view(func, |function| {
+                let is = function.inst_set();
+                let insts: Vec<_> = function.dfg.inst_ids().collect();
+                for inst in insts {
+                    stamped.insert((func.as_u32(), inst.as_u32()));
+                    if let Some(add) = downcast::<&Add>(is, function.dfg.inst(inst)) {
+                        for &marker in &MARKERS {
+                            let imm = Immediate::from_i256(I256::from(marker as i64), Type::I256);
+                            if function.dfg.value_imm(*add.rhs()) == Some(imm)
+                                || function.dfg.value_imm(*add.lhs()) == Some(imm)
+                            {
+                                let prior =
+                                    expected.insert(marker, stamp_string(func, OptInstId(inst)));
+                                assert!(prior.is_none(), "marker {marker} matched twice");
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+    assert_eq!(
+        expected.len(),
+        MARKERS.len(),
+        "optimizer must not destroy the marker adds"
+    );
+
+    // Full stamping through the bulk door: every live optimized inst gets a
+    // stamp encoding its own id.
+    compile.stamp_all_post_opt_provenance(|func, inst| Some(stamp_string(func, inst)));
+
+    (compile.compile().expect("compile succeeds"), expected, stamped)
+}
+
+/// Stamp every optimized inst and compile, no marker expectation (for fixtures
+/// that carry no marker adds).
+fn stamp_all_and_compile(source: &str, opt: OptLevel) -> Vec<ObjectArtifact> {
+    let parsed = parse_module(source).expect("fixture parses");
+    let mut compile = EvmCompile::new(parsed.module)
+        .with_opt_level(opt)
+        .with_observability(true);
+    compile.stamp_all_post_opt_provenance(|func, inst| Some(stamp_string(func, inst)));
+    compile.compile().expect("compile succeeds")
+}
+
+// ---- the suite -----------------------------------------------------------
+
+#[test]
+fn exact_mapping_is_content_correct_and_conserved_at_all_opt_levels() {
+    for opt in [OptLevel::O0, OptLevel::O2, OptLevel::Os] {
+        let (artifacts, expected, stamped) = compile_fully_stamped(FIXTURE, opt);
+        let runtime = section(&artifacts[0], "runtime");
+        let obs = runtime.observability.as_ref().expect("observability on");
+
+        // Conservation (HARD): every code byte is accounted for, as a pipeline
+        // outcome, with inter-entry and trailing gaps counted unmapped.
+        assert_conserved(obs);
+
+        for &marker in &MARKERS {
+            let pc = unique_needle_pc(&runtime.bytes, &push3_needle(marker));
+            let entry = entry_covering(obs, pc);
+
+            match &entry.attribution {
+                // HARD arm (no-wrong-mapping content oracle): if this range is
+                // mapped at all, its string must decode to the add that owns this
+                // marker. This is the assertion the three shipped id-pun rounds
+                // would fail, and that any reintroduced positional/id join fails.
+                PcAttribution::Mapped {
+                    post_opt_provenance, ..
+                } => {
+                    assert_eq!(
+                        post_opt_provenance, &expected[&marker],
+                        "opt={opt:?} marker {marker:#x}: range attributed to the wrong source"
+                    );
+                }
+                // KNOWN-LOSS arm (R1#1): mandatory prep in lowering may replace a
+                // stamped add with an unstamped clone, dropping provenance. This
+                // is a completeness loss only; it does NOT weaken the mapped arm.
+                PcAttribution::Unmapped { reason, .. } => {
+                    assert_eq!(
+                        *reason,
+                        UnmappedReason::MissingProvenance,
+                        "marker lost with an unexpected reason"
+                    );
+                    eprintln!("KNOWN-LOSS opt={opt:?} marker={marker:#x}: prep dropped the stamp");
+                }
+            }
+        }
+
+        // Fixture validity (HARD): replay the exact join the removed
+        // post-hoc-provenance code did. It keyed the optimized provenance map by
+        // the machine-namespace inst id carried on each PC range (both arenas
+        // count from zero, so the ids collide silently). We reconstruct that
+        // lookup and require it to produce a DIFFERENT attribution than the
+        // pipeline's actual result on at least one range. That divergence proves
+        // the fixture exercises a real cross-arena id collision, so the content
+        // oracle above is not passing vacuously; the pipeline's actual answer
+        // (never the pun's) is the property under test. (Concretely: the `le`
+        // glue range carries the machine id of `le`, whose optimized id is also
+        // stamped, so the join would wrongly map a range the pipeline correctly
+        // leaves unmapped.)
+        let mut pun_would_diverge = false;
+        for e in &obs.pc_map {
+            let Some(func) = e.unit.function() else {
+                continue;
+            };
+            let Some(m) = e.attribution.machine_inst() else {
+                continue;
+            };
+            let pun_answer: Option<String> =
+                if stamped.contains(&(func.as_u32(), m.raw().as_u32())) {
+                    Some(stamp_string(func, OptInstId(m.raw())))
+                } else {
+                    None
+                };
+            let actual_answer: Option<String> =
+                e.attribution.post_opt_provenance().map(str::to_string);
+            if pun_answer != actual_answer {
+                pun_would_diverge = true;
+            }
+        }
+        assert!(
+            pun_would_diverge,
+            "opt={opt:?}: fixture does not exercise a machine/optimized id collision; \
+             the removed post-hoc join would have produced the same answer, so this \
+             fixture cannot distinguish the correct path from the pun"
+        );
+
+        // Honest-loss floor: even with every optimized inst stamped, unmapped
+        // bytes still exist (glue lowering carries no provenance by design).
+        assert!(
+            obs.unmapped_code_bytes > 0,
+            "opt={opt:?}: expected some unmapped glue bytes"
+        );
+    }
+}
+
+#[test]
+fn synthetic_units_are_unique_across_sections() {
+    // Late section-terminal outlining runs only under a non-Off cleanup profile.
+    // Os selects Size, which outlines the byte-identical terminal blocks of the
+    // inline(never) helpers in FIXTURE_B into a shared section unit per section,
+    // minted as `PcMapUnit::Synthetic`. A synthetic unit spans many PC ranges
+    // (one per machine insn), so identities repeat across a unit's own entries;
+    // the property under test is cross-section, not per-entry.
+    let artifacts = stamp_all_and_compile(FIXTURE_B, OptLevel::Os);
+
+    // Distinct synthetic identities (deduped across a unit's own entries), and,
+    // per raw section-unit number, the set of sections that minted it.
+    let mut identities: HashSet<(String, String, u32)> = HashSet::new();
+    let mut sections_by_raw_unit: HashMap<u32, HashSet<String>> = HashMap::new();
+    let mut synthetic_seen = false;
+
+    for artifact in &artifacts {
+        for (_, sec) in artifact.sections.iter() {
+            let Some(obs) = sec.observability.as_ref() else {
+                continue;
+            };
+            assert_conserved(obs);
+            for e in &obs.pc_map {
+                if let PcMapUnit::Synthetic {
+                    object,
+                    section,
+                    unit,
+                } = &e.unit
+                {
+                    synthetic_seen = true;
+                    let obj = object.0.as_str().to_string();
+                    let sect = section.0.as_str().to_string();
+                    identities.insert((obj, sect.clone(), unit.0));
+                    sections_by_raw_unit.entry(unit.0).or_default().insert(sect);
+                    // A synthetic range is compiler-synthesized, so it is always
+                    // unmapped with the Synthetic reason, never mapped to source.
+                    assert!(matches!(
+                        &e.attribution,
+                        PcAttribution::Unmapped {
+                            reason: UnmappedReason::Synthetic,
+                            ..
+                        }
+                    ));
+                }
+            }
+        }
+    }
+
+    // Non-vacuous: fail loudly if the fixture minted nothing to test.
+    assert!(
+        synthetic_seen,
+        "fixture minted no synthetic units; iterate FIXTURE_B"
+    );
+
+    // The hazard is real: each section numbers its outlined units from zero, so
+    // the same raw unit id appears in more than one section. If the identity were
+    // just that raw number (as a bare arena id would be), the two would pun.
+    let raw_collision = sections_by_raw_unit
+        .values()
+        .any(|sections| sections.len() >= 2);
+    assert!(
+        raw_collision,
+        "expected the same raw section-unit id in more than one section; \
+         FIXTURE_B did not exercise a cross-section unit-id collision"
+    );
+
+    // The property: object+section fully disambiguates those colliding ids, so
+    // every (section, raw-unit) pair maps to its own distinct identity and no
+    // identity is shared across sections.
+    let distinct_section_unit_pairs: usize =
+        sections_by_raw_unit.values().map(|s| s.len()).sum();
+    assert_eq!(
+        identities.len(),
+        distinct_section_unit_pairs,
+        "object+section must keep colliding synthetic unit ids apart"
+    );
+}

--- a/crates/codegen/tests/attribution_conformance.rs
+++ b/crates/codegen/tests/attribution_conformance.rs
@@ -430,6 +430,66 @@ fn exact_mapping_is_content_correct_and_conserved_at_all_opt_levels() {
 }
 
 #[test]
+fn machine_inst_ids_are_scoped_to_function_units() {
+    // FIXTURE_B places multiple functions in each section. Their machine
+    // instruction arenas start at the same numeric IDs, so the compiled
+    // artifact is the regression oracle for a real cross-function collision,
+    // not a hand-built attribution table. Every mapped range must retain the
+    // provenance owner of its own function unit.
+    let artifacts = stamp_all_and_compile(FIXTURE_B, OptLevel::Os);
+    let mut functions_by_machine_id: HashMap<u32, HashSet<u32>> = HashMap::new();
+    let mut mapped_entries = 0usize;
+
+    for artifact in &artifacts {
+        for (_, section) in artifact.sections.iter() {
+            let Some(observability) = section.observability.as_ref() else {
+                continue;
+            };
+            for entry in &observability.pc_map {
+                let PcMapUnit::Function(func) = &entry.unit else {
+                    continue;
+                };
+                let PcAttribution::Mapped {
+                    machine_inst,
+                    post_opt_provenance,
+                } = &entry.attribution
+                else {
+                    continue;
+                };
+                mapped_entries += 1;
+
+                let mut fields = post_opt_provenance.split(':');
+                assert_eq!(fields.next(), Some("conformance"));
+                let provenance_func = fields
+                    .next()
+                    .and_then(|raw| raw.parse::<u32>().ok())
+                    .unwrap_or_else(|| panic!("malformed provenance: {post_opt_provenance}"));
+                assert_eq!(
+                    provenance_func,
+                    func.as_u32(),
+                    "mapped range for function {func:?} has another function's provenance"
+                );
+                functions_by_machine_id
+                    .entry(machine_inst.raw().as_u32())
+                    .or_default()
+                    .insert(func.as_u32());
+            }
+        }
+    }
+
+    assert!(
+        mapped_entries > 0,
+        "fixture must emit mapped function ranges"
+    );
+    assert!(
+        functions_by_machine_id
+            .values()
+            .any(|funcs| funcs.len() >= 2),
+        "compiled fixture must contain a machine-ID collision across functions"
+    );
+}
+
+#[test]
 fn synthetic_units_are_unique_across_sections() {
     // Late section-terminal outlining runs only under a non-Off cleanup profile.
     // Os selects Size, which outlines the byte-identical terminal blocks of the

--- a/crates/codegen/tests/attribution_preparation.rs
+++ b/crates/codegen/tests/attribution_preparation.rs
@@ -1,0 +1,163 @@
+//! Public-door attribution coverage for mandatory EVM preparation.
+//!
+//! This is intentionally a narrow regression fixture. It checks that a
+//! dynamic `const.load` survives mandatory preparation with its exact stamp,
+//! while other lowering output remains honestly unmapped. The marker add gives
+//! the test a content-derived PC oracle instead of trusting IDs.
+
+use sonatina_codegen::{
+    EvmCompile, OptInstId, OptLevel,
+    object::{PcAttribution, UnmappedReason},
+};
+use sonatina_ir::{
+    I256, Immediate, Type,
+    inst::{arith::Add, data::ConstLoad, downcast},
+};
+use sonatina_parser::parse_module;
+
+const MARKER: u32 = 10_597_059;
+
+const FIXTURE: &str = r#"
+target = "evm-ethereum-osaka"
+
+global private const [i256; 2] $values = [11, 22];
+
+func public %runtime(v0.i256) -> i256 {
+    block0:
+        v1.constref<[i256; 2]> = const.ref $values;
+        v2.constref<i256> = const.index v1 v0;
+        v3.i256 = const.load v2;
+        v4.i256 = add v3 10597059.i256;
+        mstore 0.i256 v4 i256;
+        return v4;
+}
+
+object @Contract {
+  section runtime {
+    entry %runtime;
+  }
+}
+"#;
+
+fn entry_covering(
+    observability: &sonatina_codegen::object::SectionObservability,
+    pc: u32,
+) -> &sonatina_codegen::object::PcMapEntry {
+    observability
+        .pc_map
+        .iter()
+        .find(|entry| entry.pc_start <= pc && pc < entry.pc_end)
+        .expect("marker PC must be covered by the pc map")
+}
+
+fn marker_push3_positions(code: &[u8], marker: u32) -> Vec<usize> {
+    let bytes = marker.to_be_bytes();
+    let mut positions = Vec::new();
+    let mut pc = 0;
+    while pc < code.len() {
+        let opcode = code[pc];
+        let push_len = opcode.checked_sub(0x5f).filter(|&len| len <= 32);
+        if opcode == 0x62 && code.get(pc + 1..pc + 4) == Some(&bytes[1..]) {
+            positions.push(pc);
+        }
+        pc += 1 + push_len.unwrap_or(0) as usize;
+    }
+    positions
+}
+
+#[test]
+fn mandatory_preparation_keeps_exact_stamps_and_marks_unstamped_output_unmapped() {
+    for opt in [OptLevel::O0, OptLevel::O2, OptLevel::Os] {
+        let parsed = parse_module(FIXTURE).expect("fixture parses");
+        let mut compile = EvmCompile::new(parsed.module)
+            .with_opt_level(opt)
+            .with_observability(true);
+
+        let func = compile.optimize().funcs()[0];
+        let (const_load, marker_add) = compile.optimize().func_store.view(func, |function| {
+            let mut const_load = None;
+            let mut marker_add = None;
+            for inst in function.dfg.inst_ids() {
+                let is = function.inst_set();
+                if downcast::<&ConstLoad>(is, function.dfg.inst(inst)).is_some() {
+                    const_load = Some(inst);
+                } else if let Some(add) = downcast::<&Add>(is, function.dfg.inst(inst)) {
+                    let marker = Immediate::from_i256(I256::from(MARKER as i64), Type::I256);
+                    if function.dfg.value_imm(*add.lhs()) == Some(marker)
+                        || function.dfg.value_imm(*add.rhs()) == Some(marker)
+                    {
+                        marker_add = Some(inst);
+                    }
+                }
+            }
+            (
+                const_load.expect("dynamic const.load must survive optimization"),
+                marker_add.expect("marker add must survive optimization"),
+            )
+        });
+
+        compile
+            .stamp_post_opt_provenance(func, OptInstId(const_load), "prep:const-load")
+            .unwrap_or_else(|error| panic!("opt={opt:?}: const.load stamp rejected: {error}"));
+        compile
+            .stamp_post_opt_provenance(func, OptInstId(marker_add), "prep:marker-add")
+            .unwrap_or_else(|error| panic!("opt={opt:?}: marker add stamp rejected: {error}"));
+
+        let artifacts = compile
+            .compile()
+            .unwrap_or_else(|errors| panic!("opt={opt:?}: fixture failed: {errors:?}"));
+        let runtime = artifacts[0]
+            .sections
+            .iter()
+            .find(|(name, _)| name.0.as_str() == "runtime")
+            .map(|(_, section)| section)
+            .expect("runtime section exists");
+        let observability = runtime
+            .observability
+            .as_ref()
+            .expect("observability enabled");
+
+        assert_eq!(
+            observability.mapped_code_bytes + observability.unmapped_code_bytes,
+            observability.code_bytes,
+            "opt={opt:?}: preparation must conserve emitted code bytes"
+        );
+        assert!(
+            observability.mapped_code_bytes > 0,
+            "opt={opt:?}: at least one exact stamped operation must map"
+        );
+
+        let code_bytes = observability.code_bytes as usize;
+        let marker_hits = marker_push3_positions(
+            runtime
+                .bytes
+                .get(..code_bytes)
+                .expect("code bytes must be within section bytes"),
+            MARKER,
+        );
+        assert_eq!(
+            marker_hits.len(),
+            1,
+            "opt={opt:?}: marker PUSH3 must be unique at an instruction boundary"
+        );
+        let marker_entry = entry_covering(observability, marker_hits[0] as u32);
+        assert!(matches!(
+            &marker_entry.attribution,
+            PcAttribution::Mapped { post_opt_provenance, .. }
+                if post_opt_provenance == "prep:marker-add"
+        ));
+
+        assert!(observability.pc_map.iter().any(|entry| matches!(
+            &entry.attribution,
+            PcAttribution::Mapped { post_opt_provenance, .. }
+                if post_opt_provenance == "prep:const-load"
+        )));
+        assert!(observability.pc_map.iter().any(|entry| matches!(
+            &entry.attribution,
+            PcAttribution::Unmapped {
+                reason: UnmappedReason::MissingProvenance,
+                ..
+            }
+        )));
+    }
+}

--- a/crates/ir/src/func_cursor.rs
+++ b/crates/ir/src/func_cursor.rs
@@ -49,9 +49,36 @@ pub trait FuncCursor {
         self.insert_inst_data_dyn(func, Box::new(data))
     }
 
+    /// Insert an instruction derived from `source` and copy its attribution.
+    ///
+    /// Lowering and legalization passes should use this instead of a bare
+    /// insertion when the new instruction is part of the semantic replacement
+    /// for an existing instruction.
+    fn insert_inst_data_from<I: Inst>(
+        &mut self,
+        func: &mut Function,
+        source: InstId,
+        data: I,
+    ) -> InstId {
+        self.insert_inst_data_dyn_from(func, source, Box::new(data))
+    }
+
     fn insert_inst_data_dyn(&mut self, func: &mut Function, data: Box<dyn Inst>) -> InstId {
         let inst = func.dfg.make_inst_dyn(data);
         self.insert_inst(func, inst);
+        inst
+    }
+
+    /// Dynamic counterpart of [`FuncCursor::insert_inst_data_from`].
+    fn insert_inst_data_dyn_from(
+        &mut self,
+        func: &mut Function,
+        source: InstId,
+        data: Box<dyn Inst>,
+    ) -> InstId {
+        let attribution = func.inst_attribution(source);
+        let inst = self.insert_inst_data_dyn(func, data);
+        func.apply_inst_attribution(inst, &attribution);
         inst
     }
 

--- a/crates/ir/src/function.rs
+++ b/crates/ir/src/function.rs
@@ -1,15 +1,24 @@
-use std::io;
+use std::{io, sync::Arc};
+
+use cranelift_entity::SecondaryMap;
 
 use smallvec::SmallVec;
 
 use super::{BlockId, DataFlowGraph, InstId, Layout, Type, ValueId};
 use crate::{InstSetBase, Linkage, ir_writer::IrWrite, module::ModuleCtx};
 
+#[derive(Clone, Debug, Default)]
+pub struct InstAttribution {
+    frontend_origin: Option<Arc<str>>,
+    provenance: Option<Arc<str>>,
+}
+
 #[derive(Clone)]
 pub struct Function {
     pub arg_values: smallvec::SmallVec<[ValueId; 8]>,
     pub dfg: DataFlowGraph,
     pub layout: Layout,
+    inst_attribution: SecondaryMap<InstId, InstAttribution>,
 }
 
 impl Function {
@@ -29,11 +38,69 @@ impl Function {
             arg_values,
             dfg,
             layout: Layout::default(),
+            inst_attribution: SecondaryMap::new(),
         }
     }
 
     pub fn ctx(&self) -> &ModuleCtx {
         &self.dfg.ctx
+    }
+
+    pub fn set_inst_frontend_origin(&mut self, inst: InstId, origin: Arc<str>) {
+        self.inst_attribution[inst].frontend_origin = Some(origin);
+    }
+
+    pub fn inst_frontend_origin(&self, inst: InstId) -> Option<&str> {
+        self.inst_attribution
+            .get(inst)
+            .and_then(|attribution| attribution.frontend_origin.as_deref())
+    }
+
+    pub fn set_inst_provenance(&mut self, inst: InstId, provenance: String) {
+        self.inst_attribution[inst].provenance = Some(Arc::from(provenance));
+    }
+
+    pub fn inst_provenance(&self, inst: InstId) -> Option<&str> {
+        self.inst_attribution
+            .get(inst)
+            .and_then(|attribution| attribution.provenance.as_deref())
+    }
+
+    fn clear_inst_attribution(&mut self, inst: InstId) {
+        self.inst_attribution[inst] = InstAttribution::default();
+    }
+
+    pub fn inst_attribution(&self, inst: InstId) -> InstAttribution {
+        self.inst_attribution.get(inst).cloned().unwrap_or_default()
+    }
+
+    pub fn apply_inst_attribution(&mut self, inst: InstId, attribution: &InstAttribution) {
+        self.inst_attribution[inst] = attribution.clone();
+    }
+
+    pub fn propagate_inst_attribution(&mut self, new_inst: InstId, source_inst: InstId) {
+        let attribution = self.inst_attribution(source_inst);
+        self.apply_inst_attribution(new_inst, &attribution);
+    }
+
+    pub fn import_inst_attribution_from(&mut self, source: &Function, from: InstId, to: InstId) {
+        let attribution = source.inst_attribution(from);
+        self.apply_inst_attribution(to, &attribution);
+    }
+
+    pub fn import_inst_frontend_origin_from(
+        &mut self,
+        source: &Function,
+        from: InstId,
+        to: InstId,
+    ) {
+        if let Some(origin) = source
+            .inst_attribution
+            .get(from)
+            .and_then(|attribution| attribution.frontend_origin.clone())
+        {
+            self.inst_attribution[to].frontend_origin = Some(origin);
+        }
     }
 
     pub fn inst_set(&self) -> &'static dyn InstSetBase {
@@ -51,6 +118,7 @@ impl Function {
         if inst_results_have_stale_users(self, &[inst]) {
             self.rebuild_users();
         }
+        self.clear_inst_attribution(inst);
         self.dfg.delete_inst(inst);
     }
 
@@ -72,6 +140,7 @@ impl Function {
         }
 
         for &inst in insts {
+            self.clear_inst_attribution(inst);
             self.dfg.delete_inst(inst);
         }
     }
@@ -122,6 +191,8 @@ fn inst_results_have_stale_users(func: &Function, insts: &[InstId]) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::{
         Immediate, Linkage, Signature, Type, builder::test_util::test_module_builder,
         func_cursor::InstInserter, inst::arith::Add,
@@ -229,6 +300,52 @@ mod tests {
 
         assert!(!builder.func.dfg.has_inst(producer_inst));
         assert!(!builder.func.dfg.has_inst(consumer_inst));
+    }
+
+    #[test]
+    fn attribution_is_shared_and_cleared_with_the_instruction() {
+        let mb = test_module_builder();
+        let sig = Signature::new_unit("test_func", Linkage::Public, &[]);
+        let func_ref = mb.declare_function(sig).unwrap();
+
+        let mut builder = mb.func_builder::<InstInserter>(func_ref);
+        let entry = builder.append_block();
+        builder.switch_to_block(entry);
+
+        let lhs = builder.make_imm_value(Immediate::I32(1));
+        let rhs = builder.make_imm_value(Immediate::I32(2));
+        let has_add = builder.inst_set().has_add().unwrap();
+        let first = builder.insert_inst(Add::new(has_add, lhs, rhs), Type::I32);
+        let first_inst = builder.func.dfg.value_inst(first).unwrap();
+        let second = builder.insert_inst(Add::new(has_add, first, lhs), Type::I32);
+        let second_inst = builder.func.dfg.value_inst(second).unwrap();
+
+        let origin: Arc<str> = Arc::from("fake-dsl://module::expr@7");
+        builder
+            .func
+            .set_inst_frontend_origin(first_inst, Arc::clone(&origin));
+        builder
+            .func
+            .propagate_inst_attribution(second_inst, first_inst);
+
+        assert_eq!(
+            builder.func.inst_frontend_origin(second_inst),
+            Some("fake-dsl://module::expr@7")
+        );
+        assert!(Arc::ptr_eq(
+            builder.func.inst_attribution[first_inst]
+                .frontend_origin
+                .as_ref()
+                .unwrap(),
+            builder.func.inst_attribution[second_inst]
+                .frontend_origin
+                .as_ref()
+                .unwrap()
+        ));
+
+        builder.func.layout.remove_inst(second_inst);
+        builder.func.erase_inst(second_inst);
+        assert_eq!(builder.func.inst_frontend_origin(second_inst), None);
     }
 }
 

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -16,6 +16,7 @@ pub mod linkage;
 pub mod module;
 pub mod module_linker;
 pub mod object;
+pub mod trace_view;
 pub mod types;
 pub mod value;
 pub mod visitor;
@@ -31,7 +32,7 @@ pub use effects::{
     EffectBits, EffectCostClass, FuncEffectSummary, InstEffectSummary, InstEffects, MemoryAccess,
     OtherEffects,
 };
-pub use function::{Function, Signature};
+pub use function::{Function, InstAttribution, Signature};
 pub use global_variable::{GlobalVariableData, GlobalVariableRef};
 pub use graphviz::render_to;
 pub use inst::{
@@ -44,6 +45,7 @@ pub use module::{InlineHint, Module};
 pub use object::{
     Directive, Embed, EmbedSymbol, Object, ObjectName, Section, SectionName, SectionRef,
 };
+pub use trace_view::{CfgEdge, CfgEdgeKind, InstKindView, SonatinaTraceView};
 pub use types::Type;
 pub use value::{Immediate, Value, ValueId};
 

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -16,6 +16,7 @@ pub mod linkage;
 pub mod module;
 pub mod module_linker;
 pub mod object;
+pub mod trace_view;
 pub mod types;
 pub mod value;
 pub mod visitor;
@@ -44,6 +45,7 @@ pub use module::{InlineHint, Module};
 pub use object::{
     Directive, Embed, EmbedSymbol, Object, ObjectName, Section, SectionName, SectionRef,
 };
+pub use trace_view::{CfgEdge, CfgEdgeKind, InstKindView, SonatinaTraceView};
 pub use types::Type;
 pub use value::{Immediate, Value, ValueId};
 

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -31,7 +31,7 @@ pub use effects::{
     EffectBits, EffectCostClass, FuncEffectSummary, InstEffectSummary, InstEffects, MemoryAccess,
     OtherEffects,
 };
-pub use function::{Function, Signature};
+pub use function::{Function, InstAttribution, Signature};
 pub use global_variable::{GlobalVariableData, GlobalVariableRef};
 pub use graphviz::render_to;
 pub use inst::{

--- a/crates/ir/src/trace_view.rs
+++ b/crates/ir/src/trace_view.rs
@@ -1,0 +1,205 @@
+use crate::{
+    BlockId, Function, InstId, Module,
+    inst::{
+        InstClassKind,
+        control_flow::{BranchInfo, BranchKind},
+    },
+    module::FuncRef,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum CfgEdgeKind {
+    Jump,
+    Branch,
+    BranchTable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CfgEdge {
+    pub from: BlockId,
+    pub to: BlockId,
+    pub terminator: InstId,
+    pub ordinal: usize,
+    pub kind: CfgEdgeKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct InstKindView {
+    pub opcode: &'static str,
+    pub class: InstClassKind,
+    pub terminator: bool,
+}
+
+pub trait SonatinaTraceView {
+    fn trace_functions(&self) -> Vec<FuncRef>;
+    fn trace_blocks(&self, func: FuncRef) -> Vec<BlockId>;
+    fn trace_instructions(&self, func: FuncRef, block: BlockId) -> Vec<InstId>;
+    fn trace_block_successors(&self, func: FuncRef, block: BlockId) -> Vec<CfgEdge>;
+    fn trace_inst_kind(&self, func: FuncRef, inst: InstId) -> Option<InstKindView>;
+}
+
+impl SonatinaTraceView for Module {
+    fn trace_functions(&self) -> Vec<FuncRef> {
+        self.funcs()
+    }
+
+    fn trace_blocks(&self, func: FuncRef) -> Vec<BlockId> {
+        self.func_store
+            .try_view(func, |func| func.layout.iter_block().collect())
+            .unwrap_or_default()
+    }
+
+    fn trace_instructions(&self, func: FuncRef, block: BlockId) -> Vec<InstId> {
+        self.func_store
+            .try_view(func, |func| trace_instructions(func, block))
+            .unwrap_or_default()
+    }
+
+    fn trace_block_successors(&self, func: FuncRef, block: BlockId) -> Vec<CfgEdge> {
+        self.func_store
+            .try_view(func, |func| trace_block_successors(func, block))
+            .unwrap_or_default()
+    }
+
+    fn trace_inst_kind(&self, func: FuncRef, inst: InstId) -> Option<InstKindView> {
+        self.func_store.try_view(func, |func| {
+            func.dfg.get_inst(inst).map(|inst| InstKindView {
+                opcode: inst.as_text(),
+                class: inst.kind(),
+                terminator: inst.is_terminator(),
+            })
+        })?
+    }
+}
+
+fn trace_instructions(func: &Function, block: BlockId) -> Vec<InstId> {
+    if !func.layout.has_block_slot(block) || !func.layout.is_block_inserted(block) {
+        return Vec::new();
+    }
+
+    func.layout.iter_inst(block).collect()
+}
+
+fn trace_block_successors(func: &Function, block: BlockId) -> Vec<CfgEdge> {
+    let Some(Some(terminator)) = func.layout.try_last_inst_of(block) else {
+        return Vec::new();
+    };
+    let Some(branch) = func.dfg.branch_info(terminator) else {
+        return Vec::new();
+    };
+
+    let kind = cfg_edge_kind(branch);
+    branch
+        .dests()
+        .into_iter()
+        .enumerate()
+        .map(|(ordinal, to)| CfgEdge {
+            from: block,
+            to,
+            terminator,
+            ordinal,
+            kind,
+        })
+        .collect()
+}
+
+fn cfg_edge_kind(branch: &dyn BranchInfo) -> CfgEdgeKind {
+    match branch.branch_kind() {
+        BranchKind::Jump(_) => CfgEdgeKind::Jump,
+        BranchKind::Br(_) => CfgEdgeKind::Branch,
+        BranchKind::BrTable(_) => CfgEdgeKind::BranchTable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Linkage, Signature, Type,
+        builder::test_util::{test_isa, test_module_builder},
+        func_cursor::InstInserter,
+        inst::{
+            arith::Add,
+            control_flow::{Br, Jump, Return},
+        },
+        isa::Isa,
+    };
+
+    use super::{CfgEdgeKind, InstKindView, SonatinaTraceView};
+
+    #[test]
+    fn trace_view_exposes_deterministic_cfg_and_instruction_membership() {
+        let mb = test_module_builder();
+        let sig = Signature::new_unit("trace_loop", Linkage::Public, &[Type::I1]);
+        let func_ref = mb.declare_function(sig).unwrap();
+        let evm = test_isa();
+        let is = evm.inst_set();
+
+        let mut builder = mb.func_builder::<InstInserter>(func_ref);
+        let entry = builder.append_block();
+        let header = builder.append_block();
+        let body = builder.append_block();
+        let exit = builder.append_block();
+        let cond = builder.args()[0];
+
+        builder.switch_to_block(entry);
+        builder.insert_inst_no_result(Jump::new(is, header));
+
+        builder.switch_to_block(header);
+        builder.insert_inst_no_result(Br::new(is, cond, body, exit));
+
+        builder.switch_to_block(body);
+        let lhs = builder.make_imm_value(1i32);
+        let rhs = builder.make_imm_value(2i32);
+        let sum = builder.insert_inst(Add::new(is, lhs, rhs), Type::I32);
+        let sum_inst = builder.func.dfg.value_inst(sum).unwrap();
+        builder.insert_inst_no_result(Jump::new(is, header));
+
+        builder.switch_to_block(exit);
+        builder.insert_inst_no_result(Return::new_unit(is));
+        builder.seal_all();
+        builder.finish();
+
+        let module = mb.build();
+
+        assert_eq!(module.trace_functions(), vec![func_ref]);
+        assert_eq!(
+            module.trace_blocks(func_ref),
+            vec![entry, header, body, exit]
+        );
+
+        let entry_edges = module.trace_block_successors(func_ref, entry);
+        assert_eq!(entry_edges.len(), 1);
+        assert_eq!(entry_edges[0].from, entry);
+        assert_eq!(entry_edges[0].to, header);
+        assert_eq!(entry_edges[0].kind, CfgEdgeKind::Jump);
+        assert_eq!(entry_edges[0].ordinal, 0);
+
+        let header_edges = module.trace_block_successors(func_ref, header);
+        assert_eq!(
+            header_edges
+                .iter()
+                .map(|edge| (edge.to, edge.kind, edge.ordinal))
+                .collect::<Vec<_>>(),
+            vec![
+                (body, CfgEdgeKind::Branch, 0),
+                (exit, CfgEdgeKind::Branch, 1)
+            ]
+        );
+
+        let body_edges = module.trace_block_successors(func_ref, body);
+        assert_eq!(body_edges[0].to, header);
+        assert_eq!(body_edges[0].kind, CfgEdgeKind::Jump);
+
+        let body_insts = module.trace_instructions(func_ref, body);
+        assert_eq!(body_insts.first().copied(), Some(sum_inst));
+
+        assert_eq!(
+            module.trace_inst_kind(func_ref, sum_inst),
+            Some(InstKindView {
+                opcode: "add",
+                class: crate::inst::InstClassKind::Binary(crate::inst::BinaryInstKind::Add),
+                terminator: false,
+            })
+        );
+    }
+}

--- a/crates/macros/src/inst.rs
+++ b/crates/macros/src/inst.rs
@@ -395,7 +395,7 @@ impl InstStruct {
             #[allow(clippy::too_many_arguments)]
             pub fn new(hi: &dyn crate::HasInst<Self>, #(#ctor_args),*) -> Self {
                 Self {
-                    #(#field_names: #field_names),*
+                    #(#field_names),*
                 }
             }
 
@@ -403,7 +403,7 @@ impl InstStruct {
             pub fn new_unchecked(isb: &dyn crate::InstSetBase, #(#ctor_args),*) -> Self {
                 isb.#has_inst_method().unwrap();
                 Self {
-                    #(#field_names: #field_names),*
+                    #(#field_names),*
                 }
             }
         }


### PR DESCRIPTION
  ## Summary

  Add the minimal Sonatina substrate required by Fe's `ethdebug-distill` work:

  - carry opaque Fe origin keys through IR optimization,
  - expose deterministic views over optimized IR,
  - stamp post-optimization instruction provenance,
  - and join that provenance to EVM bytecode through byte-exact PC ranges.

  This is intentionally scoped to Fe's trace pipeline rather than being a general-purpose debug-info framework.

  ## Design

  Each instruction can carry two independent optional attribution channels:

  - **Frontend origin**: attached by Fe during MIR-to-Sonatina lowering and preserved through optimization.
  - **Post-optimization provenance**: stamped by Fe after optimization and carried through EVM lowering into the final PC map.

  Attribution strings use shared `Arc<str>` storage. Inlining and machine lowering therefore preserve identity without duplicating long frontend keys per instruction.

  `Function::propagate_inst_attribution` copies both channels when a pass replaces or expands an instruction. This contract is used by the relevant optimizer passes and both inliners.

  ## Trace views

  The PR exposes deterministic, panic-free views over:

  - functions,
  - blocks,
  - instructions,
  - CFG edges,
  - and instruction kinds.

  It also exposes the optimized module before backend preparation so Fe can emit post-optimization trace facts and stamp instruction provenance.

  ## EVM observability

  EVM lowering distinguishes between:

  - exact 1:1 lowering, which carries both attribution channels, and
  - synthesized glue instructions, which may inherit frontend context but must not impersonate a stamped post-optimization instruction.

  The object layer emits byte-reconciled PC ranges with either:

  - frontend provenance for mapped ranges, or
  - an explicit unmapped reason.

  Synthetic observability units are numbered after all real module functions, avoiding identity collisions.

  ## Attribution correctness

  The PR also fixes incorrect attribution in branch canonicalization: replacement compares now inherit attribution from the compare they replace, rather than borrowing it from the enclosing branch.

  Missing attribution remains missing. Instructions created without a valid attribution anchor are deliberately left unmapped instead of borrowing nearby provenance.

  Known uncovered creation sites remain in parts of aggregate/ABI transformation and GVN/LSR/CFG-edit phi construction.

  ## Verification

  Sonatina:

  - `cargo test -p sonatina-ir`
  - `cargo test -p sonatina-codegen`
  - all 819 Sonatina codegen unit tests and integration tests pass

  Fe, using a temporary local Cargo patch:

  - `cargo test -p fe-codegen`
  - `cargo test -p fe`
  - Fe codegen, CLI, trace, ethdebug, E2E, and formatter-roundtrip suites pass
