### PR TITLE
Preserve object aliases across SSA aggregate boundaries

### DIFF
--- a/crates/codegen/src/transform/aggregate/object_effects.rs
+++ b/crates/codegen/src/transform/aggregate/object_effects.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    slice,
+};
 
 use crate::module_analysis::{CallGraph, CallGraphSccs, SccBuilder, SccRef};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -279,7 +282,9 @@ impl ObjectArgEffect {
             .unwrap_or(0);
         Self {
             local_only: false,
-            escapes: false,
+            // No per-field effects describe references embedded in SSA values.
+            // Keep this boundary conservative even for defined/forwarding callees.
+            escapes: shape::is_reference_aggregate(module, ty),
             reads: SliceSet::empty(total_leaves),
             writes: SliceSet::empty(total_leaves),
             materializes_stack: false,
@@ -612,6 +617,29 @@ fn compute_summary_for_func(
                         *mat_heap.object(),
                         true,
                     );
+                    continue;
+                }
+
+                let inst_data = function.dfg.inst(inst);
+                let aggregate_values =
+                    downcast::<&data::InsertValue>(function.inst_set(), inst_data)
+                        .map(|insert| slice::from_ref(insert.value()))
+                        .or_else(|| {
+                            downcast::<&data::EnumMake>(function.inst_set(), inst_data)
+                                .map(|make| make.values().as_slice())
+                        });
+                if let Some(values) = aggregate_values {
+                    // Capture summaries describe references stored in objects,
+                    // not references embedded in SSA aggregate values. Crossing
+                    // that boundary lets the reference escape our tracked uses,
+                    // including through an aggregate return or a later call.
+                    for &value in values {
+                        for (src_arg, _) in
+                            capture_source_slices(&root_captures, effect_provenance, value, None)
+                        {
+                            summary.arg_effects[src_arg].escapes = true;
+                        }
+                    }
                     continue;
                 }
 
@@ -1794,6 +1822,117 @@ mod tests {
                     (first_leaf..first_leaf + leaf_count).all(|leaf| leaves.contains(&leaf))
                 })
         })
