### PR TITLE
Fix const-data test for Rust 1.98 Clippy

### DIFF
--- a/crates/codegen/src/transform/evm/const_data/tests.rs
+++ b/crates/codegen/src/transform/evm/const_data/tests.rs
@@ -824,7 +824,7 @@ func private %entry() -> i256 {
     let blob_bytes = lowered_blob_bytes(&parsed, "value");
     assert_eq!(blob_bytes.len(), 32 * 5);
 
-    let words: Vec<_> = blob_bytes.chunks_exact(32).collect();
+    let words = blob_bytes.as_chunks::<32>().0;
     assert!(words[0][..31].iter().all(|&byte| byte == 0));
     assert_eq!(words[0][31], 1);
 


### PR DESCRIPTION
Borrow the const-data test's 32-byte words with `as_chunks` instead of collecting `chunks_exact` into a vector. This satisfies Rust 1.98's new Clippy lint while preserving the existing length and byte assertions.

Validation: Rust 1.98 strict Clippy, full workspace tests, doctests, docs, filecheck, and nightly formatting passed.

## Changelog

None.

Prerequisite for #303–#307.