+    }
+
+    #[test]
+    fn reference_aggregate_formals_require_alias_barriers() {
+        for (ty, barrier) in [
+            ("@Wrapper", true),
+            ("@Choice", true),
+            ("[@Wrapper; 2]", true),
+            ("@Pointers", true),
+            ("@Words", false),
+            ("[@Wrapper; 0]", false),
+        ] {
+            let source = format!(
+                r#"
+target = "evm-ethereum-osaka"
+type @Wrapper = {{ objref<i256> }};
+type @Choice = enum {{ #None, #Some(i256,@Wrapper) }};
+type @Pointers = {{ *i256 }};
+type @Words = {{ i256, i256 }};
+declare external %external({ty});
+func private %leaf(v0.{ty}) {{
+block0:
+    return;
+}}
+func private %forward(v0.{ty}) {{
+block0:
+    call %leaf v0;
+    return;
+}}
+"#
+            );
+            let module = parse_test_module(&source);
+            let summaries = compute_object_effect_summaries(&module);
+            for name in ["leaf", "forward", "external"] {
+                let func = lookup_func(&module, name);
+                let summary = summaries.get(&func).cloned().unwrap_or_else(|| {
+                    ObjectEffectSummary::conservative_unknown(
+                        &module.ctx,
+                        func,
+                        &mut shape::AggregateLayoutCache::default(),
+                    )
+                });
+                assert_eq!(
+                    summary.arg_effects[0].needs_unknown_object_barrier(),
+                    barrier,
+                    "{name}({ty})"
+                );
+                if barrier {
+                    assert!(!summary.arg_effects[0].local_only, "{name}({ty})");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn aggregate_return_reference_is_not_local_only() {
+        let module = parse_test_module(
+            r#"
+target = "evm-ethereum-osaka"
+type @Selection = { objref<i256>, i256 };
+
+func private %select(v0.objref<[i256; 2]>, v1.i256) -> @Selection {
+block0:
+    v2.objref<i256> = obj.index v0 v1;
+    v3.@Selection = insert_value undef.@Selection 0.i256 v2;
+    v4.@Selection = insert_value v3 1.i256 42.i256;
+    return v4;
+}
+
+func private %forward(v0.objref<[i256; 2]>) -> @Selection {
+block0:
+    v1.@Selection = call %select v0 0.i256;
+    return v1;
+}
+"#,
+        );
+        let summaries = compute_object_effect_summaries(&module);
+        for name in ["select", "forward"] {
+            let summary = &summaries[&lookup_func(&module, name)];
+            assert!(!summary.arg_effects[0].local_only, "{name}");
+            assert!(summary.arg_effects[0].escapes, "{name}");
+        }
+    }
+
+    #[test]
+    fn enum_return_reference_is_not_local_only() {
+        let module = parse_test_module(
+            r#"
+target = "evm-ethereum-osaka"
+type @Selection = enum { #None, #Some(i256,objref<i256>) };
+
+func private %select(v0.objref<[i256; 2]>, v1.i256) -> @Selection {
+block0:
+    v2.objref<i256> = obj.index v0 v1;
+    v4.@Selection = enum.make @Selection #Some (42.i256, v2);
+    return v4;
+}
+
+func private %forward(v0.objref<[i256; 2]>) -> @Selection {
+block0:
+    v1.@Selection = call %select v0 0.i256;
+    return v1;
+}
+"#,
+        );
+        let summaries = compute_object_effect_summaries(&module);
+        for name in ["select", "forward"] {
+            let summary = &summaries[&lookup_func(&module, name)];
+            assert!(!summary.arg_effects[0].local_only, "{name}");
+            assert!(summary.arg_effects[0].escapes, "{name}");
+        }
     }
 
     #[test]

--- a/crates/codegen/src/transform/aggregate/object_load_store.rs
+++ b/crates/codegen/src/transform/aggregate/object_load_store.rs
@@ -1230,6 +1230,37 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_argument_writes_invalidate_caller_loads() {
+        let module = parse_test_module(
+            r#"target = "evm-ethereum-osaka"
+type @Wrapper = { objref<i256> };
+func inline(never) private %overwrite(v0.@Wrapper) {
+block0:
+ v1.objref<i256> = extract_value v0 0.i8;
+ obj.store v1 22.i256;
+ return;
+}
+func public %entry() -> i256 {
+block0:
+ v0.objref<i256> = obj.alloc i256;
+ v1.@Wrapper = insert_value undef.@Wrapper 0.i8 v0;
+ obj.store v0 11.i256;
+ call %overwrite v1;
+ v2.i256 = obj.load v0;
+ return v2;
+}
+"#,
+        );
+        let entry = lookup_func(&module, "entry");
+        run_with_effects(&module, entry);
+        module.func_store.view(entry, |func| {
+            let dumped = FuncWriter::new(entry, func).dump_string();
+            assert!(dumped.contains("obj.load"), "{dumped}");
+            assert!(dumped.contains("obj.store"), "{dumped}");
+        });
+    }
+
+    #[test]
     fn forwards_local_object_arg_field_store_then_load() {
         let module = parse_test_module(
             r#"

--- a/crates/codegen/src/transform/aggregate/provenance.rs
+++ b/crates/codegen/src/transform/aggregate/provenance.rs
@@ -408,6 +408,20 @@ impl<'a> ProvenanceSnapshot<'a> {
             }));
         }
 
+        // An aggregate may carry aliases despite having no object root itself.
+        // Seed every value producer, including formals and multi-result calls,
+        // so all call-effect consumers see the same conservative boundary.
+        let mut reference_aggregates = FxHashMap::default();
+        for value in func.dfg.value_ids() {
+            let ty = func.dfg.value_ty(value);
+            if *reference_aggregates
+                .entry(ty)
+                .or_insert_with(|| shape::is_reference_aggregate(module, ty))
+            {
+                provenance.maybe_unknown[value] = true;
+            }
+        }
+
         compute_possible_roots(
             func,
             &self.possible_root_transfers,
@@ -696,6 +710,17 @@ fn possible_root_transfer_for_inst(
             result,
             *enum_assert_ref.object(),
         ));
+    }
+
+    // SSA aggregate fields are not represented in the object capture map. An
+    // extracted reference can alias an existing root, even though no root was
+    // recorded for the aggregate value itself. An empty known set is not a
+    // proof that this reference is disjoint from every tracked object.
+    if (downcast::<&data::ExtractValue>(func.inst_set(), func.dfg.inst(inst)).is_some()
+        || downcast::<&data::EnumExtract>(func.inst_set(), func.dfg.inst(inst)).is_some())
+        && reference_element_ty(func.ctx(), func.dfg.value_ty(result)).is_some()
+    {
+        return Some(PossibleRootTransfer::unknown(result));
     }
 
     if let Some(call) = downcast::<&control_flow::Call>(func.inst_set(), func.dfg.inst(inst)) {
@@ -2105,6 +2130,77 @@ mod tests {
             root_slices.insert(arg, whole_root_slice(layout_cache, func.ctx(), root_ty));
         }
         root_slices
+    }
+
+    #[test]
+    fn aggregate_extracted_reference_has_unknown_provenance() {
+        let module = parse_test_module(
+            r#"
+target = "evm-ethereum-osaka"
+type @Selection = { objref<i256>, i256 };
+declare external %select() -> @Selection;
+
+func private %f() -> objref<i256> {
+block0:
+    v0.@Selection = call %select;
+    v1.objref<i256> = extract_value v0 0.i256;
+    return v1;
+}
+"#,
+        );
+        module.func_store.view(lookup_func(&module, "f"), |func| {
+            let mut layout_cache = shape::AggregateLayoutCache::default();
+            let root_slices = collect_root_slices(func, None, &mut layout_cache);
+            let provenance =
+                collect_root_provenance(func, func.ctx(), &root_slices, &mut layout_cache, None);
+            let extracted = func
+                .layout
+                .iter_block()
+                .flat_map(|block| func.layout.iter_inst(block))
+                .find_map(|inst| {
+                    downcast::<&data::ExtractValue>(func.inst_set(), func.dfg.inst(inst))
+                        .and_then(|_| func.dfg.inst_result(inst))
+                })
+                .expect("reference extraction should exist");
+            assert_eq!(provenance.complete().complete_roots(extracted), None);
+            assert_known_and_unknown(provenance.may().may_roots(extracted), &[]);
+        });
+    }
+
+    #[test]
+    fn enum_extracted_reference_has_unknown_provenance() {
+        let module = parse_test_module(
+            r#"
+target = "evm-ethereum-osaka"
+type @Selection = enum { #None, #Some(objref<i256>) };
+declare private %select() -> @Selection;
+
+func private %f() -> objref<i256> {
+block0:
+    v0.@Selection = call %select;
+    enum.assert_variant v0 #Some;
+    v1.objref<i256> = enum.extract v0 #Some 0.i256;
+    return v1;
+}
+"#,
+        );
+        module.func_store.view(lookup_func(&module, "f"), |func| {
+            let mut layout_cache = shape::AggregateLayoutCache::default();
+            let root_slices = collect_root_slices(func, None, &mut layout_cache);
+            let provenance =
+                collect_root_provenance(func, func.ctx(), &root_slices, &mut layout_cache, None);
+            let extracted = func
+                .layout
+                .iter_block()
+                .flat_map(|block| func.layout.iter_inst(block))
+                .find_map(|inst| {
+                    downcast::<&data::EnumExtract>(func.inst_set(), func.dfg.inst(inst))
+                        .and_then(|_| func.dfg.inst_result(inst))
+                })
+                .expect("reference extraction should exist");
+            assert_eq!(provenance.complete().complete_roots(extracted), None);
+            assert_known_and_unknown(provenance.may().may_roots(extracted), &[]);
+        });
     }
 
     #[test]

--- a/crates/codegen/src/transform/aggregate/shape.rs
+++ b/crates/codegen/src/transform/aggregate/shape.rs
@@ -1,10 +1,48 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec};
 use sonatina_ir::{
     DataFlowGraph, Type, U256, ValueId,
     module::ModuleCtx,
     types::{CompoundType, EnumData, EnumVariantRef, TypeStore},
 };
+
+// References embedded in SSA aggregates have no object slice/capture identity.
+// Classify by type so arguments, phi results and call returns share the boundary.
+pub(crate) fn is_reference_aggregate(module: &ModuleCtx, ty: Type) -> bool {
+    module.with_ty_store(|types| {
+        if !matches!(
+            compound_ty(types, ty),
+            Some(CompoundType::Array { .. } | CompoundType::Struct(_) | CompoundType::Enum(_))
+        ) {
+            return false;
+        }
+        let mut pending = vec![ty];
+        let mut seen = FxHashSet::default();
+        while let Some(ty) = pending.pop() {
+            if !seen.insert(ty) {
+                continue;
+            }
+            match compound_ty(types, ty) {
+                Some(
+                    CompoundType::ObjRef(_) | CompoundType::Ptr(_) | CompoundType::ConstRef(_),
+                ) => {
+                    return true;
+                }
+                Some(CompoundType::Array { elem, len }) if *len != 0 => pending.push(*elem),
+                Some(CompoundType::Struct(data)) => pending.extend(data.fields.iter().copied()),
+                Some(CompoundType::Enum(data)) => {
+                    pending.extend(
+                        data.variants
+                            .iter()
+                            .flat_map(|variant| variant.fields.iter().copied()),
+                    );
+                }
+                _ => {}
+            }
+        }
+        false
+    })
+}
 
 pub type FieldPath = SmallVec<[u32; 4]>;
 pub type RuntimeLeaves = SmallVec<[AggregateLeaf; 4]>;

--- a/crates/codegen/test_files/evm/aggregate_argument_reference_effects.opt_ir.snap
+++ b/crates/codegen/test_files/evm/aggregate_argument_reference_effects.opt_ir.snap
@@ -1,0 +1,77 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: opt_ir_snapshot
+input_file: test_files/evm/aggregate_argument_reference_effects.sntn
+---
+target = "evm-ethereum-osaka"
+
+type @Wrapper = {objref<i256>};
+type @Choice = enum {
+    #None,
+    #Some(i256, @Wrapper),
+};
+
+func inline(never) private %read_struct(v0.@Wrapper) -> i256 {
+    block0:
+        v1.objref<i256> = extract_value v0 0.i8;
+        v2.i256 = obj.load v1;
+        return v2;
+}
+
+func inline(never) private %overwrite_struct(v0.@Wrapper, v1.i256) {
+    block0:
+        v2.objref<i256> = extract_value v0 0.i8;
+        obj.store v2 v1;
+        return;
+}
+
+func inline(never) private %read_enum(v0.@Choice) -> i256 {
+    block0:
+        enum.assert_variant v0 #Some;
+        v1.@Wrapper = enum.extract v0 #Some 1.i8;
+        v2.i256 = call %read_struct v1;
+        return v2;
+}
+
+func inline(never) private %overwrite_enum(v0.@Choice, v1.i256) {
+    block0:
+        enum.assert_variant v0 #Some;
+        v2.@Wrapper = enum.extract v0 #Some 1.i8;
+        call %overwrite_struct v2 v1;
+        return;
+}
+
+func inline(never) private %forward(v0.@Choice, v1.i256) {
+    block0:
+        call %overwrite_enum v0 v1;
+        return;
+}
+
+func public %entry() {
+    block0:
+        v0.i256 = evm_calldata_load 0.i256;
+        v1.objref<i256> = obj.alloc i256;
+        v2.@Wrapper = insert_value undef.@Wrapper 0.i8 v1;
+        v3.@Choice = enum.make @Choice #Some 7.i256 v2;
+        obj.store v1 v0;
+        v4.i256 = call %read_struct v2;
+        v5.i256 = add v0 22.i256;
+        call %overwrite_struct v2 v5;
+        v6.i256 = obj.load v1;
+        v7.i256 = call %read_enum v3;
+        v8.i256 = add v0 44.i256;
+        call %forward v3 v8;
+        v9.i256 = obj.load v1;
+        v10.i256 = add v4 v6;
+        v11.i256 = add v7 v9;
+        v12.i256 = add v10 v11;
+        mstore 0.i256 v12 i256;
+        evm_return 0.i256 32.i256;
+}
+
+
+object @Contract {
+    section runtime {
+        entry %entry;
+    }
+}

--- a/crates/codegen/test_files/evm/aggregate_argument_reference_effects.snap
+++ b/crates/codegen/test_files/evm/aggregate_argument_reference_effects.snap
@@ -1,0 +1,29 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: "String::from_utf8(out).unwrap()"
+input_file: test_files/evm/aggregate_argument_reference_effects.sntn
+---
+evm.config: stack_reach=16 vcode=false bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false opt=2
+
+object: Contract
+  section runtime: 113 bytes
+  total: 113 bytes
+
+functions:
+  mem: global_dyn_base=0xa0 arena_base=0xa0 scratch_peak_words=0 stable_chain_peak_words=0
+  read_struct: ir_blocks=1 ir_insts=2 vcode_ops=4 fixups=0 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  overwrite_struct: ir_blocks=1 ir_insts=2 vcode_ops=3 fixups=0 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  read_enum: ir_blocks=1 ir_insts=2 vcode_ops=8 fixups=2 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  overwrite_enum: ir_blocks=1 ir_insts=2 vcode_ops=8 fixups=2 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  forward: ir_blocks=1 ir_insts=2 vcode_ops=8 fixups=2 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  entry: ir_blocks=4 ir_insts=21 vcode_ops=61 fixups=9 imm_bytes=6
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+
+evm:
+  case input_11: calldata_len=32 success reason=Return gas_used=21495 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=355
+  case input_33: calldata_len=32 success reason=Return gas_used=21495 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=355

--- a/crates/codegen/test_files/evm/aggregate_argument_reference_effects.sntn
+++ b/crates/codegen/test_files/evm/aggregate_argument_reference_effects.sntn
@@ -1,0 +1,68 @@
+#! evm.config: { opt: 2 }
+#! evm.case: input_11
+#!   calldata: 0x000000000000000000000000000000000000000000000000000000000000000b
+#!   expect: return 0x0000000000000000000000000000000000000000000000000000000000000084
+#! evm.case: input_33
+#!   calldata: 0x0000000000000000000000000000000000000000000000000000000000000021
+#!   expect: return 0x00000000000000000000000000000000000000000000000000000000000000dc
+
+target = "evm-ethereum-osaka"
+type @Wrapper = { objref<i256> };
+type @Choice = enum { #None, #Some(i256,@Wrapper) };
+func inline(never) private %read_struct(v0.@Wrapper) -> i256 {
+block0:
+ v1.objref<i256> = extract_value v0 0.i8;
+ v2.i256 = obj.load v1;
+ return v2;
+}
+func inline(never) private %overwrite_struct(v0.@Wrapper, v1.i256) {
+block0:
+ v2.objref<i256> = extract_value v0 0.i8;
+ obj.store v2 v1;
+ return;
+}
+func inline(never) private %read_enum(v0.@Choice) -> i256 {
+block0:
+ enum.assert_variant v0 #Some;
+ v1.@Wrapper = enum.extract v0 #Some 1.i8;
+ v2.i256 = call %read_struct v1;
+ return v2;
+}
+func inline(never) private %overwrite_enum(v0.@Choice, v1.i256) {
+block0:
+ enum.assert_variant v0 #Some;
+ v2.@Wrapper = enum.extract v0 #Some 1.i8;
+ call %overwrite_struct v2 v1;
+ return;
+}
+func inline(never) private %forward(v0.@Choice, v1.i256) {
+block0:
+ call %overwrite_enum v0 v1;
+ return;
+}
+func public %entry() {
+block0:
+ v0.i256 = evm_calldata_load 0.i256;
+ v1.objref<i256> = obj.alloc i256;
+ v2.@Wrapper = insert_value undef.@Wrapper 0.i8 v1;
+ v3.@Choice = enum.make @Choice #Some (7.i256, v2);
+ obj.store v1 v0;
+ v4.i256 = call %read_struct v2;
+ v5.i256 = add v0 22.i256;
+ call %overwrite_struct v2 v5;
+ v6.i256 = obj.load v1;
+ v7.i256 = call %read_enum v3;
+ v8.i256 = add v0 44.i256;
+ call %forward v3 v8;
+ v9.i256 = obj.load v1;
+ v10.i256 = add v4 v6;
+ v11.i256 = add v7 v9;
+ v12.i256 = add v10 v11;
+ mstore 0.i256 v12 i256;
+ evm_return 0.i256 32.i256;
+}
+object @Contract {
+ section runtime {
+  entry %entry;
+ }
+}

--- a/crates/codegen/test_files/evm/aggregate_return_object_reference_alias.opt_ir.snap
+++ b/crates/codegen/test_files/evm/aggregate_return_object_reference_alias.opt_ir.snap
@@ -1,0 +1,44 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: opt_ir_snapshot
+input_file: test_files/evm/aggregate_return_object_reference_alias.sntn
+---
+target = "evm-ethereum-osaka"
+
+type @Selection = {objref<i256>, i256};
+
+func inline(never) private %select(v0.objref<[i256; 2]>, v1.i256) -> @Selection {
+    block0:
+        v2.objref<i256> = obj.index v0 v1;
+        v3.@Selection = insert_value undef.@Selection 0.i256 v2;
+        v4.@Selection = insert_value v3 1.i256 42.i256;
+        return v4;
+}
+
+func inline(never) private %overwrite(v0.objref<i256>) {
+    block0:
+        obj.store v0 22.i256;
+        return;
+}
+
+func public %entry() {
+    block0:
+        v0.objref<[i256; 2]> = obj.alloc [i256; 2];
+        v1.objref<i256> = obj.index v0 0.i256;
+        obj.store v1 11.i256;
+        v2.objref<i256> = obj.index v0 1.i256;
+        obj.store v2 33.i256;
+        v3.@Selection = call %select v0 0.i256;
+        v4.objref<i256> = extract_value v3 0.i256;
+        call %overwrite v4;
+        v5.i256 = obj.load v1;
+        mstore 0.i256 v5 i256;
+        evm_return 0.i256 32.i256;
+}
+
+
+object @Contract {
+    section runtime {
+        entry %entry;
+    }
+}

--- a/crates/codegen/test_files/evm/aggregate_return_object_reference_alias.snap
+++ b/crates/codegen/test_files/evm/aggregate_return_object_reference_alias.snap
@@ -1,0 +1,22 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: "String::from_utf8(out).unwrap()"
+input_file: test_files/evm/aggregate_return_object_reference_alias.sntn
+---
+evm.config: stack_reach=16 vcode=false bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false opt=2
+
+object: Contract
+  section runtime: 67 bytes
+  total: 67 bytes
+
+functions:
+  mem: global_dyn_base=0xa0 arena_base=0xa0 scratch_peak_words=0 stable_chain_peak_words=0
+  select: ir_blocks=1 ir_insts=3 vcode_ops=10 fixups=0 imm_bytes=2
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  overwrite: ir_blocks=1 ir_insts=2 vcode_ops=5 fixups=0 imm_bytes=1
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  entry: ir_blocks=4 ir_insts=14 vcode_ops=39 fixups=5 imm_bytes=7
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+
+evm:
+  case mutate_returned_reference: calldata_len=0 success reason=Return gas_used=21186 gas_refunded=0 logs=0 output=call len=32 tx_gas=21000 runtime_gas=186

--- a/crates/codegen/test_files/evm/aggregate_return_object_reference_alias.sntn
+++ b/crates/codegen/test_files/evm/aggregate_return_object_reference_alias.sntn
@@ -1,0 +1,43 @@
+#! evm.config: { opt: 2 }
+#! evm.case: mutate_returned_reference
+#!   calldata:
+#!   expect: return u256(22)
+
+target = "evm-ethereum-osaka"
+
+type @Selection = { objref<i256>, i256 };
+
+func inline(never) private %select(v0.objref<[i256; 2]>, v1.i256) -> @Selection {
+block0:
+    v2.objref<i256> = obj.index v0 v1;
+    v3.@Selection = insert_value undef.@Selection 0.i256 v2;
+    v4.@Selection = insert_value v3 1.i256 42.i256;
+    return v4;
+}
+
+func inline(never) private %overwrite(v0.objref<i256>) {
+block0:
+    obj.store v0 22.i256;
+    return;
+}
+
+func public %entry() {
+block0:
+    v0.objref<[i256; 2]> = obj.alloc [i256; 2];
+    v1.objref<i256> = obj.index v0 0.i256;
+    obj.store v1 11.i256;
+    v2.objref<i256> = obj.index v0 1.i256;
+    obj.store v2 33.i256;
+    v3.@Selection = call %select v0 0.i256;
+    v4.objref<i256> = extract_value v3 0.i256;
+    call %overwrite v4;
+    v5.i256 = obj.load v1;
+    mstore 0.i256 v5 i256;
+    evm_return 0.i256 32.i256;
+}
+
+object @Contract {
+  section runtime {
+    entry %entry;
+  }
+}

--- a/crates/codegen/test_files/evm/aggregate_return_object_reference_reads.opt_ir.snap
+++ b/crates/codegen/test_files/evm/aggregate_return_object_reference_reads.opt_ir.snap
@@ -1,0 +1,66 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: opt_ir_snapshot
+input_file: test_files/evm/aggregate_return_object_reference_reads.sntn
+---
+target = "evm-ethereum-osaka"
+
+type @Selection = {objref<i256>, i256};
+type @Nested = {i256, @Selection};
+
+func inline(never) private %select(v0.objref<[i256; 2]>, v1.i256) -> @Nested {
+    block0:
+        v2.objref<i256> = obj.index v0 v1;
+        v3.@Selection = insert_value undef.@Selection 0.i256 v2;
+        v4.@Selection = insert_value v3 1.i256 42.i256;
+        v5.@Nested = insert_value undef.@Nested 0.i256 7.i256;
+        v6.@Nested = insert_value v5 1.i256 v4;
+        return v6;
+}
+
+func inline(never) private %forward(v0.objref<[i256; 2]>, v1.i256) -> @Nested {
+    block0:
+        v2.@Nested = call %select v0 v1;
+        return v2;
+}
+
+func inline(never) private %read(v0.objref<i256>) -> i256 {
+    block0:
+        v1.i256 = obj.load v0;
+        return v1;
+}
+
+func inline(never) private %overwrite(v0.objref<i256>) {
+    block0:
+        obj.store v0 22.i256;
+        return;
+}
+
+func public %entry() {
+    block0:
+        v0.objref<[i256; 2]> = obj.alloc [i256; 2];
+        v1.objref<i256> = obj.index v0 0.i256;
+        obj.store v1 11.i256;
+        v2.objref<i256> = obj.index v0 1.i256;
+        obj.store v2 33.i256;
+        v3.i256 = evm_calldata_load 0.i256;
+        v4.i256 = and v3 1.i256;
+        v5.@Nested = call %forward v0 v4;
+        v6.@Selection = extract_value v5 1.i256;
+        v7.objref<i256> = extract_value v6 0.i256;
+        v8.i256 = call %read v7;
+        v9.objref<i256> = obj.index v0 v4;
+        obj.store v9 55.i256;
+        call %overwrite v7;
+        v10.i256 = obj.load v9;
+        v11.i256 = add v8 v10;
+        mstore 0.i256 v11 i256;
+        evm_return 0.i256 32.i256;
+}
+
+
+object @Contract {
+    section runtime {
+        entry %entry;
+    }
+}

--- a/crates/codegen/test_files/evm/aggregate_return_object_reference_reads.snap
+++ b/crates/codegen/test_files/evm/aggregate_return_object_reference_reads.snap
@@ -1,0 +1,27 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: "String::from_utf8(out).unwrap()"
+input_file: test_files/evm/aggregate_return_object_reference_reads.sntn
+---
+evm.config: stack_reach=16 vcode=false bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false opt=2
+
+object: Contract
+  section runtime: 117 bytes
+  total: 117 bytes
+
+functions:
+  mem: global_dyn_base=0xa0 arena_base=0xa0 scratch_peak_words=0 stable_chain_peak_words=0
+  select: ir_blocks=1 ir_insts=3 vcode_ops=12 fixups=0 imm_bytes=3
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  forward: ir_blocks=1 ir_insts=2 vcode_ops=11 fixups=2 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  read: ir_blocks=1 ir_insts=2 vcode_ops=4 fixups=0 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  overwrite: ir_blocks=1 ir_insts=2 vcode_ops=5 fixups=0 imm_bytes=1
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  entry: ir_blocks=4 ir_insts=21 vcode_ops=62 fixups=7 imm_bytes=10
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+
+evm:
+  case first_element: calldata_len=32 success reason=Return gas_used=21451 gas_refunded=0 logs=0 output=call len=32 tx_gas=21128 runtime_gas=323
+  case second_element: calldata_len=32 success reason=Return gas_used=21463 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=323

--- a/crates/codegen/test_files/evm/aggregate_return_object_reference_reads.sntn
+++ b/crates/codegen/test_files/evm/aggregate_return_object_reference_reads.sntn
@@ -1,0 +1,68 @@
+#! evm.config: { opt: 2 }
+#! evm.case: first_element
+#!   calldata: u256(0)
+#!   expect: return u256(33)
+#! evm.case: second_element
+#!   calldata: u256(1)
+#!   expect: return u256(55)
+
+target = "evm-ethereum-osaka"
+
+type @Selection = { objref<i256>, i256 };
+type @Nested = { i256, @Selection };
+
+func inline(never) private %select(v0.objref<[i256; 2]>, v1.i256) -> @Nested {
+block0:
+    v2.objref<i256> = obj.index v0 v1;
+    v3.@Selection = insert_value undef.@Selection 0.i256 v2;
+    v4.@Selection = insert_value v3 1.i256 42.i256;
+    v5.@Nested = insert_value undef.@Nested 0.i256 7.i256;
+    v6.@Nested = insert_value v5 1.i256 v4;
+    return v6;
+}
+
+func inline(never) private %forward(v0.objref<[i256; 2]>, v1.i256) -> @Nested {
+block0:
+    v2.@Nested = call %select v0 v1;
+    return v2;
+}
+
+func inline(never) private %read(v0.objref<i256>) -> i256 {
+block0:
+    v1.i256 = obj.load v0;
+    return v1;
+}
+
+func inline(never) private %overwrite(v0.objref<i256>) {
+block0:
+    obj.store v0 22.i256;
+    return;
+}
+
+func public %entry() {
+block0:
+    v0.objref<[i256; 2]> = obj.alloc [i256; 2];
+    v1.objref<i256> = obj.index v0 0.i256;
+    obj.store v1 11.i256;
+    v2.objref<i256> = obj.index v0 1.i256;
+    obj.store v2 33.i256;
+    v3.i256 = evm_calldata_load 0.i256;
+    v4.i256 = and v3 1.i256;
+    v5.@Nested = call %forward v0 v4;
+    v6.@Selection = extract_value v5 1.i256;
+    v7.objref<i256> = extract_value v6 0.i256;
+    v8.i256 = call %read v7;
+    v9.objref<i256> = obj.index v0 v4;
+    obj.store v9 55.i256;
+    call %overwrite v7;
+    v10.i256 = obj.load v9;
+    v11.i256 = add v8 v10;
+    mstore 0.i256 v11 i256;
+    evm_return 0.i256 32.i256;
+}
+
+object @Contract {
+  section runtime {
+    entry %entry;
+  }
+}

--- a/crates/codegen/test_files/evm/enum_return_object_reference_reads.opt_ir.snap
+++ b/crates/codegen/test_files/evm/enum_return_object_reference_reads.opt_ir.snap
@@ -1,0 +1,69 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: opt_ir_snapshot
+input_file: test_files/evm/enum_return_object_reference_reads.sntn
+---
+target = "evm-ethereum-osaka"
+
+type @Nested = {i256, @Selection};
+type @Selection = enum {
+    #None,
+    #Some(i256, objref<i256>),
+};
+
+func inline(never) private %select(v0.objref<[i256; 2]>, v1.i256) -> @Nested {
+    block0:
+        v2.objref<i256> = obj.index v0 v1;
+        v4.@Selection = enum.make @Selection #Some 42.i256 v2;
+        v5.@Nested = insert_value undef.@Nested 0.i256 7.i256;
+        v6.@Nested = insert_value v5 1.i256 v4;
+        return v6;
+}
+
+func inline(never) private %forward(v0.objref<[i256; 2]>, v1.i256) -> @Nested {
+    block0:
+        v2.@Nested = call %select v0 v1;
+        return v2;
+}
+
+func inline(never) private %read(v0.objref<i256>) -> i256 {
+    block0:
+        v1.i256 = obj.load v0;
+        return v1;
+}
+
+func inline(never) private %overwrite(v0.objref<i256>) {
+    block0:
+        obj.store v0 22.i256;
+        return;
+}
+
+func public %entry() {
+    block0:
+        v0.objref<[i256; 2]> = obj.alloc [i256; 2];
+        v1.objref<i256> = obj.index v0 0.i256;
+        obj.store v1 11.i256;
+        v2.objref<i256> = obj.index v0 1.i256;
+        obj.store v2 33.i256;
+        v3.i256 = evm_calldata_load 0.i256;
+        v4.i256 = and v3 1.i256;
+        v5.@Nested = call %forward v0 v4;
+        v6.@Selection = extract_value v5 1.i256;
+        enum.assert_variant v6 #Some;
+        v7.objref<i256> = enum.extract v6 #Some 1.i256;
+        v8.i256 = call %read v7;
+        v9.objref<i256> = obj.index v0 v4;
+        obj.store v9 55.i256;
+        call %overwrite v7;
+        v10.i256 = obj.load v9;
+        v11.i256 = add v8 v10;
+        mstore 0.i256 v11 i256;
+        evm_return 0.i256 32.i256;
+}
+
+
+object @Contract {
+    section runtime {
+        entry %entry;
+    }
+}

--- a/crates/codegen/test_files/evm/enum_return_object_reference_reads.snap
+++ b/crates/codegen/test_files/evm/enum_return_object_reference_reads.snap
@@ -1,0 +1,27 @@
+---
+source: crates/codegen/tests/evm.rs
+expression: "String::from_utf8(out).unwrap()"
+input_file: test_files/evm/enum_return_object_reference_reads.sntn
+---
+evm.config: stack_reach=16 vcode=false bytecode_hex=false stackify_trace=false evm_trace=false emit_observability=false opt=2
+
+object: Contract
+  section runtime: 120 bytes
+  total: 120 bytes
+
+functions:
+  mem: global_dyn_base=0xa0 arena_base=0xa0 scratch_peak_words=0 stable_chain_peak_words=0
+  select: ir_blocks=1 ir_insts=3 vcode_ops=13 fixups=0 imm_bytes=4
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  forward: ir_blocks=1 ir_insts=2 vcode_ops=12 fixups=2 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  read: ir_blocks=1 ir_insts=2 vcode_ops=4 fixups=0 imm_bytes=0
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  overwrite: ir_blocks=1 ir_insts=2 vcode_ops=5 fixups=0 imm_bytes=1
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+  entry: ir_blocks=4 ir_insts=21 vcode_ops=62 fixups=7 imm_bytes=10
+    mem: scratch_words=0 stable_words=0 stable_mode=None entry_abs_words=0 abs_words_end=0
+
+evm:
+  case first_element: calldata_len=32 success reason=Return gas_used=21456 gas_refunded=0 logs=0 output=call len=32 tx_gas=21128 runtime_gas=328
+  case second_element: calldata_len=32 success reason=Return gas_used=21468 gas_refunded=0 logs=0 output=call len=32 tx_gas=21140 runtime_gas=328

--- a/crates/codegen/test_files/evm/enum_return_object_reference_reads.sntn
+++ b/crates/codegen/test_files/evm/enum_return_object_reference_reads.sntn
@@ -1,0 +1,68 @@
+#! evm.config: { opt: 2 }
+#! evm.case: first_element
+#!   calldata: u256(0)
+#!   expect: return u256(33)
+#! evm.case: second_element
+#!   calldata: u256(1)
+#!   expect: return u256(55)
+
+target = "evm-ethereum-osaka"
+
+type @Selection = enum { #None, #Some(i256,objref<i256>) };
+type @Nested = { i256, @Selection };
+
+func inline(never) private %select(v0.objref<[i256; 2]>, v1.i256) -> @Nested {
+block0:
+    v2.objref<i256> = obj.index v0 v1;
+    v4.@Selection = enum.make @Selection #Some (42.i256, v2);
+    v5.@Nested = insert_value undef.@Nested 0.i256 7.i256;
+    v6.@Nested = insert_value v5 1.i256 v4;
+    return v6;
+}
+
+func inline(never) private %forward(v0.objref<[i256; 2]>, v1.i256) -> @Nested {
+block0:
+    v2.@Nested = call %select v0 v1;
+    return v2;
+}
+
+func inline(never) private %read(v0.objref<i256>) -> i256 {
+block0:
+    v1.i256 = obj.load v0;
+    return v1;
+}
+
+func inline(never) private %overwrite(v0.objref<i256>) {
+block0:
+    obj.store v0 22.i256;
+    return;
+}
+
+func public %entry() {
+block0:
+    v0.objref<[i256; 2]> = obj.alloc [i256; 2];
+    v1.objref<i256> = obj.index v0 0.i256;
+    obj.store v1 11.i256;
+    v2.objref<i256> = obj.index v0 1.i256;
+    obj.store v2 33.i256;
+    v3.i256 = evm_calldata_load 0.i256;
+    v4.i256 = and v3 1.i256;
+    v5.@Nested = call %forward v0 v4;
+    v6.@Selection = extract_value v5 1.i256;
+    enum.assert_variant v6 #Some;
+    v7.objref<i256> = enum.extract v6 #Some 1.i256;
+    v8.i256 = call %read v7;
+    v9.objref<i256> = obj.index v0 v4;
+    obj.store v9 55.i256;
+    call %overwrite v7;
+    v10.i256 = obj.load v9;
+    v11.i256 = add v8 v10;
+    mstore 0.i256 v11 i256;
+    evm_return 0.i256 32.i256;
+}
+
+object @Contract {
+  section runtime {
+    entry %entry;
+  }
+}


### PR DESCRIPTION
Object references carried through SSA structs, enums, or arrays could lose alias information and allow incorrect load forwarding or store deletion across calls. Preserve escapes at construction, unknown aliases at extraction and aggregate value boundaries, and conservative effects for reference-bearing aggregate arguments. Add non-inlined execution regressions for returned and passed references, including nested read/write helpers.

Validation: Rust 1.98 strict Clippy, full workspace tests, doctests, docs, filecheck, and nightly formatting passed.

## Changelog

Fix miscompilation of object references carried through SSA aggregate arguments and returns.

Based on main.
